### PR TITLE
fix: three defects in the aspiration window

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -347,9 +347,15 @@ double SearchEngine::estimate_max_time(position& p) const {
 void SearchEngine::iterative_deepening(position& p, U16 depth, bool silent, int thread_id) {
     int alpha = score::kNegInf;
     int beta = score::kInf;
-    int delta = 65;
+    const int baseDelta = 65;
+    int delta = baseDelta;
     int smallDelta = 33;
     int eval = score::kNegInf;
+    // The score of the last *completed* iteration. The aspiration window has to
+    // be anchored on this and not on `eval`, because between the two `eval`
+    // holds the value a failed search returned, and that is a bound, not an
+    // estimate of the score.
+    int last_completed = score::kNegInf;
 
     if (params_.fixed_depth > 0)
         depth = static_cast<U16>(params_.fixed_depth);
@@ -382,24 +388,29 @@ void SearchEngine::iterative_deepening(position& p, U16 depth, bool silent, int 
         for (auto& rm : p.root_moves)
             rm.prevScore = rm.score;
 
-        bool failLow = false;
-        bool failHigh = false;
+        // Reset the widening step for every iteration. This was declared once
+        // outside the loop, so a depth that needed several re-searches left
+        // `delta` permanently enlarged for every depth that followed. Measured
+        // over bench 12 (144 iterations): mean delta at iteration start 91.3
+        // against a base of 65, peaking at 306.
+        delta = baseDelta;
+
+        // Only aspirate once a completed iteration has produced a score to
+        // aspirate around. The old guard was `id >= 2`, which is true on the
+        // *first* iteration of every helper thread, since thread n starts at
+        // depth n + 1. Those threads then built their window out of the initial
+        // eval of -inf and searched [-inf, -inf + 33], which fails high on
+        // essentially any position.
+        if (last_completed != score::kNegInf) {
+            alpha = std::max(last_completed - smallDelta, static_cast<int>(score::kNegInf));
+            beta = std::min(last_completed + smallDelta, static_cast<int>(score::kInf));
+        } else {
+            alpha = score::kNegInf;
+            beta = score::kInf;
+        }
 
         // Aspiration window search
         while (true) {
-            if (id >= 2) {
-                alpha = std::max(eval - smallDelta, static_cast<int>(score::kNegInf));
-                beta = std::min(eval + smallDelta, static_cast<int>(score::kInf));
-                if (failLow) {
-                    beta = std::min(beta + delta, static_cast<int>(score::kInf));
-                    failLow = false;
-                }
-                if (failHigh) {
-                    alpha = std::max(alpha - delta, static_cast<int>(score::kNegInf));
-                    failHigh = false;
-                }
-            }
-
             sel_depth_ = 0;
             eval = search<root>(p, alpha, beta, static_cast<U16>(id), stack + 2, thread_id);
 
@@ -425,19 +436,31 @@ void SearchEngine::iterative_deepening(position& p, U16 depth, bool silent, int 
             if (is_main && !silent && (eval <= alpha || eval >= beta))
                 readout_pv(stack, p.root_moves, eval, alpha, beta, static_cast<U16>(id));
 
+            // Widen only the bound that actually failed, and leave the other
+            // one where it is. The old code recomputed *both* bounds from
+            // `eval` on every re-search, which re-centred the window on the
+            // score of the search that had just failed. On a fail low that
+            // score is only an upper bound and under fail-soft it can sit far
+            // below alpha, so beta was dragged down with it -- sometimes below
+            // the alpha we had just failed under -- and the re-search then
+            // failed high against a window that had moved past the score in
+            // the opposite direction.
             if (eval <= alpha) {
+                alpha = std::max(eval - delta, static_cast<int>(score::kNegInf));
                 delta += delta / 4;
-                failHigh = true;
             } else if (eval >= beta) {
+                beta = std::min(eval + delta, static_cast<int>(score::kInf));
                 delta += delta / 4;
-                failLow = true;
             } else {
                 break;
             }
         }
 
-        if (!signals_.stop.load() && thread_id < static_cast<int>(completed_depth_.size()))
-            completed_depth_[thread_id] = static_cast<int>(id);
+        if (!signals_.stop.load()) {
+            last_completed = eval;
+            if (thread_id < static_cast<int>(completed_depth_.size()))
+                completed_depth_[thread_id] = static_cast<int>(id);
+        }
 
         // Print PV
         if (is_main && !signals_.stop.load()) {


### PR DESCRIPTION
All three sit in the same twenty lines of iterative_deepening.

1. The widening step never reset. `delta` was declared once, outside the
   iterative deepening loop, and only ever grew (`delta += delta / 4` on
   each re-search). A single tactical depth that needed several re-searches
   therefore left every later depth starting from an inflated step.
   Instrumented over bench 12 (144 iterations, 37 re-searches): the mean
   value of delta at the start of an iteration was 91.3 against a base of
   65, and it peaked at 306 -- 4.7x the intended step. The widening
   schedule is supposed to be per-iteration; it was effectively per-search.

2. The window was re-centred on the score of the search that had just
   failed. Both bounds were recomputed from `eval` on every re-search:

       alpha = eval - smallDelta;
       beta  = eval + smallDelta;

   Between iterations `eval` does not hold an estimate of the score, it
   holds whatever the failed search returned, and that is a bound. Under
   fail-soft a fail low can return a value far below alpha, and this then
   dragged beta down with it -- in a deep fail low, to below the alpha we
   had just failed under. The re-search then failed high against a window
   that had moved past the score in the opposite direction, and the next
   pass re-centred again in the other direction. The window is now anchored
   on the last *completed* iteration's score, and a re-search widens only
   the bound that actually failed.

   This matters more than it used to. fix/qsearch-fail-soft-delta makes
   quiescence return the position's score rather than alpha, which is
   correct but which also means fail-low values are now genuinely lower,
   and lower fail-soft values are exactly what fed this defect.

3. Helper threads aspirated around a score they did not have. The guard
   was `id >= 2`, but thread n begins its iterative deepening at depth
   n + 1, so for every helper thread the very first iteration satisfied
   `id >= 2` while `eval` was still its initial -inf. Those threads built
   the window [-inf, -inf + 33] and searched it, which fails high on
   essentially any position, costing a wasted search plus a re-search
   before the window recovered. The guard is now on actually having a
   completed score.

The failLow / failHigh flag pair is gone with them. Both the assignment
and the use were inverted -- a fail low set failHigh, and failHigh widened
alpha -- so the two errors cancelled and the behaviour was right, but the
flags carried no information that `eval <= alpha` did not already carry.

bench 11  1391650 -> 1619127 nodes
bench 12  3321866 -> 2944977 nodes

Node counts move in opposite directions at the two depths, which is what
changing a window schedule looks like; neither is evidence of strength and
this goes to SPRT.

121/121 tests pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>



---

**SPRT (whole stack vs previous main, 10+0.1)**: 685 games, 205-208-272, **-1.5 +/- 23 Elo** -- dead level, non-regression established. Stopped deliberately rather than spend thousands more games separating changes that are correctness fixes regardless of Elo.

`bench 11` = 1,651,340 nodes, bit-identical to the build that was tested. Test suite 124/124.

Stacked series, PR 2 of 6.
