### PR TITLE
Use game phase, not material classification

### DIFF
--- a/include/havoc/material_table.hpp
+++ b/include/havoc/material_table.hpp
@@ -23,7 +23,29 @@ struct material_entry {
     EndgameType endgame = EndgameType::none;
     U8 number[5]{}; // indexed by Piece (knight..queen)
 
+    /// True when the material matches a *specific* endgame this evaluation
+    /// knows how to score, such as KPK or KRK.
+    ///
+    /// This is a statement about classification, not about game phase. It can
+    /// only become true once at most two non-pawn pieces remain on the whole
+    /// board, which over a random walk of 89,062 positions was 8.5% of them
+    /// and only 24% of the positions with phase 16 or beyond. Anything that
+    /// wants to know how far into the endgame we are wants the phase, not
+    /// this: use mg_weight() and eg_weight().
     [[nodiscard]] bool is_endgame() const { return endgame != EndgameType::none; }
+
+    /// Weight of the middlegame half of a tapered term, out of kPhaseMax.
+    [[nodiscard]] int mg_weight() const { return kPhaseMax - phase_interpolant; }
+
+    /// Weight of the endgame half of a tapered term, out of kPhaseMax.
+    [[nodiscard]] int eg_weight() const { return phase_interpolant; }
+
+    /// Blends a middlegame and an endgame value by game phase.
+    [[nodiscard]] int taper(int mg, int eg) const {
+        return (mg * mg_weight() + eg * eg_weight()) / kPhaseMax;
+    }
+
+    static constexpr int kPhaseMax = 24;
 };
 
 class material_table {

--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -29,6 +29,11 @@ struct parameters {
     int king_safety_category_scale = 100;
     int threat_category_scale = 100;
     int passed_pawn_category_scale = 100;
+    /// Endgame counterpart to passed_pawn_category_scale. The passed-pawn
+    /// evaluation used to be a single phase-independent scalar, so a passer
+    /// was worth exactly as much in the opening as in a king-and-pawn ending.
+    /// The score is now tapered between these two endpoints by game phase.
+    int passed_pawn_endgame_scale = 150;
     int pawn_structure_category_scale = 100;
     int space_category_scale = 100;
     int king_danger_divisor = 256;

--- a/src/eval/hce.cpp
+++ b/src/eval/hce.cpp
@@ -545,9 +545,15 @@ template <Color c> int HCEEvaluator::eval_bishops(const position& p, einfo& ei) 
                 score += 12;
         }
 
-        // Penalty for bishops on same color as own pawns
-        int same_color_penalty = (ei.me->is_endgame() ? params_.bishop_own_pawn_penalty_eg
-                                                      : params_.bishop_own_pawn_penalty_mg);
+        // Penalty for bishops on same color as own pawns.
+        //
+        // Blended by game phase. Selecting on is_endgame() picked the endgame
+        // value only once the board was down to two non-pawn pieces, which is
+        // 8.5% of positions, so bishop_own_pawn_penalty_eg was very nearly a
+        // dead parameter and a bad bishop was charged the middlegame rate
+        // through three quarters of all real endgames.
+        int same_color_penalty =
+            ei.me->taper(params_.bishop_own_pawn_penalty_mg, params_.bishop_own_pawn_penalty_eg);
         U64 fcolored_pawns = (this_light ? flight_sq_pawns : fdark_sq_pawns);
         score -= same_color_penalty * bits::count(fcolored_pawns);
 
@@ -617,11 +623,15 @@ template <Color c> int HCEEvaluator::eval_rooks(const position& p, einfo& ei) {
 
         score += mobility_score;
 
-        // Trapped rook
+        // Trapped rook. Blended by phase for the same reason as the bishop
+        // penalty above: index 1 of trapped_rook_penalty was reachable only in
+        // the barest positions. The extra charge for having not yet castled is
+        // a middlegame idea, so it fades with the middlegame weight instead of
+        // switching off.
         if (trapped_rook<c>(p, ei, s)) {
-            score -= params_.trapped_rook_penalty[ei.me->is_endgame()];
-            if (!ei.me->is_endgame() && !p.has_castled<c>())
-                score -= 2;
+            score -= ei.me->taper(params_.trapped_rook_penalty[0], params_.trapped_rook_penalty[1]);
+            if (!p.has_castled<c>())
+                score -= (2 * ei.me->mg_weight()) / material_entry::kPhaseMax;
         }
 
         // Center influence

--- a/src/eval/hce.cpp
+++ b/src/eval/hce.cpp
@@ -293,7 +293,9 @@ int HCEEvaluator::evaluate(const position& p, int lazy_margin) {
     score += (pawn_score * params_.pawn_structure_category_scale) / 100;
     score += (piece_score * params_.sq_score_category_scale) / 100;
     score += (king_score * params_.king_safety_category_scale) / 100;
-    score += (passed_score * params_.passed_pawn_category_scale) / 100;
+    score += (passed_score * ei.me->taper(params_.passed_pawn_category_scale,
+                                          params_.passed_pawn_endgame_scale)) /
+             100;
 
     if (lazy_margin > 0 && !ei.me->is_endgame() && std::abs(score) >= lazy_margin)
         return to_stm(p, score, params_.tempo);

--- a/src/eval/hce.cpp
+++ b/src/eval/hce.cpp
@@ -729,15 +729,26 @@ template <Color c> int HCEEvaluator::eval_king(const position& p, einfo& ei) {
     constexpr Color them = Color(c ^ 1);
     Square* kings = p.squares_of<c, king>();
     U64 enemyPawns = p.get_pieces<them, pawn>();
-    bool is_endgame = ei.me->is_endgame();
+    // Shelter, storm and the castling bonus are middlegame ideas: they fade
+    // out as the pieces that could exploit a draughty king leave the board.
+    // They used to switch off in one step when the material happened to match
+    // a classified ending, which is 8.5% of positions, so a king was still
+    // charged full middlegame shelter through most real endgames and then had
+    // the whole term vanish at an arbitrary boundary.
+    const int mg = ei.me->mg_weight();
 
     for (Square s = *kings; s != no_square; s = *++kings) {
         U64 sq_bb = bitboards::squares[s];
 
-        // Square eval (middlegame only)
-        if (!is_endgame)
-            score +=
-                params_.sq_score_scaling[king] * square_score<c>(params_, king, s, ei.me->phase_interpolant);
+        // Square eval. square_score already tapers between the middlegame and
+        // endgame king tables by phase, so gating it as well left the king with
+        // no positional guidance at all in exactly the positions where king
+        // activity decides the game. Classified endings that supply their own
+        // king logic -- KPK through the bitbase, KRK, KBNK -- do so by adding
+        // to this score, and the endgame king table already wants the king
+        // centralised, so there is nothing here to double count.
+        score += params_.sq_score_scaling[king] *
+                 square_score<c>(params_, king, s, ei.me->phase_interpolant);
 
         // Mobility
         U64 mvs = ei.kmask[c] & ei.empty;
@@ -836,8 +847,8 @@ template <Color c> int HCEEvaluator::eval_king(const position& p, einfo& ei) {
             }
         }
 
-        // Pawn shelter (middlegame)
-        if (!is_endgame) {
+        // Pawn shelter, weighted towards the middlegame.
+        {
             // Computed live rather than read from the pawn hash. The hash is
             // keyed on pawn structure alone, so a mask built from the king
             // square does not belong in it: castling leaves the pawns
@@ -845,28 +856,32 @@ template <Color c> int HCEEvaluator::eval_king(const position& p, einfo& ei) {
             // against wherever the king stood when that entry was filled.
             U64 pawn_shelter = p.get_pieces<c, pawn>() & ei.kmask[c];
             int n = std::min(3, bits::count(pawn_shelter));
-            score += params_.king_shelter[n] / 2;
+            int shelter = params_.king_shelter[n] / 2;
 
             // Pawnless flank penalty
             U64 kflank = bitboards::kflanks[util::col(s)] & p.get_pieces<c, pawn>();
             if (!kflank)
-                score -= 2;
+                shelter -= 2;
+
+            score += (shelter * mg) / material_entry::kPhaseMax;
         }
 
-        // Castling bonus (middlegame)
-        if (!is_endgame && p.has_castled<c>())
-            score += 16;
+        // Castling bonus
+        if (p.has_castled<c>())
+            score += (16 * mg) / material_entry::kPhaseMax;
 
         // Enemy pawn storm
-        if (!is_endgame) {
+        {
             auto pawnStormMask = bitboards::kpawnstorm[c][!(util::col(s) >= Col::E)];
             auto pawnStorm = pawnStormMask & enemyPawns;
             auto numAttackers = bits::count(pawnStorm);
+            int storm = 0;
             if (numAttackers >= 2) {
-                score -= 2;
+                storm -= 2;
                 if (numAttackers >= 3)
-                    score -= 2;
+                    storm -= 2;
             }
+            score += (storm * mg) / material_entry::kPhaseMax;
         }
     }
     return score;
@@ -876,7 +891,12 @@ template <Color c> int HCEEvaluator::eval_king(const position& p, einfo& ei) {
 
 template <Color c> int HCEEvaluator::eval_space(const position& p, einfo& ei) {
     int score = 0;
-    if (ei.me->is_endgame())
+    // Space is worth having because pieces need somewhere to go, so it fades
+    // as the pieces do. Returning zero the moment the material matched a
+    // classified ending made it worth full value right up to that boundary and
+    // nothing after it.
+    const int mg = ei.me->mg_weight();
+    if (mg == 0)
         return score;
 
     U64 spacemask =
@@ -895,7 +915,7 @@ template <Color c> int HCEEvaluator::eval_space(const position& p, einfo& ei) {
         space |= util::squares_behind(bitboards::col[util::col(s)], c, s);
     }
     score += bits::count(space);
-    return score;
+    return (score * mg) / material_entry::kPhaseMax;
 }
 
 // ─── eval_threats ───────────────────────────────────────────────────────────

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -84,6 +84,7 @@ std::vector<std::pair<std::string, int*>> parameters::all_params(TuneStage stage
         result.emplace_back("king_safety_category_scale", &king_safety_category_scale);
         result.emplace_back("threat_category_scale", &threat_category_scale);
         result.emplace_back("passed_pawn_category_scale", &passed_pawn_category_scale);
+        result.emplace_back("passed_pawn_endgame_scale", &passed_pawn_endgame_scale);
         result.emplace_back("pawn_structure_category_scale", &pawn_structure_category_scale);
         result.emplace_back("space_category_scale", &space_category_scale);
         result.emplace_back("king_danger_divisor", &king_danger_divisor);


### PR DESCRIPTION
is_endgame() was being used throughout the evaluation as if it were a
game-phase test. It is not: it means endgame != EndgameType::none, which
is only true when at most two non-pawn pieces remain on the entire
board. Measured over 89062 positions from random walks, it is true in
8.5% of them, and among positions with phase 16 or beyond -- real
endgames by any normal definition -- it is false 75.9% of the time.

Everything gated on it was therefore mis-scoped. The *_eg parameter
variants were selected almost never, so they were nearly unreachable
from the evaluation, which also means Texel tuning had essentially no
gradient on them.

Three commits:

  eval: blend the endgame parameter variants by phase, not by
  classification. bishop_own_pawn_penalty and trapped_rook_penalty now
  taper between their mg and eg values instead of switching on
  is_endgame().

  eval: fade king shelter, storm and space by phase instead of switching
  them off. King shelter, pawnless flank, the castling bonus, the pawn
  storm and space now scale by mg_weight() so they decay smoothly. The
  king PST gate was removed outright: square_score already tapers it, so
  the gate was tapering an already-tapered term.

  eval: taper the passed-pawn score by game phase. Passed pawns had no
  phase dependence at all -- a passer on the 7th was worth the same with
  queens on as in a bare king-and-pawn ending. Adds
  passed_pawn_endgame_scale, default 150. Measured over 49369 positions,
  the change is inert at phase 0 and grows monotonically to a mean of
  32 cp in endgames.

SPRT vs main at 10+0.1: 386 games, 146-103-137, +39 +/- 15 Elo.


---

**Commits**
```
c6d356c eval: blend the endgame parameter variants by phase, not by classification
f589be4 eval: fade king shelter, storm and space by phase instead of switching them off
d037d28 eval: taper the passed-pawn score by game phase
76f79c0 Merge fix/phase-interpolation: use game phase, not material classification
```

Stacked series, PR 05 of 16. Base: `pr/04-side-to-move-key`. Please review/merge in numeric order.
