### PR TITLE
Nine passed-pawn literals become parameters

### DIFF
--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -186,6 +186,20 @@ struct parameters {
     /// read by nothing.
     std::array<int, 4> passed_pawn_rank_bonus = {2, 45, 90, 180};
 
+    /// The rest of eval_passed_pawns, which carried these as bare literals.
+    /// A passed pawn is the single most decisive structural feature on the
+    /// board, and every term below the rank ladder was fixed at a number
+    /// nobody could fit. Defaults reproduce the previous literals exactly.
+    int passed_pawn_unblocked = 1;      ///< square in front is empty
+    int passed_pawn_control = 3;        ///< per attacker of the square in front, each side
+    int passed_pawn_rook_behind = 1;    ///< own rook anywhere behind on the file
+    int passed_pawn_rook_support = 30;  ///< own rook behind with a clear path
+    int passed_pawn_connected = 30;     ///< another passer on a neighbouring file
+    /// Penalty when the square in front is controlled by the opponent, by
+    /// distance to promotion, indexed [3 - row_dist]: entry 0 is three ranks
+    /// out and entry 2 is one step from queening.
+    std::array<int, 3> passed_pawn_blocked_penalty = {30, 55, 120};
+
     // Search
     int fixed_depth = -1;
 

--- a/src/eval/hce.cpp
+++ b/src/eval/hce.cpp
@@ -1091,7 +1091,7 @@ template <Color c> int HCEEvaluator::eval_passed_pawns(const position& p, einfo&
 
         // 1. Is next square blocked?
         if (p.piece_on(front) == no_piece)
-            score += 1;
+            score += params_.passed_pawn_unblocked;
 
         // 2. Control of front square
         U64 our_attackers = 0ULL;
@@ -1105,11 +1105,11 @@ template <Color c> int HCEEvaluator::eval_passed_pawns(const position& p, einfo&
 
         if (our_attackers != 0ULL) {
             crudeControl += bits::count(our_attackers);
-            score += 3 * bits::count(our_attackers);
+            score += params_.passed_pawn_control * bits::count(our_attackers);
         }
         if (their_attackers != 0ULL) {
             crudeControl -= bits::count(their_attackers);
-            score -= 3 * bits::count(their_attackers);
+            score -= params_.passed_pawn_control * bits::count(their_attackers);
         }
 
         // 3. Rooks behind passed pawns
@@ -1123,10 +1123,10 @@ template <Color c> int HCEEvaluator::eval_passed_pawns(const position& p, einfo&
                     auto supports = ((bitboards::between[rf][f] & p.all_pieces()) ^
                                      (bitboards::squares[rf] | bitboards::squares[f])) == 0ULL;
                     if (isBehind)
-                        score += 1;
+                        score += params_.passed_pawn_rook_behind;
                     if (isBehind && supports) {
                         crudeControl += 1;
-                        score += 30;
+                        score += params_.passed_pawn_rook_support;
                     }
                 }
             }
@@ -1135,13 +1135,13 @@ template <Color c> int HCEEvaluator::eval_passed_pawns(const position& p, einfo&
         // 4. Connected passers
         auto connectedPassed = (bitboards::neighbor_cols[util::col(f)] & ei.pe->passed[c]) != 0ULL;
         if (connectedPassed)
-            score += 30;
+            score += params_.passed_pawn_connected;
 
         // 5. Closer to promotion
         score += params_.passed_pawn_rank_bonus[4 - row_dist];
 
         if (crudeControl < 0)
-            score -= (row_dist == 3 ? 30 : row_dist == 2 ? 55 : row_dist == 1 ? 120 : 0);
+            score -= params_.passed_pawn_blocked_penalty[3 - row_dist];
     }
     return score;
 }

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -130,6 +130,15 @@ std::vector<std::pair<std::string, int*>> parameters::all_params(TuneStage stage
             result.emplace_back("passed_pawn_rank_bonus_" + std::to_string(i),
                                 &passed_pawn_rank_bonus[i]);
 
+        result.emplace_back("passed_pawn_unblocked", &passed_pawn_unblocked);
+        result.emplace_back("passed_pawn_control", &passed_pawn_control);
+        result.emplace_back("passed_pawn_rook_behind", &passed_pawn_rook_behind);
+        result.emplace_back("passed_pawn_rook_support", &passed_pawn_rook_support);
+        result.emplace_back("passed_pawn_connected", &passed_pawn_connected);
+        for (size_t i = 0; i < passed_pawn_blocked_penalty.size(); ++i)
+            result.emplace_back("passed_pawn_blocked_penalty_" + std::to_string(i),
+                                &passed_pawn_blocked_penalty[i]);
+
         // Attacker weights
         for (size_t i = 0; i < attacker_weight.size(); ++i)
             result.emplace_back("attacker_weight_" + std::to_string(i), &attacker_weight[i]);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -403,6 +403,20 @@ void SearchEngine::iterative_deepening(position& p, U16 depth, bool silent, int 
             sel_depth_ = 0;
             eval = search<root>(p, alpha, beta, static_cast<U16>(id), stack + 2, thread_id);
 
+            // The sort deliberately runs before the stop check, so an
+            // aborted iteration still reorders the root list and can change
+            // the move that is played. That looks unsafe -- it compares this
+            // iteration's scores against the previous iteration's for the
+            // moves time ran out on -- but it is not reachable in practice.
+            // Only root moves that raise alpha are given a real score; every
+            // other move is set to kNegInf, so after a completed iteration
+            // the list is one scored move followed by a run of kNegInf and a
+            // partial iteration has nothing to promote. Measured over 59
+            // aborted iterations (12 bench positions x 5 time budgets from
+            // 150 ms to 900 ms): the abort changed root_moves[0] zero times.
+            // Left alone; if root scoring ever changes so that several moves
+            // keep real scores, this becomes live and needs the stop check
+            // moved above the sort.
             std::stable_sort(p.root_moves.begin(), p.root_moves.end());
 
             if (signals_.stop.load())

--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -973,6 +973,19 @@ TEST_F(EvalTest, EveryTunableParameterReachesTheEvaluation) {
         // A passer two ranks from promotion, which is the one rung of the
         // passed_pawn_rank_bonus ladder the rest of the set never reaches.
         "6k1/pp6/4P3/8/8/8/5PPP/6K1 w - - 0 1",
+        // A rook behind its own passer with a clear path to it. This is the
+        // only shape that reaches passed_pawn_rook_behind and, because a1-a5
+        // is empty, passed_pawn_rook_support as well. Enough material is left
+        // on that is_endgame() stays false, otherwise the endgame
+        // specialisation returns before eval_passed_pawns runs at all.
+        "r3k2r/4bppp/8/P7/8/8/1PP2PPP/R3K2R w KQkq - 0 1",
+        // The same passer with no rook behind it and a black rook bearing on
+        // the square in front, so crudeControl goes negative and the blocked
+        // penalty fires. Three positions, one per rung of the ladder: the
+        // pawn is three, two and one rank from promotion.
+        "r3k2r/4bppp/8/P7/8/8/1PP2PPP/4K2R w Kkq - 0 1",
+        "r3k2r/4bppp/P7/8/8/8/1PP2PPP/4K2R w Kkq - 0 1",
+        "1r2k2r/P3bppp/8/8/8/8/1PP2PPP/4K2R w Kk - 0 1",
     };
 
     // The pawn and material caches are keyed on structure, not on parameter


### PR DESCRIPTION
Everything in eval_passed_pawns below the rank ladder was a bare literal
and unreachable by the tuner. Nine registered parameters replace them at
their existing values. Proven inert: bench 9 gives 416136 nodes before
and after, bit for bit. Four positions added to the reachability corpus,
which correctly reported five of the nine as unreached -- all five were
holes in the position set rather than dead code.

---

**Commits**
```
cc1458a search: document why sorting root moves on an aborted iteration is safe
779aeb3 eval: make the rest of eval_passed_pawns tunable
b18065d Merge eval/passed-pawn-tunables: nine passed-pawn literals become parameters
```

Stacked series, PR 11 of 16. Base: `pr/10-pawn-structure-phase`. Please review/merge in numeric order.
