### PR TITLE
King safety safe checks

### DIFF
--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -122,6 +122,11 @@ struct parameters {
     std::vector<int> king_shelter{-3, -2, 2, 3}; // 0,1,2,3 pawns
     std::vector<int> king_safe_sqs{-4, -2, -1, 0, 0, 1, 2, 4};
 
+    /// Danger per square from which an enemy piece could give check without
+    /// being recaptured, indexed by the checking piece. Index 0 (pawn) is
+    /// unused: a pawn check is never the threat that matters here.
+    std::vector<int> safe_check_weight{0, 6, 5, 8, 12};
+
     int uncastled_penalty = 5;
     static constexpr int connected_rook_bonus = 1;
     static constexpr int doubled_bishop_bonus = 4;

--- a/src/eval/hce.cpp
+++ b/src/eval/hce.cpp
@@ -647,6 +647,44 @@ template <Color c> int HCEEvaluator::eval_king(const position& p, einfo& ei) {
         for (Piece pc = pawn; pc <= queen; ++pc)
             unsafe_bb |= ei.kattk_points[them][pc];
 
+        // Safe checks. The most concrete form of king danger is a square an
+        // enemy piece already attacks, from which it would give check, and
+        // which we do not defend -- the check simply lands and cannot be
+        // answered by taking the checker.
+        //
+        // The check-from sets are computed with magics against the current
+        // occupancy rather than read from bitboards::kchecks, which holds
+        // empty-board slider attacks. On a real board a bishop sitting on a
+        // kchecks square usually is not giving check at all, because
+        // something stands in between, so that table overstates slider checks
+        // badly and is only correct for the knight.
+        //
+        // "Safe" excludes squares occupied by the attacker's own pieces, which
+        // it cannot move onto, and any square in our attack map. The king's
+        // own ring counts as defended: a check the king can simply capture is
+        // not the danger this term is about.
+        {
+            const U64 our_attacks = ei.pe->attacks[c] | ei.piece_attacks[c][knight] |
+                                    ei.piece_attacks[c][bishop] | ei.piece_attacks[c][rook] |
+                                    ei.piece_attacks[c][queen] | ei.kmask[c];
+            const U64 safe = ~ei.pieces[them] & ~our_attacks;
+
+            const U64 rook_from = magics::attacks<rook>(ei.all_pieces, s);
+            const U64 bishop_from = magics::attacks<bishop>(ei.all_pieces, s);
+
+            U64 check_from[5]{};
+            check_from[knight] = bitboards::nmask[s];
+            check_from[bishop] = bishop_from;
+            check_from[rook] = rook_from;
+            check_from[queen] = rook_from | bishop_from;
+
+            for (Piece pc = knight; pc <= queen; ++pc) {
+                const U64 checks = check_from[pc] & ei.piece_attacks[them][pc] & safe;
+                if (checks)
+                    score -= params_.safe_check_weight[pc] * bits::count(checks);
+            }
+        }
+
         if (unsafe_bb) {
             mvs &= ~unsafe_bb;
 

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -132,6 +132,8 @@ std::vector<std::pair<std::string, int*>> parameters::all_params(TuneStage stage
         // King safe squares
         for (size_t i = 0; i < king_safe_sqs.size(); ++i)
             result.emplace_back("king_safe_sqs_" + std::to_string(i), &king_safe_sqs[i]);
+        for (size_t i = 1; i < safe_check_weight.size(); ++i)
+            result.emplace_back("safe_check_weight_" + std::to_string(i), &safe_check_weight[i]);
 
         result.emplace_back("bishop_own_pawn_penalty_mg", &bishop_own_pawn_penalty_mg);
         result.emplace_back("bishop_own_pawn_penalty_eg", &bishop_own_pawn_penalty_eg);

--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -720,6 +720,11 @@ TEST_F(EvalTest, EveryTunableParameterReachesTheEvaluation) {
         // Cramped, to reach the bottom of the mobility tables
         "rnbqkbnr/pppppppp/8/8/8/PPPPPPPP/RNBQKBNR/8 w kq - 0 1",
         "1nb1kb2/1ppppp2/8/8/8/8/PPPPPP2/1NB1KB2 w - - 0 1",
+        // A knight safe check: black Kg8 is checked from f6, the white
+        // knight on e4 attacks f6, and nothing black owns defends it -- the
+        // h7 pawn covers g6, not f6. Without this the knight safe-check
+        // weight is never exercised by any position in this list.
+        "r5k1/7p/8/8/4N3/8/5PPP/4K2R w K - 0 1",
         // Material imbalances, so the material values do not cancel
         "rnb1kbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
         "r1bqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",


### PR DESCRIPTION
Adds a safe-check term to king safety: a square from which an enemy
knight, bishop, rook or queen could give check, that the defender does
not cover, is real danger and was worth nothing.

The check-from sets are computed against live occupancy with two magic
lookups per king rather than read from the precomputed kchecks table,
which stores empty-board slider attacks and would claim a bishop gives
check straight through a blocker. That table has been dead since it was
written and is correct only for the knight.

Prevalence was measured before the term was trusted: it fires in 45.7%
of 4,552 positions drawn from random play, mean 12.3 cp, max 70.

SPRT vs the previous main: 679 games, 250-197-232, +26.9 +/- 23 Elo,
LOS ~99%. Non-regressing, and the draw ratio rose from 31% to 37%, the
signature a real king-safety term should have.


---

**Commits**
```
816e265 eval: add safe checks to king safety
a5aba9c Merge branch 'feat/king-safety-safe-checks': king safety safe checks
```

Stacked series, PR 01 of 16. Base: `main`. Please review/merge in numeric order.
