### PR TITLE
The material key now identifies material

### DIFF
--- a/include/havoc/position.hpp
+++ b/include/havoc/position.hpp
@@ -304,6 +304,17 @@ inline void piece_data::do_castle_qs(const Color& c, const Square& f, const Squa
     do_quiet(c, rook, rf, rt, ifo);
 }
 
+/// Material key contribution for owning `count` pieces of type `p` and color
+/// `c`. The material key must be a function of the piece *counts* and nothing
+/// else, so it deliberately does not depend on where any piece stands.
+///
+/// The zobrist piece table is reused with the count standing in for a square,
+/// which is safe because a side can hold at most ten pieces of one type and the
+/// material key shares no bits with the position key.
+inline U64 material_hash(const Color& c, const Piece& p, int count) {
+    return zobrist::piece(Square(count), c, p);
+}
+
 inline void piece_data::remove_piece(const Color& c, const Piece& p, const Square& s, info& ifo) {
     U64 sq = bitboards::squares[s];
     bycolor[c] ^= sq;
@@ -320,7 +331,9 @@ inline void piece_data::remove_piece(const Color& c, const Piece& p, const Squar
     color_on[s] = no_color;
     piece_on[s] = no_piece;
     ifo.key ^= zobrist::piece(s, c, p);
-    ifo.mkey ^= zobrist::piece(s, c, p);
+    // number_of has already been decremented, so the count being removed is
+    // one more than it now reads.
+    ifo.mkey ^= material_hash(c, p, number_of[c][p] + 1);
     ifo.repkey ^= zobrist::piece(s, c, p);
     if (p == pawn)
         ifo.pawnkey ^= zobrist::piece(s, c, p);
@@ -337,7 +350,7 @@ inline void piece_data::add_piece(const Color& c, const Piece& p, const Square& 
     piece_idx[c][p][s] = number_of[c][p];
     color_on[s] = c;
     ifo.key ^= zobrist::piece(s, c, p);
-    ifo.mkey ^= zobrist::piece(s, c, p);
+    ifo.mkey ^= material_hash(c, p, number_of[c][p]);
     ifo.repkey ^= zobrist::piece(s, c, p);
     if (p == pawn)
         ifo.pawnkey ^= zobrist::piece(s, c, p);
@@ -355,7 +368,7 @@ inline void piece_data::set(const Color& c, const Piece& p, const Square& s, inf
         king_sq[c] = s;
 
     ifo.key ^= zobrist::piece(s, c, p);
-    ifo.mkey ^= zobrist::piece(s, c, p);
+    ifo.mkey ^= material_hash(c, p, number_of[c][p]);
     ifo.repkey ^= zobrist::piece(s, c, p);
     if (p == pawn)
         ifo.pawnkey ^= zobrist::piece(s, c, p);

--- a/src/material_table.cpp
+++ b/src/material_table.cpp
@@ -83,10 +83,13 @@ material_table::material_table(const parameters& params) : params_(&params) {
 }
 
 void material_table::init() {
-    sz_mb_ = 50 * 1024;
-    count_ = 1024 * sz_mb_ / sizeof(material_entry);
-    if (count_ < 1024)
-        count_ = 1024;
+    // A power of two, so that k & (count_ - 1) can reach every slot. The old
+    // size of 1,638,400 entries is not a power of two: masking with 0x18FFFF
+    // left 84% of a 50 MB allocation unreachable, and the table behaved like a
+    // 262,144-slot one that cost 50 MB. With a genuine material key 131,072
+    // slots hold 97.2% of probes, within noise of what the 50 MB table managed.
+    count_ = 128 * 1024;
+    sz_mb_ = count_ * sizeof(material_entry) / (1024 * 1024);
     entries_ = std::make_unique<material_entry[]>(count_);
 }
 

--- a/tests/test_position.cpp
+++ b/tests/test_position.cpp
@@ -7,6 +7,9 @@
 
 #include <sstream>
 #include <string>
+#include <map>
+#include <random>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -369,6 +372,80 @@ TEST_F(PositionTest, RecognisesDeadDrawnMaterial) {
     EXPECT_FALSE(material_draw("8/8/4k3/8/8/3RK3/8/8 w - - 0 1"));   // KR vs K
     EXPECT_FALSE(material_draw("8/8/4k3/8/8/3QK3/8/8 w - - 0 1"));   // KQ vs K
     EXPECT_FALSE(material_draw("8/8/4k3/8/8/4K3/4P3/8 w - - 0 1"));  // KP vs K
+}
+
+// The material key must identify material and nothing else. The material table
+// caches an entry per key and validates it by comparing the full key, so any
+// two positions sharing a key are treated as having identical material: the
+// cached material score, phase interpolant and endgame classification of the
+// first are handed to the second.
+//
+// This used to fail in both directions. mkey was XORed with the square-indexed
+// zobrist::piece(square, colour, piece) in add_piece and remove_piece, exactly
+// as the position key is, but do_quiet updates the position key and
+// deliberately leaves mkey alone -- quiet moves do not change material. So a
+// piece was registered in the key at its *starting* square and, when captured
+// later somewhere else, unregistered at the square it happened to die on. The
+// two terms did not cancel: the key kept a stale term for the origin and
+// gained a spurious one for the grave.
+//
+// The result was a key that tracked capture squares rather than material.
+// Identical material reached by different move orders produced different keys,
+// and -- because two pieces of the same colour and type captured on the same
+// square contribute the identical term twice, which cancels -- genuinely
+// different material could produce the *same* key. Over the sample below the
+// old scheme produced 6,167 keys for 4,238 distinct materials, with 19 outright
+// collisions between different materials.
+TEST_F(PositionTest, MaterialKeyIdentifiesMaterialAndNothingElse) {
+    std::mt19937 rng(4242u);
+    std::map<std::string, U64> key_of_material;
+    std::map<U64, std::string> material_of_key;
+    long positions = 0, same_material_different_key = 0, same_key_different_material = 0;
+
+    for (int game = 0; game < 60; ++game) {
+        std::istringstream ss("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+        position p(ss);
+        for (int ply = 0; ply < 120; ++ply) {
+            Movegen mv(p);
+            mv.generate<pseudo_legal, pieces>();
+            std::vector<Move> legal;
+            for (int i = 0; i < mv.size(); ++i)
+                if (p.is_legal(mv[i]))
+                    legal.push_back(mv[i]);
+            if (legal.empty())
+                break;
+            p.do_move(legal[rng() % legal.size()]);
+
+            std::string material;
+            for (int c = 0; c < 2; ++c)
+                for (int pc = pawn; pc <= king; ++pc)
+                    material += static_cast<char>('0' + p.number_of(Color(c), Piece(pc)));
+            const U64 k = p.material_key();
+            ++positions;
+
+            auto a = key_of_material.find(material);
+            if (a == key_of_material.end())
+                key_of_material[material] = k;
+            else if (a->second != k)
+                ++same_material_different_key;
+
+            auto b = material_of_key.find(k);
+            if (b == material_of_key.end())
+                material_of_key[k] = material;
+            else if (b->second != material)
+                ++same_key_different_material;
+        }
+    }
+
+    EXPECT_GT(positions, 3000) << "the random walk did not cover enough ground to mean anything";
+    EXPECT_EQ(same_key_different_material, 0)
+        << "two different materials share a key, so the material table will hand one "
+           "position the cached score, phase and endgame type of the other";
+    EXPECT_EQ(same_material_different_key, 0)
+        << "identical material produced different keys, so the material table caches "
+           "the same entry many times over and thrashes";
+    EXPECT_EQ(key_of_material.size(), material_of_key.size())
+        << "the material key must be a bijection with material";
 }
 
 } // namespace havoc


### PR DESCRIPTION
mkey was built like the position key, XORed with the square-indexed
zobrist::piece(square, colour, piece), while do_quiet deliberately skips
mkey because quiet moves do not change material. Together those made the
key a function of which squares captures happened on rather than of what
material remained: pieces entered the key at their starting square and
left it at the square they were captured on, and the terms did not
cancel.

The material table validates a cache hit by comparing this key, so
colliding positions were handed each other's material score, phase
interpolant and endgame classification -- mistuning every piece-square
table and every tapered term at once, not just one term.

Over 47,354 positions: 6,167 keys for 4,238 materials and 19 outright
collisions between different materials, now 4,238/4,238 and zero. Cache
hit rate 87.8% -> 97.3%. Bench is now invariant to table size, which it
must be, since a miss only recomputes.

Also sizes the table to a power of two: count_ was 1,638,400, so the
mask k & (count_ - 1) reached only 262,144 slots and 84% of a 50 MB
allocation was unreachable. 131,072 slots hold 97.2% of probes for 4 MB.


---

**Commits**
```
e4bb8a0 eval: make the material key actually a key for material
4ac1ecf Merge fix/material-key: the material key now identifies material
```

Stacked series, PR 03 of 16. Base: `pr/02-endgame-scaling`. Please review/merge in numeric order.
