### PR TITLE
fix: delta pruning returned the window instead of the score

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1054,12 +1054,28 @@ int SearchEngine::qsearch(position& p, int alpha, int beta, U16 depth, SearchNod
         if (best_score >= beta)
             return best_score;
 
-        // Delta pruning
+        // Delta pruning.
+        //
+        // This returned `alpha`, which is a fail-hard return inside a fail-soft
+        // search. Two things are wrong with that. It throws away what the node
+        // actually knows -- best_score is below alpha - deltaCut, so it is a
+        // strictly tighter and equally valid upper bound than alpha is. And it
+        // makes the value a function of the window the node happened to be
+        // searched with rather than of the position, so the same position
+        // reached with a different window, or with a different move ordering
+        // ahead of it, returns a different number.
+        //
+        // That second part is measurable: with an exact evaluation underneath
+        // it, QuiescenceIsMirrorSymmetricOverRandomPlay finds a position and its
+        // mirror scoring -18 and -19 at depth 1. Returning best_score makes all
+        // 189 sampled positions symmetric again. The asymmetry is only hidden
+        // today because the lazy evaluation cutoff above usually returns before
+        // the difference can show.
         int deltaCut = 910;
         if (anyPawnsOn7th)
             deltaCut += 775;
         if (best_score < alpha - deltaCut)
-            return alpha;
+            return best_score;
 
         if (pv_type && alpha < best_score)
             alpha = best_score;


### PR DESCRIPTION
Quiescence delta pruning ended with `return alpha`, a fail-hard return in
an otherwise fail-soft search. Two things are wrong with it.

It discards what the node already knows. The branch is only taken when
best_score < alpha - deltaCut, so best_score is a strictly tighter upper
bound on the node's value than alpha is, and equally valid. Returning
alpha hands the parent a weaker bound than the one in hand.

More seriously, it makes the returned value a function of the window the
node happened to be searched with rather than of the position. The same
position reached under a different window, or after a different move
ordering shifted alpha, returns a different number. That is the same
defect as has_castled: something that is not part of the position leaking
into a value that is supposed to describe it.

Proven by measurement. With an exact evaluation underneath it -- lazy
evaluation removed so nothing masks the difference --
QuiescenceIsMirrorSymmetricOverRandomPlay finds a position and its mirror
scoring -18 and -19 at depth 1, and the static evaluations of that pair
are identical at -42, so the asymmetry is entirely in the search.
Returning best_score makes all 189 sampled positions symmetric again.

The defect is present today and merely hidden: the lazy cutoff above
usually returns before delta pruning can be reached, which is why the
existing suite passes either way. Full suite 120/120 with this change.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>



---

**SPRT (whole stack vs previous main, 10+0.1)**: 685 games, 205-208-272, **-1.5 +/- 23 Elo** -- dead level, non-regression established. Stopped deliberately rather than spend thousands more games separating changes that are correctness fixes regardless of Elo.

`bench 11` = 1,651,340 nodes, bit-identical to the build that was tested. Test suite 124/124.

Stacked series, PR 1 of 6.
