### PR TITLE
Inert mobility phase parameter

### DIFF
--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -26,6 +26,12 @@ struct parameters {
     // All at 100 = original eval scale. Tune individual params directly.
     int sq_score_category_scale = 100;
     int mobility_category_scale = 100;
+    /// Endgame counterpart to mobility_category_scale. Mobility had no phase
+    /// dependence at all, so a mobile knight was worth the same with a full
+    /// board as with four pieces left. Unlike the passed-pawn taper the right
+    /// direction here is not obvious, so this defaults equal to the middlegame
+    /// endpoint: the change is inert until the tuner fits it.
+    int mobility_endgame_scale = 100;
     int king_safety_category_scale = 100;
     int threat_category_scale = 100;
     int passed_pawn_category_scale = 100;

--- a/src/eval/hce.cpp
+++ b/src/eval/hce.cpp
@@ -403,7 +403,7 @@ template <Color c> int HCEEvaluator::eval_knights(const position& p, einfo& ei) 
                           : params_.knight_mobility_table.back();
             score += ((params_.knight_mobility_scale * params_.mobility_scaling[knight] * mob) /
                       100) *
-                     params_.mobility_category_scale / 100;
+                     ei.me->taper(params_.mobility_category_scale, params_.mobility_endgame_scale) / 100;
         }
 
         // Outpost
@@ -501,7 +501,7 @@ template <Color c> int HCEEvaluator::eval_bishops(const position& p, einfo& ei) 
                           : params_.bishop_mobility_table.back();
         int mobility_score =
             ((params_.bishop_mobility_scale * params_.mobility_scaling[bishop] * mob_val) / 100) *
-            params_.mobility_category_scale / 100;
+            ei.me->taper(params_.mobility_category_scale, params_.mobility_endgame_scale) / 100;
         if ((sq_bb & p.pinned<c>()) && mobility_score > 0)
             mobility_score /= params_.pinned_scaling[bishop];
 
@@ -618,7 +618,7 @@ template <Color c> int HCEEvaluator::eval_rooks(const position& p, einfo& ei) {
                         : params_.rook_mobility_table.back();
         int mobility_score =
             ((params_.rook_mobility_scale * params_.mobility_scaling[rook] * mob_r) / 100) *
-            params_.mobility_category_scale / 100;
+            ei.me->taper(params_.mobility_category_scale, params_.mobility_endgame_scale) / 100;
 
         if (sq_bb & p.pinned<c>())
             mobility_score /= params_.pinned_scaling[rook];

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -81,6 +81,7 @@ std::vector<std::pair<std::string, int*>> parameters::all_params(TuneStage stage
         // to prevent the bias term from absorbing scale changes.
         result.emplace_back("sq_score_category_scale", &sq_score_category_scale);
         result.emplace_back("mobility_category_scale", &mobility_category_scale);
+        result.emplace_back("mobility_endgame_scale", &mobility_endgame_scale);
         result.emplace_back("king_safety_category_scale", &king_safety_category_scale);
         result.emplace_back("threat_category_scale", &threat_category_scale);
         result.emplace_back("passed_pawn_category_scale", &passed_pawn_category_scale);


### PR DESCRIPTION
taper(x, x) == x exactly, so the default endgame endpoint reproduces
previous behaviour bit-for-bit. Verified identical best moves at depth 9
across four positions. No SPRT required.

---

**Commits**
```
22b592c eval: give mobility a game-phase knob for the tuner
1da017a Merge eval/mobility-phase-knob: inert mobility phase parameter
```

Stacked series, PR 09 of 16. Base: `pr/08-zobrist-entropy`. Please review/merge in numeric order.
