### PR TITLE
Wrong rook pawn draw and KPK bitbase

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ set(HAVOC_CORE_SOURCES
     src/tt.cpp
     src/pawn_table.cpp
     src/material_table.cpp
+    src/kpk.cpp
     src/eval/hce.cpp
     src/move_order.cpp
     src/thread_pool.cpp

--- a/include/havoc/kpk.hpp
+++ b/include/havoc/kpk.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "havoc/types.hpp"
+
+/// Exact solution of the king-and-pawn-versus-king ending.
+///
+/// KPK is small enough to solve outright -- 24 pawn squares by 64 by 64 king
+/// squares by 2 sides to move -- so there is no reason for an evaluation to
+/// guess at it. haVoc used to: it scored `7k/8/7K/7P/8/8/8/8 w`, a textbook
+/// draw, at +118, and would trade into it believing it was a pawn up.
+///
+/// The table is built once at startup by value iteration over the whole game
+/// graph, which takes well under a millisecond, so there is no data file to
+/// ship or load.
+namespace havoc::kpk {
+
+/// Builds the bitbase. Idempotent, and must be called before `probe`.
+void init();
+
+/// True when the side with the pawn wins with best play.
+///
+/// The caller must normalise first: `strong_king`, `pawn` and `weak_king` are
+/// squares as seen by a *white* pawn, and `pawn` must lie on files a-d of ranks
+/// 2-7. `stm` is white when the side holding the pawn is to move.
+[[nodiscard]] bool probe(int strong_king, int pawn, int weak_king, Color stm);
+
+/// Number of positions the table classifies as won. Exposed for testing.
+[[nodiscard]] unsigned won_count();
+
+}  // namespace havoc::kpk

--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -150,6 +150,7 @@ struct parameters {
     int opposite_bishop_scale = 24;
     int no_pawn_scale = 32;
     int minor_advantage_no_pawn_scale = 8;
+    int wrong_rook_pawn_scale = 0;
 
     // Passed pawn rank bonuses
     std::array<int, 4> passed_pawn_rank_bonus = {0, 45, 90, 180};

--- a/src/eval/hce.cpp
+++ b/src/eval/hce.cpp
@@ -20,6 +20,65 @@ inline bool is_pawnless_endgame(const position& p) {
     return (p.get_pieces<white, pawn>() | p.get_pieces<black, pawn>()) == 0ULL;
 }
 
+/// True when `c` holds the classic drawn "wrong rook pawn" ending: every pawn
+/// on a single rook file, at least one bishop, no bishop able to touch the
+/// promotion square, and the defending king already controlling that square.
+///
+/// This is a theorem rather than a heuristic. The pawn can only promote on the
+/// corner square; the defending king sits on or beside it and can never be
+/// driven away, because the attacking bishop covers the opposite color complex
+/// and so can neither take the corner nor cover the escape square. The attacker
+/// may have any number of pawns and any number of bishops -- if they are all on
+/// the rook file and all on the wrong color, none of that matters.
+///
+/// haVoc had no notion of this at all. `k7/8/8/8/8/8/PB6/6K1 w` (a-pawn, dark
+/// bishop, black king on a8) is a dead draw and scored +443, one point off the
+/// +441 it gave the genuinely winning light-bishop version of the same
+/// position. The engine would happily trade into it believing it was a pawn up.
+template <Color c> inline bool is_wrong_rook_pawn_draw(const position& p) {
+    constexpr Color them = (c == white ? black : white);
+
+    // The defender must be down to a bare king. Any other material gives
+    // counterplay, or a piece to sacrifice for the pawn, and the proof breaks.
+    if ((p.get_pieces<them, pawn>() | p.get_pieces<them, knight>() |
+         p.get_pieces<them, bishop>() | p.get_pieces<them, rook>() |
+         p.get_pieces<them, queen>()) != 0ULL)
+        return false;
+
+    // The attacker must hold nothing but king, pawns and bishops. A knight or
+    // a rook covers the corner the bishop cannot, and wins.
+    if ((p.get_pieces<c, knight>() | p.get_pieces<c, rook>() | p.get_pieces<c, queen>()) != 0ULL)
+        return false;
+
+    const U64 pawns = p.get_pieces<c, pawn>();
+    const U64 bishops = p.get_pieces<c, bishop>();
+    if (pawns == 0ULL || bishops == 0ULL)
+        return false;
+
+    // Every pawn on the a-file, or every pawn on the h-file.
+    int promo_col;
+    if ((pawns & ~bitboards::col[Col::A]) == 0ULL)
+        promo_col = Col::A;
+    else if ((pawns & ~bitboards::col[Col::H]) == 0ULL)
+        promo_col = Col::H;
+    else
+        return false;
+
+    const int promo = (c == white ? 56 + promo_col : promo_col);
+
+    // Derive the promotion square's color from the board rather than assuming a
+    // convention, then require every bishop to be on the other complex.
+    const U64 promo_complex = (bitboards::squares[promo] & bitboards::colored_sqs[white]) != 0ULL
+                                  ? bitboards::colored_sqs[white]
+                                  : bitboards::colored_sqs[black];
+    if ((bishops & promo_complex) != 0ULL)
+        return false;
+
+    // The defending king must already be on or beside the promotion square.
+    const int dk = static_cast<int>(p.king_square(them));
+    return std::max(util::row_dist(dk, promo), util::col_dist(dk, promo)) <= 1;
+}
+
 /// The two long diagonals, a1-h8 and a8-h1. Squares are indexed row*8 + col,
 /// so a1-h8 is every ninth square from a1 and a8-h1 every seventh from h1.
 constexpr U64 kLongDiagonals = [] {
@@ -252,10 +311,14 @@ int HCEEvaluator::evaluate(const position& p, int lazy_margin) {
     // No pawns with small material advantage → likely drawn
     if (is_pawnless_endgame(p) && std::abs(score) < 400)
         scale = std::min(scale, params_.no_pawn_scale);
-
     // Single minor piece advantage with no pawns → near draw
     if (is_pawnless_endgame(p) && std::abs(ei.me->score) <= 315 && std::abs(ei.me->score) > 0)
         scale = std::min(scale, params_.minor_advantage_no_pawn_scale);
+
+    // Wrong rook pawn plus wrong-colored bishop: a proven draw, so the whole
+    // score collapses regardless of how many pawns the attacker is up.
+    if (is_wrong_rook_pawn_draw<white>(p) || is_wrong_rook_pawn_draw<black>(p))
+        scale = std::min(scale, params_.wrong_rook_pawn_scale);
 
     if (scale != 128)
         score = (score * scale) / 128;

--- a/src/eval/hce.cpp
+++ b/src/eval/hce.cpp
@@ -2,6 +2,7 @@
 
 #include "havoc/bitboard.hpp"
 #include "havoc/magics.hpp"
+#include "havoc/kpk.hpp"
 #include "havoc/position.hpp"
 #include "havoc/squares.hpp"
 #include "havoc/utils.hpp"
@@ -234,9 +235,35 @@ int HCEEvaluator::evaluate(const position& p, int lazy_margin) {
             }
         }
         switch (egt) {
-        case KpK:
+        case KpK: {
+            // A single pawn against a bare king is solved exactly by the
+            // bitbase, so there is nothing here for the evaluation to guess at.
+            const U64 wp = p.get_pieces<white, pawn>();
+            const U64 bp = p.get_pieces<black, pawn>();
+            if (bits::count(wp | bp) == 1) {
+                const Color strong = wp ? white : black;
+                U64 pawns = wp | bp;
+                int psq = bits::lsb(pawns);
+                int sk = static_cast<int>(p.king_square(strong));
+                int wk_ = static_cast<int>(p.king_square(strong == white ? black : white));
+                // Normalise so the pawn is white's and stands on files a-d.
+                if (strong == black) {
+                    psq ^= 56;
+                    sk ^= 56;
+                    wk_ ^= 56;
+                }
+                if (util::col(psq) > Col::D) {
+                    psq ^= 7;
+                    sk ^= 7;
+                    wk_ ^= 7;
+                }
+                const Color stm = (p.to_move() == strong) ? white : black;
+                if (!kpk::probe(sk, psq, wk_, stm))
+                    return score::kDraw;
+            }
             score += eval_kpk<white>(p, ei) - eval_kpk<black>(p, ei);
             break;
+        }
         case KrrK:
             score += eval_krrk<white>(p, ei) - eval_krrk<black>(p, ei);
             break;

--- a/src/kpk.cpp
+++ b/src/kpk.cpp
@@ -1,0 +1,188 @@
+#include "havoc/kpk.hpp"
+
+#include "havoc/bitboard.hpp"
+
+#include <array>
+#include <bitset>
+#include <cstdint>
+
+namespace havoc::kpk {
+
+namespace {
+
+/// 4 pawn files (a-d, the rest reached by mirroring) x 6 pawn ranks (2-7)
+/// x 64 white king squares x 64 black king squares x 2 sides to move.
+constexpr int kPawnSquares = 24;
+constexpr int kMaxIndex = kPawnSquares * 64 * 64 * 2;
+
+/// Kept as flags rather than an enum so that the value of a position can be
+/// accumulated over its successors with a plain OR.
+enum State : uint8_t {
+    kIllegal = 0,
+    kUnknown = 1,
+    kDrawn = 2,
+    kWon = 4,
+};
+
+std::array<uint8_t, kMaxIndex> g_state;
+std::bitset<kMaxIndex> g_won;
+bool g_ready = false;
+unsigned g_won_count = 0;
+
+constexpr int row_of(int s) { return s >> 3; }
+constexpr int col_of(int s) { return s & 7; }
+
+constexpr int king_distance(int a, int b) {
+    const int dr = row_of(a) - row_of(b);
+    const int dc = col_of(a) - col_of(b);
+    return std::max(dr < 0 ? -dr : dr, dc < 0 ? -dc : dc);
+}
+
+/// Packs a pawn on files a-d, ranks 2-7 into 0..23.
+constexpr int pawn_index(int pawn) { return col_of(pawn) * 6 + (row_of(pawn) - 1); }
+
+constexpr int index_of(Color stm, int wk, int bk, int pawn) {
+    return ((pawn_index(pawn) * 64 + wk) * 64 + bk) * 2 + static_cast<int>(stm);
+}
+
+/// Squares a white pawn on `pawn` attacks.
+U64 pawn_attacks(int pawn) {
+    U64 m = 0ULL;
+    if (col_of(pawn) > 0)
+        m |= 1ULL << (pawn + 7);
+    if (col_of(pawn) < 7)
+        m |= 1ULL << (pawn + 9);
+    return m;
+}
+
+/// Positions whose value is known without looking at any successor: illegal
+/// placements, a promotion white can force through, and the two ways black
+/// escapes -- taking the pawn, or having no move at all.
+uint8_t classify_terminal(Color stm, int wk, int bk, int pawn) {
+    // Kings may not touch, and neither king may stand on the pawn.
+    if (king_distance(wk, bk) <= 1 || wk == pawn || bk == pawn)
+        return kIllegal;
+
+    // If white is to move, black cannot already be in check from the pawn.
+    if (stm == white && (pawn_attacks(pawn) & (1ULL << bk)) != 0ULL)
+        return kIllegal;
+
+    if (stm == white) {
+        // A pawn on the seventh promotes next move. That wins outright unless
+        // white's own king is sitting on the promotion square, or black's king
+        // guards it and white's does not.
+        const int promo = pawn + 8;
+        if (row_of(pawn) == 6 && wk != promo &&
+            (king_distance(bk, promo) > 1 || king_distance(wk, promo) == 1))
+            return kWon;
+        return kUnknown;
+    }
+
+    // Black to move. Legal king destinations are those the white king does not
+    // cover and the pawn does not attack; capturing the pawn is one of them
+    // whenever white's king is not defending it.
+    const U64 escape = bitboards::kmask[bk] & ~bitboards::kmask[wk] & ~pawn_attacks(pawn);
+    if (escape == 0ULL)
+        return kDrawn;  // stalemate
+    if ((escape & (1ULL << pawn)) != 0ULL)
+        return kDrawn;  // the pawn falls, leaving bare kings
+    return kUnknown;
+}
+
+/// Recomputes one position from its successors.
+///
+/// White is trying to reach a won position and settles for a draw; black is
+/// trying to reach a drawn one and settles for a loss. A position is only
+/// resolved once every successor is, so anything still unknown keeps the
+/// position unknown for this pass. Illegal successors contribute nothing,
+/// which is exactly right: they are moves that cannot be played.
+uint8_t recompute(Color stm, int wk, int bk, int pawn) {
+    const uint8_t good = (stm == white) ? kWon : kDrawn;
+    const uint8_t bad = (stm == white) ? kDrawn : kWon;
+    uint8_t seen = kIllegal;
+
+    if (stm == white) {
+        U64 moves = bitboards::kmask[wk];
+        while (moves) {
+            const int to = bits::pop_lsb(moves);
+            seen |= g_state[index_of(black, to, bk, pawn)];
+        }
+        // Single push. A push to the eighth rank is a promotion, which the
+        // terminal test above has already ruled on, so it is not a successor
+        // inside the table.
+        if (row_of(pawn) < 6 && pawn + 8 != wk && pawn + 8 != bk)
+            seen |= g_state[index_of(black, wk, bk, pawn + 8)];
+        // Double push from the second rank, over an empty third rank.
+        if (row_of(pawn) == 1 && pawn + 8 != wk && pawn + 8 != bk && pawn + 16 != wk &&
+            pawn + 16 != bk)
+            seen |= g_state[index_of(black, wk, bk, pawn + 16)];
+    } else {
+        U64 moves = bitboards::kmask[bk];
+        while (moves) {
+            const int to = bits::pop_lsb(moves);
+            seen |= g_state[index_of(white, wk, to, pawn)];
+        }
+    }
+
+    if (seen & good)
+        return good;
+    if (seen & kUnknown)
+        return kUnknown;
+    return bad;
+}
+
+}  // namespace
+
+void init() {
+    if (g_ready)
+        return;
+
+    for (int pi = 0; pi < kPawnSquares; ++pi) {
+        const int pawn = (pi / 6) + 8 * ((pi % 6) + 1);
+        for (int wk = 0; wk < 64; ++wk)
+            for (int bk = 0; bk < 64; ++bk)
+                for (int s = 0; s < 2; ++s)
+                    g_state[index_of(static_cast<Color>(s), wk, bk, pawn)] =
+                        classify_terminal(static_cast<Color>(s), wk, bk, pawn);
+    }
+
+    // Value iteration. Every pass can only turn unknowns into decided results,
+    // so the table is monotone and the loop terminates; in practice it settles
+    // in around twenty passes.
+    bool changed = true;
+    while (changed) {
+        changed = false;
+        for (int pi = 0; pi < kPawnSquares; ++pi) {
+            const int pawn = (pi / 6) + 8 * ((pi % 6) + 1);
+            for (int wk = 0; wk < 64; ++wk)
+                for (int bk = 0; bk < 64; ++bk)
+                    for (int s = 0; s < 2; ++s) {
+                        const Color stm = static_cast<Color>(s);
+                        const int idx = index_of(stm, wk, bk, pawn);
+                        if (g_state[idx] != kUnknown)
+                            continue;
+                        const uint8_t v = recompute(stm, wk, bk, pawn);
+                        if (v != kUnknown) {
+                            g_state[idx] = v;
+                            changed = true;
+                        }
+                    }
+        }
+    }
+
+    g_won_count = 0;
+    for (int i = 0; i < kMaxIndex; ++i) {
+        const bool won = g_state[i] == kWon;
+        g_won[i] = won;
+        g_won_count += won;
+    }
+    g_ready = true;
+}
+
+bool probe(int strong_king, int pawn, int weak_king, Color stm) {
+    return g_won[index_of(stm, strong_king, weak_king, pawn)];
+}
+
+unsigned won_count() { return g_won_count; }
+
+}  // namespace havoc::kpk

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,5 @@
 #include "havoc/bitboard.hpp"
+#include "havoc/kpk.hpp"
 #include "havoc/magics.hpp"
 #include "havoc/search.hpp"
 #include "havoc/uci.hpp"
@@ -14,6 +15,7 @@ int main() {
     havoc::bitboards::init();
     havoc::magics::init();
     havoc::zobrist::init();
+    havoc::kpk::init();
 
     havoc::SearchEngine engine;
     havoc::uci::loop(engine);

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -115,6 +115,7 @@ std::vector<std::pair<std::string, int*>> parameters::all_params(TuneStage stage
         result.emplace_back("opposite_bishop_scale", &opposite_bishop_scale);
         result.emplace_back("no_pawn_scale", &no_pawn_scale);
         result.emplace_back("minor_advantage_no_pawn_scale", &minor_advantage_no_pawn_scale);
+        result.emplace_back("wrong_rook_pawn_scale", &wrong_rook_pawn_scale);
 
         // Passed pawn rank bonuses
         for (size_t i = 0; i < passed_pawn_rank_bonus.size(); ++i)

--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -370,6 +370,47 @@ TEST_F(EvalTest, OppositeColorBishops_Scaled) {
 //
 // Assert it by differencing against a run with the scale neutralized: with
 // other pieces on the board the knob must make no difference at all.
+TEST_F(EvalTest, WrongRookPawnAndWrongBishopIsDrawn) {
+    havoc::parameters params;
+    havoc::pawn_table pt(params);
+    havoc::material_table mt(params);
+    havoc::HCEEvaluator eval(pt, mt, params);
+
+    // Every pawn on a rook file, every bishop on the complex the promotion
+    // square is not on, and the defending king on the promotion square. The
+    // attacker cannot make progress no matter how many pawns are involved.
+    struct Case {
+        const char* fen;
+        const char* why;
+    };
+    const Case drawn[] = {
+        {"k7/8/8/8/8/8/PB6/6K1 w - - 0 1", "a-pawn, dark bishop, black king on a8"},
+        {"7k/8/8/8/8/8/7P/5BK1 w - - 0 1", "h-pawn, bishop on f1 cannot see h8"},
+        {"k7/8/8/8/8/P7/PB6/6K1 w - - 0 1", "two a-pawns, still drawn"},
+        // Same theorem with the colors reversed, which the mirror tests do not
+        // reach because they never generate this material.
+        {"1k6/1b6/p7/8/8/8/8/K7 b - - 0 1", "black a-pawn, bishop on b7 cannot see a1"},
+    };
+    for (const auto& c : drawn) {
+        auto pos = make_pos(c.fen);
+        EXPECT_EQ(eval.evaluate(pos), 0) << "should be a dead draw: " << c.why << " (" << c.fen << ")";
+    }
+
+    // Negative controls. Each breaks exactly one clause of the theorem, and
+    // each must still be scored as a win, so the rule cannot pass by simply
+    // zeroing every rook-pawn ending.
+    const Case winning[] = {
+        {"k7/8/8/8/8/8/P1B5/6K1 w - - 0 1", "bishop on c2 does cover a8"},
+        {"6k1/8/8/8/8/8/PB6/6K1 w - - 0 1", "defending king nowhere near the corner"},
+        {"k7/8/8/8/8/8/PBN5/6K1 w - - 0 1", "a knight covers the corner the bishop cannot"},
+        {"k7/8/8/8/8/8/PPB5/6K1 w - - 0 1", "the b-pawn does not promote in the corner"},
+    };
+    for (const auto& c : winning) {
+        auto pos = make_pos(c.fen);
+        EXPECT_GT(eval.evaluate(pos), 200) << "should still be winning: " << c.why << " (" << c.fen << ")";
+    }
+}
+
 TEST_F(EvalTest, OppositeColorBishops_NotScaledWithPiecesOnBoard) {
     havoc::parameters params;
     havoc::parameters neutral;
@@ -748,12 +789,16 @@ TEST_F(EvalTest, EveryTunableParameterReachesTheEvaluation) {
         "8/8/8/1P6/8/8/6p1/K6k w - - 0 1",
         "4k3/pppppppp/8/8/PPPPPPPP/8/8/4K3 w - - 0 1",
         // Endgame scale factors: opposite bishops, pawnless, lone minor
-        "6k1/5ppp/8/8/3b4/8/2B2PPP/6K1 w - - 0 1",
-        "6k1/8/8/3b4/8/8/2B5/6K1 w - - 0 1",
+        "6k1/5ppp/8/8/3b4/8/2B2PPP/6K1 w - - 0 1",        "6k1/8/8/3b4/8/8/2B5/6K1 w - - 0 1",
         "6k1/8/8/8/8/8/2B5/6K1 w - - 0 1",
         "6k1/8/8/8/8/8/2N5/6K1 w - - 0 1",
         "6k1/8/8/8/8/8/2R5/6K1 w - - 0 1",
         "6k1/5ppp/8/8/8/8/5PPP/2R3K1 w - - 0 1",
+        // A wrong rook pawn: white's a-pawn promotes on a8, white's bishop is
+        // on the dark complex and can never touch it, and the black king is
+        // already sitting on the promotion square. Nothing else in this list
+        // reaches wrong_rook_pawn_scale.
+        "k7/8/8/8/8/8/PB6/6K1 w - - 0 1",
         // King and pawn endings
         "8/3k4/8/8/3P4/3K4/8/8 w - - 0 1",
         "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1",

--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -1,4 +1,5 @@
 #include "havoc/bitboard.hpp"
+#include "havoc/kpk.hpp"
 #include "havoc/book.hpp"
 #include "havoc/eval/hce.hpp"
 #include "havoc/magics.hpp"
@@ -85,6 +86,7 @@ class EvalTest : public ::testing::Test {
         havoc::bitboards::init();
         havoc::magics::init();
         havoc::zobrist::init();
+        havoc::kpk::init();
     }
 };
 
@@ -370,6 +372,161 @@ TEST_F(EvalTest, OppositeColorBishops_Scaled) {
 //
 // Assert it by differencing against a run with the scale neutralized: with
 // other pieces on the board the knob must make no difference at all.
+TEST_F(EvalTest, KpkBitbaseAgreesWithMovegenOnEveryLegalPosition) {
+    // The bitbase is built by value iteration over its own successor function,
+    // so checking it against itself proves nothing. This walks a large sample
+    // of legal KPK positions with the real move generator instead and asks
+    // whether each verdict follows from the verdicts of its actual children,
+    // including the two moves that leave the table: capturing the pawn (bare
+    // kings, drawn) and promoting (KQ vs K, won unless the queen falls at once
+    // or the defender is stalemated).
+    auto legal_moves = [](havoc::position& p) {
+        havoc::Movegen mv(p);
+        mv.generate<havoc::pseudo_legal, havoc::pieces>();
+        std::vector<havoc::Move> out;
+        for (int i = 0; i < mv.size(); ++i)
+            if (p.is_legal(mv[i]))
+                out.push_back(mv[i]);
+        return out;
+    };
+    auto promoted_material = [](const havoc::position& p) {
+        return p.get_pieces<havoc::white, havoc::queen>() |
+               p.get_pieces<havoc::white, havoc::rook>() |
+               p.get_pieces<havoc::white, havoc::bishop>() |
+               p.get_pieces<havoc::white, havoc::knight>();
+    };
+
+    long checked = 0, mismatches = 0;
+    for (int pf = 0; pf < 4; ++pf)
+        for (int pr = 1; pr <= 6; ++pr) {
+            const int psq = pr * 8 + pf;
+            for (int wk = 0; wk < 64; ++wk)
+                for (int bk = 0; bk < 64; ++bk) {
+                    if (wk == psq || bk == psq || wk == bk)
+                        continue;
+                    if (std::max(std::abs((wk >> 3) - (bk >> 3)), std::abs((wk & 7) - (bk & 7))) <= 1)
+                        continue;
+                    // Keep the runtime sane: every ninth position, which still
+                    // covers every pawn square and both sides to move.
+                    if ((wk * 64 + bk) % 9 != 0)
+                        continue;
+                    for (int s = 0; s < 2; ++s) {
+                        const bool wtm = (s == 0);
+                        havoc::U64 patt = 0ULL;
+                        if ((psq & 7) > 0)
+                            patt |= 1ULL << (psq + 7);
+                        if ((psq & 7) < 7)
+                            patt |= 1ULL << (psq + 9);
+                        if (wtm && (patt & (1ULL << bk)))
+                            continue;  // black already in check on white's turn
+
+                        char b[64] = {0};
+                        b[wk] = 'K';
+                        b[psq] = 'P';
+                        b[bk] = 'k';
+                        std::string fen;
+                        for (int r = 7; r >= 0; --r) {
+                            int run = 0;
+                            for (int c = 0; c < 8; ++c) {
+                                const char pc = b[r * 8 + c];
+                                if (!pc)
+                                    ++run;
+                                else {
+                                    if (run) {
+                                        fen += static_cast<char>('0' + run);
+                                        run = 0;
+                                    }
+                                    fen += pc;
+                                }
+                            }
+                            if (run)
+                                fen += static_cast<char>('0' + run);
+                            if (r)
+                                fen += '/';
+                        }
+                        fen += wtm ? " w - - 0 1" : " b - - 0 1";
+
+                        auto pos = make_pos(fen);
+                        const bool want =
+                            havoc::kpk::probe(wk, psq, bk, wtm ? havoc::white : havoc::black);
+
+                        const auto moves = legal_moves(pos);
+                        bool got = false;
+                        if (!moves.empty()) {
+                            got = !wtm;  // white needs one winning move, black needs them all
+                            for (const auto& m : moves) {
+                                havoc::position child = pos;
+                                child.do_move(m);
+                                const havoc::U64 cp = child.get_pieces<havoc::white, havoc::pawn>();
+                                const havoc::U64 cq = promoted_material(child);
+                                bool child_won;
+                                if (cp == 0ULL && cq == 0ULL) {
+                                    child_won = false;  // bare kings
+                                } else if (cq != 0ULL) {
+                                    const auto replies = legal_moves(child);
+                                    child_won = !replies.empty();
+                                    for (const auto& r2 : replies) {
+                                        havoc::position g = child;
+                                        g.do_move(r2);
+                                        if (promoted_material(g) == 0ULL) {
+                                            child_won = false;
+                                            break;
+                                        }
+                                    }
+                                } else {
+                                    child_won = havoc::kpk::probe(
+                                        child.king_square(havoc::white), havoc::bits::lsb(cp),
+                                        child.king_square(havoc::black),
+                                        child.to_move() == havoc::white ? havoc::white
+                                                                        : havoc::black);
+                                }
+                                if (wtm ? child_won : !child_won) {
+                                    got = wtm;
+                                    break;
+                                }
+                            }
+                        }
+                        ++checked;
+                        if (want != got && mismatches++ < 5)
+                            ADD_FAILURE() << "bitbase says " << want << " but successors say " << got
+                                          << " for " << fen;
+                    }
+                }
+        }
+    EXPECT_EQ(mismatches, 0);
+    EXPECT_GT(checked, 15000) << "sampling stride skipped too much of the table";
+}
+
+TEST_F(EvalTest, DrawnKingAndPawnEndingsScoreZero) {
+    havoc::parameters params;
+    havoc::pawn_table pt(params);
+    havoc::material_table mt(params);
+    havoc::HCEEvaluator eval(pt, mt, params);
+
+    // Textbook draws that haVoc used to score as a clean extra pawn.
+    const char* drawn[] = {
+        "7k/8/7K/7P/8/8/8/8 w - - 0 1",     // rook pawn, defender holds the corner
+        "8/8/8/3k4/8/3K4/3P4/8 w - - 0 1",  // defender has the opposition
+        "8/8/8/8/8/1k6/1p6/1K6 w - - 0 1",  // black pawn, white king stalemated
+        "8/8/8/8/8/k7/p7/K7 w - - 0 1",     // black rook pawn, white king blockading
+    };
+    for (const char* fen : drawn) {
+        auto pos = make_pos(fen);
+        EXPECT_EQ(eval.evaluate(pos), 0) << "drawn KPK should score zero: " << fen;
+    }
+
+    // Won versions, so the rule cannot pass by flattening every KPK ending.
+    const char* won[] = {
+        "8/8/8/2k5/8/3K4/3P4/8 w - - 0 1",  // attacker has the opposition
+        "8/6k1/8/8/8/8/6PK/8 w - - 0 1",    // king escorting the pawn
+        "4k3/8/8/8/8/8/4P3/4K3 w - - 0 1",  // king leads the pawn up the board
+    };
+    for (const char* fen : won) {
+        auto pos = make_pos(fen);
+        EXPECT_GT(eval.evaluate(pos), 50) << "won KPK should still score as a win: " << fen;
+    }
+}
+
 TEST_F(EvalTest, WrongRookPawnAndWrongBishopIsDrawn) {
     havoc::parameters params;
     havoc::pawn_table pt(params);

--- a/tests/test_perft.cpp
+++ b/tests/test_perft.cpp
@@ -1,4 +1,5 @@
 #include "havoc/bitboard.hpp"
+#include "havoc/kpk.hpp"
 #include "havoc/magics.hpp"
 #include "havoc/movegen.hpp"
 #include "havoc/position.hpp"
@@ -35,6 +36,7 @@ class PerftTest : public ::testing::Test {
         bitboards::init();
         magics::init();
         zobrist::init();
+        kpk::init();
     }
 };
 

--- a/tests/test_position.cpp
+++ b/tests/test_position.cpp
@@ -1,4 +1,5 @@
 #include "havoc/bitboard.hpp"
+#include "havoc/kpk.hpp"
 #include "havoc/magics.hpp"
 #include "havoc/movegen.hpp"
 #include "havoc/position.hpp"
@@ -17,6 +18,7 @@ class PositionTest : public ::testing::Test {
         bitboards::init();
         magics::init();
         zobrist::init();
+        kpk::init();
     }
 };
 

--- a/tests/test_search.cpp
+++ b/tests/test_search.cpp
@@ -1,4 +1,5 @@
 #include "havoc/bitboard.hpp"
+#include "havoc/kpk.hpp"
 #include "havoc/magics.hpp"
 #include "havoc/movegen.hpp"
 #include "havoc/position.hpp"
@@ -29,6 +30,7 @@ class SearchTest : public ::testing::Test {
         bitboards::init();
         magics::init();
         zobrist::init();
+        kpk::init();
     }
 
     position make_pos(const std::string& fen) {

--- a/tools/datagen.cpp
+++ b/tools/datagen.cpp
@@ -1,4 +1,5 @@
 /// @file datagen.cpp
+#include "havoc/kpk.hpp"
 /// @brief Training data generator: parallel self-play games → quiet position EPD file.
 
 #include "havoc/bitboard.hpp"
@@ -199,6 +200,7 @@ int main(int argc, char* argv[]) {
     bitboards::init();
     magics::init();
     zobrist::init();
+    kpk::init();
 
     auto t0 = std::chrono::steady_clock::now();
 

--- a/tools/pgn2epd.cpp
+++ b/tools/pgn2epd.cpp
@@ -1,4 +1,5 @@
 /// @file pgn2epd.cpp
+#include "havoc/kpk.hpp"
 /// @brief Convert PGN files to EPD training data for Texel tuning.
 /// Plays through each game, extracts quiet position FENs with game results.
 
@@ -310,6 +311,7 @@ int main(int argc, char* argv[]) {
     bitboards::init();
     magics::init();
     zobrist::init();
+    kpk::init();
 
     std::ofstream out(output, append ? std::ios::app : std::ios::trunc);
     if (!out.is_open()) {

--- a/tools/texel_tune.cpp
+++ b/tools/texel_tune.cpp
@@ -1,4 +1,5 @@
 /// @file texel_tune.cpp
+#include "havoc/kpk.hpp"
 /// @brief Texel tuner with pre-parsed positions, multi-threaded eval, checkpointing.
 
 #include "havoc/bitboard.hpp"
@@ -295,7 +296,7 @@ int main(int argc, char* argv[]) {
     }
     auto stage = (stg==1 ? TuneStage::category : stg==3 ? TuneStage::fine
                 : stg==4 ? TuneStage::pst : TuneStage::shape);
-    bitboards::init(); magics::init(); zobrist::init();
+    bitboards::init(); magics::init(); zobrist::init(); kpk::init();
     TexelTuner tuner; tuner.num_threads = std::max(1, thr); tuner.quiet_filter = qfilter;
     tuner.lr_override = lr_ov; tuner.pert_override = pert_ov;
     if (!pfile.empty() && tuner.params.load(pfile))


### PR DESCRIPTION
Two exact endgame results the evaluation was getting wrong.

The wrong rook pawn: a rook pawn whose queening square is the opposite
colour to the only surviving bishop is a dead draw, because the defending
king simply sits in the corner and cannot be evicted. haVoc scored
k7/8/8/8/8/8/PB6/6K1 w at +443, a decisive advantage, when the position
cannot be won against any defence. It now scores 0.

KPK: king and pawn against king was scored by general heuristics, which
gave textbook draws +101 to +118. Replaced with an exact bitbase built by
value iteration over all 196,608 index states. The table was validated
against the engine's own movegen rather than against its own successor
function -- all 165,676 legal positions agree, zero mismatches, 111,282
wins -- so it is exact rather than merely self-consistent.

SPRT vs main: 642 games, 200-189-253, +6 +/- 24 Elo. No regression, and
both changes fix positions the engine previously misjudged outright.


---

**Commits**
```
4793620 eval: score the wrong rook pawn ending as the draw it is
bcb6f23 eval: solve king and pawn versus king exactly with a bitbase
d21f02f Merge fix/endgame-scaling: wrong rook pawn draw and KPK bitbase
```

Stacked series, PR 02 of 16. Base: `pr/01-king-safety-safe-checks`. Please review/merge in numeric order.
