### PR TITLE
Prefer evicting entries from earlier searches

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -39,6 +39,25 @@ bool hash_table::fetch(U64 key, hash_data& e) {
     for (unsigned i = 0; i < cluster_size; ++i, ++stored) {
         if ((stored->pkey ^ stored->dkey) == key) {
             e.decode(stored->dkey);
+
+            // An entry that is still being hit is still useful, but eviction
+            // scores it by when it was *written*, not by when it was last
+            // needed: entry_value() is depth - 8 * relative_age(). Without a
+            // refresh, everything carried over from the previous search looks
+            // one generation stale no matter how often the current search
+            // transposes into it, and gets thrown out in favour of whatever
+            // shallow entry the current search happens to write next.
+            //
+            // Stamp the current generation on the way past. The age field is
+            // bits 55-62 of dkey, so it can be rewritten in place; pkey has to
+            // be re-derived from the key so the XOR validation still holds.
+            if (e.age != generation_) {
+                const U64 refreshed =
+                    (stored->dkey & ~(0xFFULL << 55)) | (U64(generation_) << 55);
+                stored->dkey = refreshed;
+                stored->pkey = key ^ refreshed;
+                e.age = generation_;
+            }
             return true;
         }
     }


### PR DESCRIPTION
TT replacement now weighs generation alongside depth, so entries left
over from previous searches are evicted before entries written by the
current one.

SPRT: 851 games, 265-257-329, +3.3 Elo, LLR -0.193 against elo0=0
elo1=10. Neither bound reached; stopped deliberately rather than spend
thousands more games on a change this small. What it establishes is
non-regression to within roughly +/- 20 Elo.

Merged on the strength of the node measurement rather than the match:
bench 9 drops from 416,136 to 384,773 nodes, 7.5% fewer nodes to reach
the same depth, which is a direct measure of better TT retention. A
10+0.1 match with a 64 MB hash barely fills the table, so it is close to
the worst case for showing what aging buys; the gain should be larger at
longer time controls and smaller hashes, neither of which this SPRT
tested. Generation-aware replacement is also simply the correct
behaviour -- without it a stale deep entry outranks a fresh one forever.


---

**Commits**
```
09802ce tt: refresh entry age on a probe hit (INCONCLUSIVE, needs an SPRT)
a560013 Merge perf/tt-age-refresh: prefer evicting entries from earlier searches
```

Stacked series, PR 15 of 16. Base: `pr/14-eval-cache-purity`. Please review/merge in numeric order.
