### PR TITLE
Delete two attack tables with no readers

### DIFF
--- a/include/havoc/bitboard.hpp
+++ b/include/havoc/bitboard.hpp
@@ -85,9 +85,7 @@ extern U64 kflanks[8];
 /// Pawn storm detection masks [color][side].
 extern U64 kpawnstorm[2][2];
 /// King zone masks (extended king area for eval).
-extern U64 kzone[64];
 /// Check masks for each piece type from king square.
-extern U64 kchecks[5][64];
 /// Passed pawn detection masks [color][square].
 extern U64 passpawn_mask[2][64];
 /// Pawn majority region masks (queen/center/king-side).

--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -22,8 +22,6 @@ U64 pawnmaskleft[2];
 U64 pawnmaskright[2];
 U64 nmask[64];
 U64 kmask[64];
-U64 kchecks[5][64];
-U64 kzone[64];
 U64 kflanks[8];
 U64 rmask[64];
 U64 kpawnstorm[2][2];
@@ -86,10 +84,6 @@ void bitboards::init() {
         {},                                 // queen
         {-1, 1, 8, -8, -9, -7, 9, 7}        // king
     };
-
-    std::vector<int> zsteps = {-1,     1,      8,      -8,     -9,      -7,      9,       7,
-                               -2,     2,      -2 + 8, -2 - 8, 2 + 8,   2 - 8,   -2 - 16, -2 + 16,
-                               2 - 16, 2 + 16, -16,    16,     -16 - 1, -16 + 1, 16 + 1,  16 - 1};
 
     for (Square s = A1; s <= H8; ++s) {
         squares[s] = (1ULL << s);
@@ -203,16 +197,6 @@ void bitboards::init() {
         }
         kmask[s] = bm;
 
-        // King zone (for eval)
-        bm = 0ULL;
-        for (auto& step : zsteps) {
-            int to = s + step;
-            if (on_board(to) && col_dist(s, to) <= 2 && row_dist(s, to) <= 2) {
-                bm |= squares[to];
-            }
-        }
-        kzone[s] = bm;
-
         // Pawn attack masks for each color
         int pawn_steps[2][2] = {{9, 7}, {-7, -9}};
         for (Color c = white; c <= black; ++c) {
@@ -318,12 +302,6 @@ void bitboards::init() {
                squares[sq_col(s)] | squares[sq_col(s) + 56];
         bm ^= trim;
         rmask[s] = bm;
-
-        // King check masks
-        kchecks[knight][s] = nmask[s];
-        kchecks[bishop][s] = battks[s];
-        kchecks[rook][s] = rattks[s];
-        kchecks[queen][s] = battks[s] | rattks[s];
     }
 
     // King pawn storm detection


### PR DESCRIPTION
kzone[64] and kchecks[5][64] were both built at startup and never read.
No behaviour change; 98/98 tests pass.


---

**Commits**
```
c8bf59f bitboard: delete two attack tables that were built and never read
3c365bf Merge chore/dead-bitboard-tables: delete two attack tables with no readers
```

Stacked series, PR 06 of 16. Base: `pr/05-phase-interpolation`. Please review/merge in numeric order.
