### PR TITLE
Dead-position knowledge and mate technique

### DIFF
--- a/include/havoc/position.hpp
+++ b/include/havoc/position.hpp
@@ -138,6 +138,10 @@ class position {
     [[nodiscard]] U64 pinned(Color us);
     [[nodiscard]] bool is_draw();
 
+    /// True when neither side can possibly deliver mate, so the position is
+    /// dead drawn no matter how well either side plays.
+    [[nodiscard]] bool is_material_draw() const;
+
     [[nodiscard]] inline bool can_castle_ks() const {
         return (ifo.cmask & (ifo.stm == white ? wks : bks)) == (ifo.stm == white ? wks : bks);
     }

--- a/src/eval/hce.cpp
+++ b/src/eval/hce.cpp
@@ -38,6 +38,13 @@ static inline int to_stm(const position& p, int score, int tempo) {
 }
 
 int HCEEvaluator::evaluate(const position& p, int lazy_margin) {
+    // A dead position is worth exactly nothing to either side. Without this the
+    // material term happily reports a bishop or knight up in a king-and-minor
+    // ending, which is how the search traded into one: the stand pat in qsearch,
+    // reverse futility and null move pruning all read this number.
+    if (p.is_material_draw())
+        return score::kDraw;
+
     int score = 0;
     einfo ei{};
 

--- a/src/eval/hce.cpp
+++ b/src/eval/hce.cpp
@@ -20,6 +20,59 @@ inline bool is_pawnless_endgame(const position& p) {
     return (p.get_pieces<white, pawn>() | p.get_pieces<black, pawn>()) == 0ULL;
 }
 
+/// Evaluation for a pawnless ending in which one side is down to a lone king.
+///
+/// The ordinary evaluation is completely flat here. Every strong-side move
+/// leaves the same material, the same (empty) pawn structure and the same
+/// undefended enemy king, so the search looks out over a plateau, finds nothing
+/// to climb, and shuffles until the repetition or fifty-move rule rescues the
+/// defender. That is not a subtle weakness: haVoc could not win king and two
+/// bishops against a bare king, nor king, bishop and knight, from a standard
+/// starting position at any depth. Giving the score a gradient -- drive the
+/// defending king to the edge, and walk the attacking king in behind it --
+/// turns the plateau into a hill, which is all the search needs to find mate.
+inline int eval_bare_king(const position& p, Color strong, const parameters& params) {
+    const int sk = static_cast<int>(p.king_square(strong));
+    const int wk = static_cast<int>(p.king_square(strong == white ? black : white));
+
+    // Read the tuned piece values rather than a private table, so this path
+    // stays on the same scale as the rest of the evaluation and the tuner keeps
+    // its grip on material_value in these positions.
+    int score = 0;
+    for (int pc = pawn; pc < king; ++pc)
+        score += params.material_value[pc] * static_cast<int>(p.number_of(strong, Piece(pc)));
+
+    // 90 in a corner, falling to -90 in the centre. The distance is squared so
+    // that the last step out to the edge is worth much more than the first,
+    // which is what stops the defending king drifting back to safety.
+    const int cf = std::min(sq_col(wk), 7 - sq_col(wk));
+    const int cr = std::min(sq_row(wk), 7 - sq_row(wk));
+    score += 90 - 10 * (cf * cf + cr * cr);
+
+    // Mate needs the attacking king in opposition, and the defender has nothing
+    // better to do than run, so closing the gap is always progress.
+    score += 70 - 10 * std::max(row_dist(sk, wk), col_dist(sk, wk));
+
+    // Bishop and knight mate only in the two corners the bishop can reach, so
+    // aim at those specifically -- the generic edge term above is happy to herd
+    // the king into a corner where no mate exists, and the fifty-move rule then
+    // runs out while the engine tries to start again.
+    if (p.number_of(strong, bishop) == 1 && p.number_of(strong, knight) == 1 &&
+        p.number_of(strong, rook) == 0 && p.number_of(strong, queen) == 0) {
+        const U64 bishops =
+            strong == white ? p.get_pieces<white, bishop>() : p.get_pieces<black, bishop>();
+        const int bs = bits::lsb(bishops);
+        const bool dark = ((sq_col(bs) + sq_row(bs)) & 1) == 0;
+        const int c1 = dark ? A1 : H1;
+        const int c2 = dark ? H8 : A8;
+        const int d1 = std::max(row_dist(wk, c1), col_dist(wk, c1));
+        const int d2 = std::max(row_dist(wk, c2), col_dist(wk, c2));
+        score += 100 - 20 * std::min(d1, d2);
+    }
+
+    return score;
+}
+
 } // namespace
 
 // ─── Constructor ────────────────────────────────────────────────────────────
@@ -44,6 +97,17 @@ int HCEEvaluator::evaluate(const position& p, int lazy_margin) {
     // reverse futility and null move pruning all read this number.
     if (p.is_material_draw())
         return score::kDraw;
+
+    // A lone king with no pawns left on the board needs the dedicated gradient
+    // above, and it has to be answered here rather than at the end of the
+    // function: the material imbalance is enormous, so both lazy-evaluation
+    // exits fire long before the positional terms are ever reached.
+    if (is_pawnless_endgame(p)) {
+        if (p.get_pieces<black>() == p.get_pieces<black, king>())
+            return to_stm(p, eval_bare_king(p, white, params_), 0);
+        if (p.get_pieces<white>() == p.get_pieces<white, king>())
+            return to_stm(p, -eval_bare_king(p, black, params_), 0);
+    }
 
     int score = 0;
     einfo ei{};

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -155,8 +155,42 @@ std::string position::to_fen() const {
     return fen;
 }
 
+bool position::is_material_draw() const {
+    // Any pawn, rook or queen leaves mate possible, and this is the overwhelming
+    // majority of positions, so reject them with a single test before counting
+    // anything else.
+    if (number_of(white, pawn) || number_of(black, pawn) || number_of(white, rook) ||
+        number_of(black, rook) || number_of(white, queen) || number_of(black, queen))
+        return false;
+
+    const unsigned wn = number_of(white, knight), wb = number_of(white, bishop);
+    const unsigned bn = number_of(black, knight), bb = number_of(black, bishop);
+    const unsigned w = wn + wb, b = bn + bb;
+
+    // King against king, and king plus a single minor against a bare king, are
+    // dead positions under the FIDE rules: no sequence of legal moves mates.
+    if (w <= 1 && b <= 1)
+        return true;
+
+    // Two knights against a bare king cannot be forced, and the arbiter will
+    // never award it, so treating it as anything but a draw only makes the
+    // engine trade into it.
+    if ((wn == 2 && wb == 0 && b == 0) || (bn == 2 && bb == 0 && w == 0))
+        return true;
+
+    return false;
+}
+
 bool position::is_draw() {
     if (ifo.move50 > 99)
+        return true;
+
+    // Trading down into king and a lone minor is a draw however winning the
+    // material count looks. Without this the search happily walked into it: over
+    // 158 gauntlet games haVoc drew 4 by insufficient mating material while its
+    // own evaluation still read +3.6 to +3.9 on the very last move, because
+    // nothing in the engine knew the position was dead.
+    if (is_material_draw())
         return true;
 
     U64 kcurrent = ifo.repkey;

--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -319,6 +319,39 @@ TEST_F(EvalTest, PieceValuesAreLive) {
     EXPECT_GT(dear - cheap, 100);
 }
 
+// The evaluation used to be flat across every move once the defender was down
+// to a bare king: same material, no pawns, nothing positional to say. The
+// search saw a plateau, had nothing to climb, and shuffled. Over a four-
+// position suite the engine failed to mate with two bishops in two of them and
+// needed a mean of 69 plies in the others; with a gradient it mates all four in
+// a mean of 32.5. These assertions pin the gradient itself.
+TEST_F(EvalTest, DrivesTheBareKingTowardsMate) {
+    havoc::parameters params;
+    havoc::pawn_table pt(params);
+    havoc::material_table mt(params);
+    havoc::HCEEvaluator eval(pt, mt, params);
+    auto score = [&](const char* fen) {
+        auto pos = make_pos(fen);
+        return eval.evaluate(pos);
+    };
+
+    // Identical material either way, so the only thing separating these is
+    // where the defending king stands.
+    EXPECT_GT(score("k7/8/8/8/8/8/8/3RK3 w - - 0 1"), score("8/8/8/3k4/8/8/8/3RK3 w - - 0 1"))
+        << "driving the bare king to the edge has to score better than leaving "
+           "it in the centre";
+
+    // Mate needs the attacking king in opposition, so closing the gap counts.
+    EXPECT_GT(score("k7/8/1K6/8/8/8/8/3R4 w - - 0 1"), score("k7/8/8/8/8/8/8/3RK3 w - - 0 1"))
+        << "walking the attacking king in has to score better than leaving it home";
+
+    // Bishop and knight only mate in the two corners the bishop can attack.
+    // A dark-squared bishop wants h8, not a8, and both corners are otherwise
+    // identical -- same edge distance, same distance to the white king.
+    EXPECT_GT(score("7k/8/8/8/8/8/8/2BNK3 w - - 0 1"), score("k7/8/8/8/8/8/8/2BNK3 w - - 0 1"))
+        << "bishop and knight must aim at the corner the bishop covers";
+}
+
 // The scaling tables are indexed by the Piece enum, which runs pawn..king.
 // They were sized 5, so sq_score_scaling[king] read one past the end -- and
 // the value that happened to sit there was 0, which silently multiplied the
@@ -508,6 +541,14 @@ TEST_F(EvalTest, EveryTunableParameterReachesTheEvaluation) {
         "6k1/6pp/8/3B4/8/8/6PP/3R2K1 w - - 0 1",
         "8/8/4k3/8/3QB3/8/4K3/8 w - - 0 1",
         "3rr1k1/5ppp/8/3B1B2/3RR3/8/5PPP/6K1 w - - 0 1",
+        // The same wide-open boards, but with a defending minor so the side to
+        // move is not facing a bare king. Pawnless king-versus-lone-king
+        // positions take the mating shortcut in evaluate() and never reach the
+        // mobility tables, so without these the top rook and bishop buckets
+        // lose their only coverage.
+        "4k2n/8/8/8/8/8/8/R3K3 w Q - 0 1",
+        "7n/8/4k3/8/3QB3/8/4K3/8 w - - 0 1",
+        "k6n/8/8/8/3R4/8/8/4K3 w - - 0 1",
         // Cramped, to reach the bottom of the mobility tables
         "rnbqkbnr/pppppppp/8/8/8/PPPPPPPP/RNBQKBNR/8 w kq - 0 1",
         "1nb1kb2/1ppppp2/8/8/8/8/PPPPPP2/1NB1KB2 w - - 0 1",

--- a/tests/test_position.cpp
+++ b/tests/test_position.cpp
@@ -203,8 +203,10 @@ TEST_F(PositionTest, IsDraw_Repetition) {
 // ── is_draw: 50-move rule ───────────────────────────────────────────────────
 
 TEST_F(PositionTest, IsDraw_50MoveRule) {
-    // FEN with move50 = 99
-    std::istringstream fen("8/8/8/4k3/8/8/8/4K3 w - - 99 100");
+    // Both sides keep a rook. A bare king-versus-king position would now be
+    // drawn on insufficient material regardless of the counter, which would stop
+    // this test from saying anything about the fifty move rule.
+    std::istringstream fen("r7/8/8/4k3/8/8/8/R3K3 w - - 99 100");
     position pos(fen);
     EXPECT_FALSE(pos.is_draw());
 
@@ -324,6 +326,30 @@ TEST_F(PositionTest, SeeWorksWhileInCheck) {
 TEST_F(PositionTest, SeeRefusesKingCaptureOfADefendedPiece) {
     // Kxe2 is not actually available: the rook on e8 recaptures.
     EXPECT_LT(see_of("4r3/8/8/8/8/8/4r3/4K3 w - - 0 1", E1, E2), 0);
+}
+
+TEST_F(PositionTest, RecognisesDeadDrawnMaterial) {
+    auto material_draw = [](const std::string& fen) {
+        std::istringstream ss(fen);
+        position p(ss);
+        return p.is_material_draw();
+    };
+
+    // No sequence of legal moves mates in any of these.
+    EXPECT_TRUE(material_draw("8/8/4k3/8/8/4K3/8/8 w - - 0 1"));    // K vs K
+    EXPECT_TRUE(material_draw("8/8/4k3/8/8/3BK3/8/8 w - - 0 1"));   // KB vs K
+    EXPECT_TRUE(material_draw("8/8/4k3/8/8/3NK3/8/8 w - - 0 1"));   // KN vs K
+    EXPECT_TRUE(material_draw("8/8/2b1k3/8/8/3NK3/8/8 w - - 0 1")); // KN vs KB
+    // Two knights cannot force mate, and no arbiter will ever award it.
+    EXPECT_TRUE(material_draw("8/8/4k3/8/8/2NNK3/8/8 w - - 0 1")); // KNN vs K
+
+    // These are genuinely winnable and must not be written off.
+    EXPECT_FALSE(material_draw("8/8/4k3/8/8/3BK3/4P3/8 w - - 0 1")); // KBP vs K
+    EXPECT_FALSE(material_draw("8/8/4k3/8/8/3BKB2/8/8 w - - 0 1"));  // KBB vs K
+    EXPECT_FALSE(material_draw("8/8/4k3/8/8/3NKB2/8/8 w - - 0 1"));  // KBN vs K
+    EXPECT_FALSE(material_draw("8/8/4k3/8/8/3RK3/8/8 w - - 0 1"));   // KR vs K
+    EXPECT_FALSE(material_draw("8/8/4k3/8/8/3QK3/8/8 w - - 0 1"));   // KQ vs K
+    EXPECT_FALSE(material_draw("8/8/4k3/8/8/4K3/4P3/8 w - - 0 1"));  // KP vs K
 }
 
 } // namespace havoc


### PR DESCRIPTION
Two eval-side correctness fixes for games haVoc was winning and did not win.

**`8abee56` — king and a lone minor is a dead draw.**
Nothing in the engine knew this. Over 158 gauntlet games haVoc drew 4 by insufficient mating material while its own evaluation still read +3.6 to +3.9 on the final move. `position::is_material_draw()` covers K vs K, K+minor vs K and KNN vs bare K, and is wired into both `is_draw()` and the top of `evaluate()` — the latter because qsearch's stand pat, reverse futility and null-move pruning all read the static eval directly.

**`cb20afc` — a gradient when the defender is a bare king.**
The evaluation was flat across every strong-side move in a pawnless bare-king ending, so the search shuffled. Measured at fixed depth 12 against a defender that maximises its distance from the edge, over four positions per ending:

| | before | after |
|---|---|---|
| KBB vs K | mated **2/4**, mean 69.0, worst 71 | **4/4**, mean **32.5**, worst 37 |
| KBN vs K | 4/4, mean 56.5, worst **75** | 4/4, mean **38.5**, worst 51 |
| KR vs K | 2/2, mean 16.0 | 2/2, mean 15.0 |
| KQ vs K | 2/2, mean 16.0 | 2/2, mean 17.0 |

Bench 770721 -> 770124. 83/83 tests pass; both new regression tests fail against the previous evaluation.

Not yet SPRT'd — stacked on #9.