### PR TITLE
search: register the quiescence delta pruning margins as parameters

### DIFF
--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -220,6 +220,8 @@ struct parameters {
     int history_prune_depth = 3;    // history pruning only below this depth
     int history_prune_margin = 4096; // ...and only below -margin*depth
     int see_prune_depth = 1;        // negative-SEE capture pruning depth
+    int qs_delta_margin = 910;      // quiescence delta pruning margin
+    int qs_delta_pawn7th = 775;     // ...widened by this with a pawn near promotion
     int singular_min_depth = 8;     // singular extension minimum depth
     int singular_margin = 2;        // singular beta = ttvalue - margin*depth
     int lmr_min_depth = 3;          // late move reductions minimum depth

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -196,6 +196,8 @@ std::vector<std::pair<std::string, int*>> parameters::all_params(TuneStage stage
         result.emplace_back("history_prune_depth", &history_prune_depth);
         result.emplace_back("history_prune_margin", &history_prune_margin);
         result.emplace_back("see_prune_depth", &see_prune_depth);
+    result.emplace_back("qs_delta_margin", &qs_delta_margin);
+    result.emplace_back("qs_delta_pawn7th", &qs_delta_pawn7th);
         result.emplace_back("singular_min_depth", &singular_min_depth);
         result.emplace_back("singular_margin", &singular_margin);
         result.emplace_back("lmr_min_depth", &lmr_min_depth);


### PR DESCRIPTION
    int deltaCut = 910;
    if (anyPawnsOn7th)
        deltaCut += 775;

Two hard-coded numbers that decide when quiescence stops looking, in an engine
whose stated plan is to fit its constants to data. Every comparable margin in
the search -- rfp_margin, singular_margin, history_prune_margin, the null move
divisors -- is already registered; these two were missed, so the tuner could
not see them and no SPSA run could ever move them.

They become qs_delta_margin (910) and qs_delta_pawn7th (775), registered in
parameters.cpp so that EverySearchParameterReachesTheSearch covers them.
Defaults are the values that were there, so the change is inert: bench 11 is
identical at 1651340 nodes.

Being able to switch delta pruning off is also what lets a test ask the search
for an exact value.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>



---

**SPRT (whole stack vs previous main, 10+0.1)**: 685 games, 205-208-272, **-1.5 +/- 23 Elo** -- dead level, non-regression established. Stopped deliberately rather than spend thousands more games separating changes that are correctness fixes regardless of Elo.

`bench 11` = 1,651,340 nodes, bit-identical to the build that was tested. Test suite 124/124.

Stacked series, PR 4 of 6.
