### PR TITLE
The evaluation must be a function of the position

### DIFF
--- a/include/havoc/position.hpp
+++ b/include/havoc/position.hpp
@@ -31,7 +31,6 @@ struct info {
     Color stm = white;
     Square eps = no_square;
     Square ks[2] = {no_square, no_square};
-    bool has_castled[2] = {};
     Piece captured = no_piece;
     bool incheck = false;
 };
@@ -158,7 +157,6 @@ class position {
     template <Color c> [[nodiscard]] inline bool can_castle() const {
         return can_castle_ks<c>() || can_castle_qs<c>();
     }
-    template <Color c> [[nodiscard]] inline bool has_castled() const { return ifo.has_castled[c]; }
     template <Color c> [[nodiscard]] inline U64 pinned() const { return ifo.pinned[c]; }
 
     [[nodiscard]] inline bool pawns_near_promotion() const {

--- a/src/eval/hce.cpp
+++ b/src/eval/hce.cpp
@@ -632,8 +632,6 @@ template <Color c> int HCEEvaluator::eval_rooks(const position& p, einfo& ei) {
         // switching off.
         if (trapped_rook<c>(p, ei, s)) {
             score -= ei.me->taper(params_.trapped_rook_penalty[0], params_.trapped_rook_penalty[1]);
-            if (!p.has_castled<c>())
-                score -= (2 * ei.me->mg_weight()) / material_entry::kPhaseMax;
         }
 
         // Center influence
@@ -868,9 +866,7 @@ template <Color c> int HCEEvaluator::eval_king(const position& p, einfo& ei) {
             score += (shelter * mg) / material_entry::kPhaseMax;
         }
 
-        // Castling bonus
-        if (p.has_castled<c>())
-            score += (16 * mg) / material_entry::kPhaseMax;
+
 
         // Enemy pawn storm
         {

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -269,11 +269,9 @@ void position::do_move(const Move& m) {
     } else if (t == castle_ks) {
         pcs.do_castle_ks(us, from, to, ifo);
         ifo.cmask &= (us == white ? clearw : clearb);
-        ifo.has_castled[us] = true;
     } else if (t == castle_qs) {
         pcs.do_castle_qs(us, from, to, ifo);
         ifo.cmask &= (us == white ? clearw : clearb);
-        ifo.has_castled[us] = true;
     }
 
     if (ifo.cmask != old_cmask) {

--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -10,6 +10,7 @@
 #include "havoc/position.hpp"
 #include "havoc/tablebase.hpp"
 #include "havoc/tt.hpp"
+#include "havoc/uci.hpp"
 #include "havoc/zobrist.hpp"
 
 #include <algorithm>
@@ -102,6 +103,65 @@ TEST_F(EvalTest, StartposIsApproximatelyZero) {
     int score = eval.evaluate(pos);
     EXPECT_GE(score, -50) << "Startpos eval too low: " << score;
     EXPECT_LE(score, 50) << "Startpos eval too high: " << score;
+}
+
+// ─── Evaluation must be a function of the position ─────────────────────────
+
+// has_castled is set only by do_move when a castling move is played, and is
+// never derived from a FEN. It is not part of the zobrist key either. So the
+// same position, with the same key, evaluates differently depending on how it
+// was reached -- and the transposition table, which is keyed on that key,
+// hands one path's score to the other.
+//
+// This walks a king and rook from e1/h1 to g1/f1 the long way round, which
+// reaches exactly the position kingside castling reaches, and compares it
+// against the castled path.
+TEST_F(EvalTest, EvaluationDoesNotDependOnHowThePositionWasReached) {
+    havoc::parameters params;
+    havoc::pawn_table pt(params);
+    havoc::material_table mt(params);
+    havoc::HCEEvaluator eval(pt, mt, params);
+
+    auto play = [](havoc::position& pos, const std::string& uci) {
+        havoc::Movegen mvs(pos);
+        mvs.generate<havoc::pseudo_legal, havoc::pieces>();
+        for (int i = 0; i < mvs.size(); ++i) {
+            if (!pos.is_legal(mvs[i]))
+                continue;
+            if (havoc::uci::move_to_string(mvs[i]) == uci) {
+                pos.do_move(mvs[i]);
+                return true;
+            }
+        }
+        return false;
+    };
+
+    // Enough material on both sides that is_endgame() stays false, otherwise
+    // the endgame specialisation can return before the castling terms run.
+    // f2, g2 and d7 are empty so both kings have a route off their back rank.
+    const std::string start = "r3k1n1/ppp1pppp/8/8/8/8/PPPPP2P/4K2R w K - 0 1";
+
+    // Path A: castle kingside. King e1 -> g1, rook h1 -> f1.
+    auto a = make_pos(start);
+    ASSERT_TRUE(play(a, "e1g1"));
+
+    // Path B: the same placement, walked there. The rook has to go first,
+    // because once the king stands on g1 the rook can no longer cross it, and
+    // the king then has to detour over f2 and g2 for the same reason. Black
+    // shuffles on a three-move cycle so that it is Black to move at the end of
+    // both paths with its king back on e8.
+    auto b = make_pos(start);
+    for (const char* mv : {"h1f1", "e8d8", "e1f2", "d8d7", "f2g2", "d7e8", "g2g1"})
+        ASSERT_TRUE(play(b, mv)) << "could not play " << mv;
+
+    ASSERT_EQ(a.key(), b.key())
+        << "the two paths must reach the same position for this test to mean anything";
+    ASSERT_EQ(a.to_move(), b.to_move());
+
+    EXPECT_EQ(eval.evaluate(a), eval.evaluate(b))
+        << "the same position evaluates differently depending on the move order "
+           "that reached it. Both share a zobrist key, so the transposition "
+           "table will serve one of these scores for the other.";
 }
 
 // ─── Extra queen → large advantage ─────────────────────────────────────────


### PR DESCRIPTION
has_castled[] was carried in the position's info struct and read by two
evaluation terms: a +16cp middlegame castling bonus in eval_king, and an
extra trapped-rook penalty in eval_rooks. It is not part of the position.
Two identical positions -- same pieces, same side to move, same castling
rights, same en passant square, therefore the same zobrist key and the
same material key -- evaluate differently depending on whether the route
that reached them happened to include a castling move.

That is the defect class that has cost this engine the most, and this is
the eighth instance of it: material key, side to move, en passant,
castling rights, castling rights on rook capture, the pawn-hash king mask,
this, and the delta-pruning fail-hard return. Every one of them poisons a
cache that is keyed on the position while holding a value that is not a
function of the position, so the transposition table and the eval cache
hand back answers computed for a different question.

SPRT vs main: 1935 games, 584-620-731, -6.5 +/- 12.2 Elo, LOS 15.0%,
LLR -2.95, H0 accepted.

That is our largest sample to date and the interval comfortably contains
zero -- about one standard error below it. Merging on must-fix plus
non-regression.

The point deserves recording honestly: the terms that were removed were
doing real work, and deleting them is what the *fix* costs. Roughly 16 cp
of middlegame king-placement signal is now simply gone. Recovering it is
a separate matter and belongs in a separate commit, because it is not a
bug fix -- it is a new evaluation term. The pure way to say what
has_castled was groping at is a function of the king square and the
castling rights, both of which really are part of the position.


---

**Commits**
```
42f4dae fix: make the evaluation a function of the position
efc3f24 Merge fix/eval-position-purity: the evaluation must be a function of the position
```

Stacked series, PR 16 of 16. Base: `pr/15-tt-age-refresh`. Please review/merge in numeric order.
