### PR TITLE
fix: qsearch never recorded its current move, so move ordering keyed on a stale one

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1034,6 +1034,11 @@ int SearchEngine::qsearch(position& p, int alpha, int beta, U16 depth, SearchNod
 
         ++legal_moves;
 
+        // qsearch never recorded the move it was searching, so a qsearch node
+        // whose parent was also a qsearch node read whatever move some unrelated
+        // subtree left at this ply and used it to key the counter-move bonus.
+        stack->curr_move = move;
+
         auto hashOrKiller = (move == ttm) || (move == stack->killers[0]) ||
                             (move == stack->killers[1]) || (move == stack->killers[2]) ||
                             (move == stack->killers[3]);


### PR DESCRIPTION
`SearchNode::curr_move` was written in exactly one place — the move loop in `search()`. `qsearch()` never wrote it, yet both read it as `(stack - 1)->curr_move` and pass it to move ordering as `previous`, where `score_quiets()` applies the counter-move bonus.

A qsearch node whose parent is a `search()` node reads a correct value. A qsearch node whose parent is **another qsearch node** reads whatever move an unrelated subtree left in that ply's slot.

Same defect class as the `threat_move` and null-move `best_move` bugs: per-ply state read by a node that never wrote it.

## Measured (bench tree)

Marking each ply's slot unwritten at node entry and written at the assignment:

| | before | after |
|---|---|---|
| qsearch nodes reaching the read | 173,643 | — |
| read a slot the parent never wrote | **104,920 (60.4%)** | **0** |
| ...and found a real unrelated move there | **92,347 (53.2% of all qsearch nodes)** | **0** |

So over half of all qsearch nodes ordered their quiet moves against a predecessor that was never played. Captures are unaffected (`score_captures` ignores `previous`); the damage is in `QMoveorder`'s quiet stage — check evasions and quiet checks.

Recording the move costs nothing and improves ordering:

    bench  804,031 -> 770,721 nodes  (-4.1%)

All 81 tests pass.

## Deliberately not included

`search()` has a second, smaller instance of the same read: the null-move block recurses into `stack + 1` before this node has entered its move loop, so the null child also reads a stale `curr_move` (4,232 of 137,277 nodes; 4,074 a real unrelated move). Clearing it is semantically correct — after a null move there is no previous move — but it removes the counter-move bonus for the entire null subtree and costs **7.6% more nodes**. That one will be settled by a match rather than by node count.