### PR TITLE
Tunable pawn structure, inert defaults

### DIFF
--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -149,12 +149,18 @@ struct parameters {
     /// middlegame and endgame accumulators. A pawn weakness is worth far more
     /// in an endgame, where it cannot be covered by pieces and becomes a
     /// fixed target, so the endgame endpoints default higher.
+    // Endgame endpoints deliberately equal the middlegame ones, which makes
+    // the split exactly inert: sub(v, v) is the old operator-=(v) bit for bit.
+    // Raising them (doubled 4->12, isolated 4->12, backward 1->3) was measured
+    // at -85 +/- 35 Elo over 274 games, LLR -2.96, H0 accepted. The parameters
+    // exist so Texel can fit the endgame endpoints from data; guessing them by
+    // hand is what failed.
     int doubled_pawn_penalty_mg = 4;
-    int doubled_pawn_penalty_eg = 12;
+    int doubled_pawn_penalty_eg = 4;
     int backward_pawn_penalty_mg = 1;
-    int backward_pawn_penalty_eg = 3;
+    int backward_pawn_penalty_eg = 1;
     int isolated_pawn_penalty_mg = 4;
-    int isolated_pawn_penalty_eg = 12;
+    int isolated_pawn_penalty_eg = 4;
     static constexpr int semi_open_pawn_penalty = 1;
 
     // Material values

--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -155,7 +155,6 @@ struct parameters {
     int backward_pawn_penalty_eg = 3;
     int isolated_pawn_penalty_mg = 4;
     int isolated_pawn_penalty_eg = 12;
-    static constexpr int passed_pawn_bonus = 2;
     static constexpr int semi_open_pawn_penalty = 1;
 
     // Material values
@@ -168,7 +167,12 @@ struct parameters {
     int wrong_rook_pawn_scale = 0;
 
     // Passed pawn rank bonuses
-    std::array<int, 4> passed_pawn_rank_bonus = {0, 45, 90, 180};
+    /// Passed-pawn bonus by distance to promotion, indexed [4 - row_dist],
+    /// so entry 0 is a passer still four or more ranks away and entry 3 is one
+    /// step from queening. These values were hard-coded inside
+    /// eval_passed_pawns while this array sat registered with the tuner and
+    /// read by nothing.
+    std::array<int, 4> passed_pawn_rank_bonus = {2, 45, 90, 180};
 
     // Search
     int fixed_depth = -1;

--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -142,9 +142,19 @@ struct parameters {
     static constexpr int rook_7th_bonus = 2;
 
     // Pawn structure
-    static constexpr int doubled_pawn_penalty = 4;
-    static constexpr int backward_pawn_penalty = 1;
-    static constexpr int isolated_pawn_penalty = 4;
+    /// Pawn-structure penalties, split by game phase.
+    ///
+    /// These used to be static constexpr, so they were invisible to the
+    /// tuner, and pawn_score applied every penalty identically to the
+    /// middlegame and endgame accumulators. A pawn weakness is worth far more
+    /// in an endgame, where it cannot be covered by pieces and becomes a
+    /// fixed target, so the endgame endpoints default higher.
+    int doubled_pawn_penalty_mg = 4;
+    int doubled_pawn_penalty_eg = 12;
+    int backward_pawn_penalty_mg = 1;
+    int backward_pawn_penalty_eg = 3;
+    int isolated_pawn_penalty_mg = 4;
+    int isolated_pawn_penalty_eg = 12;
     static constexpr int passed_pawn_bonus = 2;
     static constexpr int semi_open_pawn_penalty = 1;
 

--- a/src/eval/hce.cpp
+++ b/src/eval/hce.cpp
@@ -1083,7 +1083,7 @@ template <Color c> int HCEEvaluator::eval_passed_pawns(const position& p, einfo&
         int row_dist = (c == white ? 7 - util::row(f) : util::row(f));
 
         if (row_dist > 3 || row_dist <= 0) {
-            score += parameters::passed_pawn_bonus;
+            score += params_.passed_pawn_rank_bonus[0];
             continue;
         }
 
@@ -1138,7 +1138,7 @@ template <Color c> int HCEEvaluator::eval_passed_pawns(const position& p, einfo&
             score += 30;
 
         // 5. Closer to promotion
-        score += (row_dist == 3 ? 45 : row_dist == 2 ? 90 : row_dist == 1 ? 180 : 0);
+        score += params_.passed_pawn_rank_bonus[4 - row_dist];
 
         if (crudeControl < 0)
             score -= (row_dist == 3 ? 30 : row_dist == 2 ? 55 : row_dist == 1 ? 120 : 0);

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -86,6 +86,12 @@ std::vector<std::pair<std::string, int*>> parameters::all_params(TuneStage stage
         result.emplace_back("passed_pawn_category_scale", &passed_pawn_category_scale);
         result.emplace_back("passed_pawn_endgame_scale", &passed_pawn_endgame_scale);
         result.emplace_back("pawn_structure_category_scale", &pawn_structure_category_scale);
+        result.emplace_back("doubled_pawn_penalty_mg", &doubled_pawn_penalty_mg);
+        result.emplace_back("doubled_pawn_penalty_eg", &doubled_pawn_penalty_eg);
+        result.emplace_back("backward_pawn_penalty_mg", &backward_pawn_penalty_mg);
+        result.emplace_back("backward_pawn_penalty_eg", &backward_pawn_penalty_eg);
+        result.emplace_back("isolated_pawn_penalty_mg", &isolated_pawn_penalty_mg);
+        result.emplace_back("isolated_pawn_penalty_eg", &isolated_pawn_penalty_eg);
         result.emplace_back("space_category_scale", &space_category_scale);
         result.emplace_back("king_danger_divisor", &king_danger_divisor);
         return result;

--- a/src/pawn_table.cpp
+++ b/src/pawn_table.cpp
@@ -96,6 +96,11 @@ struct pawn_score {
         mg = static_cast<int16_t>(mg - v);
         eg = static_cast<int16_t>(eg - v);
     }
+    /// Subtract a penalty that differs between the middlegame and the endgame.
+    void sub(int v_mg, int v_eg) {
+        mg = static_cast<int16_t>(mg - v_mg);
+        eg = static_cast<int16_t>(eg - v_eg);
+    }
 };
 
 template <Color c> pawn_score evaluate_pawns(const position& p, pawn_entry& e, const parameters& par) {
@@ -146,14 +151,14 @@ template <Color c> pawn_score evaluate_pawns(const position& p, pawn_entry& e, c
         U64 neighbors_bb = bitboards::neighbor_cols[col_idx] & pawns;
         if (neighbors_bb == 0ULL) {
             e.isolated[c] |= fbb;
-            score -= par.isolated_pawn_penalty;
+            score.sub(par.isolated_pawn_penalty_mg, par.isolated_pawn_penalty_eg);
             e.weak_squares[c] |= front;
         }
 
         // Backward pawns
         if (backward_pawn<c>(row, col_idx, pawns)) {
             e.backward[c] |= fbb;
-            score -= par.backward_pawn_penalty;
+            score.sub(par.backward_pawn_penalty_mg, par.backward_pawn_penalty_eg);
             e.weak_squares[c] |= front;
         }
 
@@ -168,9 +173,9 @@ template <Color c> pawn_score evaluate_pawns(const position& p, pawn_entry& e, c
         if (bits::more_than_one(doubled)) {
             e.doubled[c] |= doubled;
             if (e.isolated[c] & doubled)
-                score -= static_cast<int16_t>(2 * par.doubled_pawn_penalty);
+                score.sub(2 * par.doubled_pawn_penalty_mg, 2 * par.doubled_pawn_penalty_eg);
             else
-                score -= par.doubled_pawn_penalty;
+                score.sub(par.doubled_pawn_penalty_mg, par.doubled_pawn_penalty_eg);
         }
 
         // Semi-open files
@@ -178,11 +183,11 @@ template <Color c> pawn_score evaluate_pawns(const position& p, pawn_entry& e, c
         if ((column & epawns) == 0ULL) {
             e.semiopen[c] |= fbb;
             if (fbb & e.backward[c])
-                score -= static_cast<int16_t>(2 * par.backward_pawn_penalty);
+                score.sub(2 * par.backward_pawn_penalty_mg, 2 * par.backward_pawn_penalty_eg);
             if (fbb & e.isolated[c])
-                score -= static_cast<int16_t>(2 * par.isolated_pawn_penalty);
+                score.sub(2 * par.isolated_pawn_penalty_mg, 2 * par.isolated_pawn_penalty_eg);
             if (fbb & e.doubled[c])
-                score -= static_cast<int16_t>(2 * par.doubled_pawn_penalty);
+                score.sub(2 * par.doubled_pawn_penalty_mg, 2 * par.doubled_pawn_penalty_eg);
             e.weak_squares[c] |= front;
         }
 

--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -970,6 +970,9 @@ TEST_F(EvalTest, EveryTunableParameterReachesTheEvaluation) {
         // The same weakness with a full board, so the middlegame endpoint of
         // the doubled-pawn penalty is exercised and not just the endgame one.
         "r1bqkbnr/pp1ppppp/2n5/8/8/2P5/PPP2PPP/RNBQKBNR w KQkq - 0 1",
+        // A passer two ranks from promotion, which is the one rung of the
+        // passed_pawn_rank_bonus ladder the rest of the set never reaches.
+        "6k1/pp6/4P3/8/8/8/5PPP/6K1 w - - 0 1",
     };
 
     // The pawn and material caches are keyed on structure, not on parameter
@@ -1059,12 +1062,10 @@ TEST_F(EvalTest, EveryTunableParameterReachesTheEvaluation) {
         "material_value_0", "material_value_5",
         // (b) genuinely dead: declared, tuned and saved, but read by nothing.
         // attacker_weight_0 is the pawn entry of the king-danger sum, whose
-        // loop starts at knight. passed_pawn_rank_bonus and uncastled_penalty
-        // are features that were never implemented -- eval_passed_pawns uses
-        // its own hard-coded constants and eval_king has a hard-coded castling
-        // bonus with no matching penalty.
-        "attacker_weight_0", "passed_pawn_rank_bonus_0", "passed_pawn_rank_bonus_1",
-        "passed_pawn_rank_bonus_2", "passed_pawn_rank_bonus_3", "uncastled_penalty",
+        // loop starts at knight. uncastled_penalty is a feature that was never
+        // implemented -- eval_king has a hard-coded castling bonus with no
+        // matching penalty.
+        "attacker_weight_0", "uncastled_penalty",
     };
 
     std::vector<std::string> unexpected;

--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -960,6 +960,16 @@ TEST_F(EvalTest, EveryTunableParameterReachesTheEvaluation) {
         "8/3k4/8/8/3P4/3K4/8/8 w - - 0 1",
         "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1",
         "6k1/5ppp/8/8/8/8/1P6/1K6 w - - 0 1",
+        // Doubled pawns, asymmetric so the two sides cannot cancel: white has
+        // a doubled c-file, black does not. Without this the corpus never
+        // reaches the doubled-pawn penalty at all.
+        "6k1/pp3ppp/8/8/8/2P5/PPP2PPP/6K1 w - - 0 1",
+        // Doubled and isolated together, which takes the other branch of the
+        // doubled-pawn test, plus a tripled file.
+        "6k1/1p3pp1/8/8/2P5/2P5/2P2PP1/6K1 w - - 0 1",
+        // The same weakness with a full board, so the middlegame endpoint of
+        // the doubled-pawn penalty is exercised and not just the endgame one.
+        "r1bqkbnr/pp1ppppp/2n5/8/8/2P5/PPP2PPP/RNBQKBNR w KQkq - 0 1",
     };
 
     // The pawn and material caches are keyed on structure, not on parameter


### PR DESCRIPTION
Three static constexpr pawn penalties become six registered mg/eg
parameters, and passed_pawn_rank_bonus -- registered with the tuner and
read by nothing -- is wired into eval_passed_pawns. Both are exactly
inert at their defaults; the guessed endgame endpoints that were not
inert measured -85 +/- 35 Elo and have been reverted to the middlegame
values. Verified identical best moves at depth 10 over five positions.

---

**Commits**
```
5e49cb4 eval: give the pawn-structure penalties a middlegame and endgame value
1467192 eval: wire up the passed-pawn rank bonus the tuner was already tuning
5dc6eb1 eval: default the pawn-structure endgame endpoints to their middlegame values
d6ac990 Merge fix/pawn-structure-phase: tunable pawn structure, inert defaults
```

Stacked series, PR 10 of 16. Base: `pr/09-mobility-phase-knob`. Please review/merge in numeric order.
