### PR TITLE
Four zobrist key correctness bugs

### DIFF
--- a/include/havoc/types.hpp
+++ b/include/havoc/types.hpp
@@ -188,6 +188,25 @@ enum CastleRight {
     clearw = 12
 };
 
+/// Castling rights surviving a move that touches a given square.
+///
+/// A right dies when the king leaves its home square, when the rook leaves its
+/// corner, and -- the case that used to be missed entirely -- when the rook is
+/// captured on its corner. Indexing by both the origin and the destination of
+/// a move covers all three without special-casing captures: the destination of
+/// a capture on a1/h1/a8/h8 is exactly the corner whose right is lost.
+[[nodiscard]] constexpr U16 castle_rights_after(int sq) {
+    switch (sq) {
+    case 0:  return clearwqs; // A1
+    case 7:  return clearwks; // H1
+    case 4:  return clearw;   // E1
+    case 56: return clearbqs; // A8
+    case 63: return clearbks; // H8
+    case 60: return clearb;   // E8
+    default: return 15;
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Score constants (replaces legacy Score enum).
 // ---------------------------------------------------------------------------

--- a/include/havoc/zobrist.hpp
+++ b/include/havoc/zobrist.hpp
@@ -13,6 +13,16 @@ void init();
 /// Zobrist key for castling rights.
 [[nodiscard]] U64 castle(Color c, U16 rights);
 
+/// Key contribution of a complete castling-rights mask.
+///
+/// The rights have to be hashed as one value rather than per-right, because
+/// the only place that knows which individual rights went away is the code
+/// that clears them, and it clears with masks rather than with the right bits
+/// that were originally hashed in. Hashing the whole mask makes the term a
+/// function of the rights themselves, so XORing the old mask out and the new
+/// mask in is exact no matter how the change came about.
+[[nodiscard]] U64 castle_rights(U16 mask);
+
 /// Zobrist key for en-passant file.
 [[nodiscard]] U64 ep(int file);
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -59,12 +59,14 @@ void position::setup(std::istringstream& fen) {
     // castle rights
     fen >> token;
     ifo.cmask = U16(0);
-    for (auto& c : token) {
-        U16 cr = castle_right_from_char(c);
-        ifo.cmask |= cr;
-        ifo.key ^= zobrist::castle(ifo.stm, cr);
-        ifo.repkey ^= zobrist::castle(ifo.stm, cr);
-    }
+    for (auto& c : token)
+        ifo.cmask |= castle_right_from_char(c);
+    // Hashed as a whole mask. Hashing each right under zobrist::castle(stm, cr)
+    // made the term depend on whose turn it was, so the same rights hashed
+    // differently for white and for black, and it could never be cancelled by
+    // do_move, which cleared with masks under the owning colour instead.
+    ifo.key ^= zobrist::castle_rights(ifo.cmask);
+    ifo.repkey ^= zobrist::castle_rights(ifo.cmask);
 
     // ep square
     fen >> token;
@@ -212,41 +214,20 @@ void position::do_move(const Move& m) {
     const Movetype t = Movetype(m.type);
     const Piece p = piece_on(from);
     const Color us = to_move();
+    const U16 old_cmask = ifo.cmask;
 
     // king square update and castle rights update
     if (p == king) {
         pcs.king_sq[us] = to;
         ifo.ks[us] = to;
-        if (can_castle_ks() || can_castle_qs()) {
-            ifo.cmask &= (us == white ? clearw : clearb);
-            ifo.key ^=
-                (us == white ? zobrist::castle(white, clearw) : zobrist::castle(black, clearb));
-            ifo.repkey ^=
-                (us == white ? zobrist::castle(white, clearw) : zobrist::castle(black, clearb));
-        }
-    } else if (p == rook) {
-        if (us == white && can_castle<white>()) {
-            if (from == A1) {
-                ifo.cmask &= clearwqs;
-                ifo.key ^= zobrist::castle(white, clearwqs);
-                ifo.repkey ^= zobrist::castle(white, clearwqs);
-            } else if (from == H1) {
-                ifo.cmask &= clearwks;
-                ifo.key ^= zobrist::castle(white, clearwks);
-                ifo.repkey ^= zobrist::castle(white, clearwks);
-            }
-        } else if (us == black && can_castle<black>()) {
-            if (from == A8) {
-                ifo.cmask &= clearbqs;
-                ifo.key ^= zobrist::castle(black, clearbqs);
-                ifo.repkey ^= zobrist::castle(black, clearbqs);
-            } else if (from == H8) {
-                ifo.cmask &= clearbks;
-                ifo.key ^= zobrist::castle(black, clearbks);
-                ifo.repkey ^= zobrist::castle(black, clearbks);
-            }
-        }
     }
+
+    // Castling rights, hashed once from the finished mask below. Indexing by
+    // both squares the move touches retires a right when the king leaves home,
+    // when the rook leaves its corner, and when the rook is *captured* on its
+    // corner -- the last of which nothing used to handle, so the engine went on
+    // believing in a rook that was no longer on the board.
+    ifo.cmask &= castle_rights_after(from) & castle_rights_after(to);
 
     ifo.captured = no_piece;
 
@@ -283,12 +264,25 @@ void position::do_move(const Move& m) {
         ifo.has_castled[us] = true;
     }
 
-    // eps
+    if (ifo.cmask != old_cmask) {
+        ifo.key ^= zobrist::castle_rights(old_cmask) ^ zobrist::castle_rights(ifo.cmask);
+        ifo.repkey ^= zobrist::castle_rights(old_cmask) ^ zobrist::castle_rights(ifo.cmask);
+    }
+
+    // En passant. The square the previous move offered has to be hashed back
+    // out as it expires, exactly as do_null_move already did. Only XORing the
+    // new one in left every square ever offered in the key, so the key recorded
+    // the history of double pushes instead of the one square, if any, that can
+    // actually be captured on now.
+    if (ifo.eps != no_square) {
+        ifo.key ^= zobrist::ep(util::col(ifo.eps));
+        ifo.repkey ^= zobrist::ep(util::col(ifo.eps));
+    }
     ifo.eps = no_square;
     if (p == pawn && std::abs(from - to) == 16) {
         ifo.eps = Square(from + (us == white ? 8 : -8));
-        ifo.key ^= zobrist::ep(util::col(to));
-        ifo.repkey ^= zobrist::ep(util::col(to));
+        ifo.key ^= zobrist::ep(util::col(ifo.eps));
+        ifo.repkey ^= zobrist::ep(util::col(ifo.eps));
     }
 
     // move50
@@ -305,7 +299,13 @@ void position::do_move(const Move& m) {
     // half-moves
     ifo.hmvs++;
 
-    // side to move
+    // Side to move. Both terms have to move: XOR the outgoing side back out
+    // before XORing the incoming side in. Only adding the new one leaves the
+    // old one in the key, so the side-to-move contribution accumulates over a
+    // game instead of toggling, giving it a period of four plies rather than
+    // two.
+    ifo.key ^= zobrist::stm(ifo.stm);
+    ifo.repkey ^= zobrist::stm(ifo.stm);
     ifo.stm = Color(ifo.stm ^ 1);
     ifo.key ^= zobrist::stm(ifo.stm);
     ifo.repkey ^= zobrist::stm(ifo.stm);
@@ -369,6 +369,9 @@ void position::do_null_move() {
         ifo.eps = no_square;
     }
 
+    // As in do_move: the outgoing side has to be XORed back out.
+    ifo.key ^= zobrist::stm(ifo.stm);
+    ifo.repkey ^= zobrist::stm(ifo.stm);
     ifo.stm = them;
     ifo.key ^= zobrist::stm(ifo.stm);
     ifo.repkey ^= zobrist::stm(ifo.stm);

--- a/src/zobrist.cpp
+++ b/src/zobrist.cpp
@@ -371,6 +371,10 @@ U64 piece(Square sq, Color c, Piece p) {
 U64 castle(Color c, U16 rights) {
     return castle_rands[c][rights];
 }
+
+U64 castle_rights(U16 mask) {
+    return castle_rands[0][mask & 15];
+}
 U64 ep(int file) {
     return ep_rands[file];
 }

--- a/tests/test_position.cpp
+++ b/tests/test_position.cpp
@@ -448,4 +448,139 @@ TEST_F(PositionTest, MaterialKeyIdentifiesMaterialAndNothingElse) {
         << "the material key must be a bijection with material";
 }
 
+// Every incrementally maintained key must equal the key a fresh position
+// computes from scratch for the same board. The keys are updated by hand in
+// do_quiet, add_piece, remove_piece and set, each guarded by its own
+// condition, and a missed or mismatched guard is invisible until it silently
+// corrupts whatever cache the key feeds -- exactly how the material key came
+// to identify capture squares rather than material.
+//
+// Rebuilding from the FEN is the independent oracle: it exercises set() only,
+// with no incremental path at all, so agreement across a random walk means the
+// incremental updates compose to the same function as a from-scratch build.
+// Promotions and en passant are the interesting cases, since both move a pawn
+// off a square without a pawn arriving on it.
+TEST_F(PositionTest, IncrementalKeysAgreeWithKeysBuiltFromScratch) {
+    std::mt19937 rng(90210u);
+    long positions = 0, promotions = 0, en_passants = 0;
+
+    for (int game = 0; game < 40; ++game) {
+        std::istringstream ss("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+        position p(ss);
+        for (int ply = 0; ply < 140; ++ply) {
+            Movegen mv(p);
+            mv.generate<pseudo_legal, pieces>();
+            std::vector<Move> legal;
+            for (int i = 0; i < mv.size(); ++i)
+                if (p.is_legal(mv[i]))
+                    legal.push_back(mv[i]);
+            if (legal.empty())
+                break;
+
+            const Move m = legal[rng() % legal.size()];
+            if (m.type <= capture_promotion_n)
+                ++promotions;
+            if (m.type == ep)
+                ++en_passants;
+            p.do_move(m);
+            ++positions;
+
+            const std::string fen = p.to_fen();
+            std::istringstream rebuilt_ss(fen);
+            position rebuilt(rebuilt_ss);
+
+            ASSERT_EQ(p.key(), rebuilt.key()) << "position key drifted at " << fen;
+            ASSERT_EQ(p.pawnkey(), rebuilt.pawnkey()) << "pawn key drifted at " << fen;
+            ASSERT_EQ(p.material_key(), rebuilt.material_key())
+                << "material key drifted at " << fen;
+        }
+    }
+
+    EXPECT_GT(positions, 2000);
+    EXPECT_GT(promotions, 0) << "the walk never promoted, so it never tested the case "
+                                "where a pawn leaves the board without one arriving";
+    EXPECT_GT(en_passants, 0) << "the walk never played en passant, so it never tested "
+                                 "a capture on a square the captured pawn is not on";
+}
+
+namespace {
+/// Plays the move with the given origin and destination, and fails if no such
+/// legal move exists.
+bool play(position& p, Square from, Square to) {
+    Movegen mv(p);
+    mv.generate<pseudo_legal, pieces>();
+    for (int i = 0; i < mv.size(); ++i)
+        if (mv[i].f == from && mv[i].t == to && p.is_legal(mv[i])) {
+            p.do_move(mv[i]);
+            return true;
+        }
+    return false;
+}
+} // namespace
+
+// A repetition is a repetition however many moves it took to come back.
+//
+// is_draw() walks the history two plies at a time, which is right, because only
+// positions with the same side to move can repeat. But the side-to-move term
+// was XORed into the key on every move without the outgoing side being XORed
+// back out, so it accumulated rather than toggled and had a period of four
+// plies instead of two. Every candidate the walk examined at a distance of two
+// plies mod four therefore differed by a constant and could not match, no
+// matter what was on the board.
+//
+// The engine consequently saw repetitions four and eight plies back and was
+// structurally blind to those six, ten and fourteen plies back. Rooks
+// triangulating home -- a1-b1-c1-a1 against a8-b8-c8-a8 -- repeat after six.
+TEST_F(PositionTest, ARepetitionSixPliesBackIsStillARepetition) {
+    std::istringstream ss("r3k2r/8/8/8/8/8/8/R3K2R w - - 0 1");
+    position p(ss);
+    const U64 start_key = p.key();
+
+    const Square path[][2] = {{A1, B1}, {A8, B8}, {B1, C1}, {B8, C8}, {C1, A1}, {C8, A8}};
+    for (auto& mv : path) {
+        ASSERT_TRUE(play(p, mv[0], mv[1])) << "could not play the manoeuvre";
+        if (&mv != &path[5])
+            EXPECT_FALSE(p.is_draw()) << "claimed a draw before the position had repeated";
+    }
+
+    EXPECT_EQ(p.key(), start_key) << "the same board with the same side to move must hash "
+                                     "the same however many plies ago it was last seen";
+    EXPECT_TRUE(p.is_draw()) << "the position has occurred twice and was not detected";
+}
+
+// Castling rights die with the rook, whether it moves or is taken.
+//
+// do_move retired rights when the king or the rook moved, but nothing looked at
+// the square a capture landed on, so taking a rook on its home square left the
+// owner still nominally able to castle with it. The rights mask, the key and
+// the FEN all went on describing a rook that was no longer on the board, and
+// move generation kept emitting the castle for is_legal to throw away.
+TEST_F(PositionTest, CapturingARookOnItsHomeSquareRetiresTheCastlingRight) {
+    std::istringstream ss("4k2r/8/6N1/8/8/8/8/4K3 w k - 0 1");
+    position p(ss);
+    ASSERT_TRUE(p.can_castle_ks<black>());
+
+    ASSERT_TRUE(play(p, G6, H8)) << "Nxh8 should be legal";
+
+    EXPECT_FALSE(p.can_castle_ks<black>())
+        << "black kept the kingside right after the h8 rook was captured";
+    std::istringstream fen_fields(p.to_fen());
+    std::string board, stm, castling;
+    fen_fields >> board >> stm >> castling;
+    EXPECT_EQ(castling, "-")
+        << "the FEN still advertises a castling right for a rook that is gone: " << p.to_fen();
+
+    Movegen mv(p);
+    mv.generate<pseudo_legal, pieces>();
+    for (int i = 0; i < mv.size(); ++i)
+        EXPECT_NE(mv[i].type, castle_ks) << "still generating a castle with no rook to castle with";
+
+    // And the key must agree with a position built from scratch, which is what
+    // makes the stale right corrupt transposition lookups rather than merely
+    // look untidy.
+    std::istringstream rebuilt_ss(p.to_fen());
+    position rebuilt(rebuilt_ss);
+    EXPECT_EQ(p.key(), rebuilt.key());
+}
+
 } // namespace havoc


### PR DESCRIPTION
The incremental zobrist updates did not compose to the same function as
a from-scratch build. Rebuilding each position from its own FEN and
comparing keys failed on the very first move, which uncovered four
distinct 'XOR in but never out' bugs:

1. Side to move. do_move() flipped ifo.stm and then XORed in the new
   side's term without XORing out the old, so the stm contribution
   accumulated and had period 4 in plies instead of 2. Because is_draw()
   walks history in steps of 2, every repetition candidate at a distance
   of 2 mod 4 differed by a constant and could never match: the engine
   was structurally blind to repetitions 6, 10, 14, ... plies back.
   Same bug in do_null_move().

2. En passant. do_move() XORed the ep square in on a double push but
   never XORed it out when the right expired. do_null_move() already
   did this correctly.

3. Castling. set() hashed each right as zobrist::castle(ifo.stm, cr),
   keyed on the side to move and indexed by a right bit, while do_move()
   cleared with zobrist::castle(owner, clear_mask), keyed on the owner
   and indexed by a clear mask. These are unrelated randoms that can
   never cancel, so the key was path dependent.

4. Castling rights on rook capture. Nothing retired a castling right
   when a rook was captured on its home square. Verified directly: after
   Nxh8, black still held bks, the FEN still advertised 'k', and movegen
   still emitted e8g8. is_legal() rejected it, so no illegal move ever
   reached the board, but the key and the FEN were both wrong.

Adds zobrist::castle_rights(U16) and castle_rights_after(int sq) so the
whole mask is hashed as one value on both paths.

Three regression tests added, each verified to fail against the old
code: keys built incrementally agree with keys built from scratch across
a random walk, a genuine six-ply repetition is detected, and capturing a
rook on its home square retires the right.

SPRT vs main at 10+0.1: 315 games, 107-80-128, +30 +/- 17 Elo.
Non-regression confirmed; merging as must-fix correctness.


---

**Commits**
```
32e428d fix: the position key accumulated terms it never cancelled
c596ad9 Merge fix/side-to-move-key: four zobrist key correctness bugs
```

Stacked series, PR 04 of 16. Base: `pr/03-material-key`. Please review/merge in numeric order.
