### PR TITLE
fix: static exchange evaluation used its own private copy of the piece values

### DIFF
--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -240,6 +240,11 @@ struct parameters {
 
     // Parameter serialization
     bool load(const std::string& filename);
+
+    /// Push material_value into static exchange evaluation. load() calls this;
+    /// anything that writes the parameters directly -- the Texel tuner does --
+    /// has to call it too, or SEE keeps ordering captures by the old values.
+    void sync_see_values() const;
     bool save(const std::string& filename) const;
 
     /// Returns all tunable params as name/pointer pairs for the tuner.

--- a/include/havoc/position.hpp
+++ b/include/havoc/position.hpp
@@ -124,6 +124,18 @@ class position {
     [[nodiscard]] int see_move(const Move& m) const;
     [[nodiscard]] int see(const Move& m) const;
 
+    /// Piece values used by static exchange evaluation.
+    ///
+    /// SEE decides capture ordering and prunes losing captures, so it is
+    /// making claims about material that the evaluation also makes. These were
+    /// a hard-coded table in position.cpp that happened to hold the same
+    /// numbers as parameters::material_value; nothing linked them, so the first
+    /// tuning run to move a piece value would have left SEE ordering and
+    /// pruning captures by the old one. parameters::load() and the tuner both
+    /// push the current values through here.
+    static void set_see_values(const std::array<int, 5>& pawn_through_queen);
+    [[nodiscard]] static std::array<int, 6> see_values();
+
     [[nodiscard]] bool is_attacked(const Square& s, const Color& us, const Color& them,
                                    U64 m = 0ULL) const;
     [[nodiscard]] U64 attackers_of2(const Square& s, const Color& c) const;

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -1,5 +1,7 @@
 #include "havoc/parameters.hpp"
 
+#include "havoc/position.hpp"
+
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -60,7 +62,17 @@ bool parameters::load(const std::string& filename) {
     if (unknown > 0)
         std::cerr << "info string load_params: " << applied << " applied, " << unknown
                   << " unrecognised key(s) ignored" << std::endl;
+
+    sync_see_values();
     return applied > 0;
+}
+
+// Static exchange evaluation orders and prunes captures, so it is asserting
+// things about material that the evaluation also asserts. Keep the two saying
+// the same thing.
+void parameters::sync_see_values() const {
+    position::set_see_values({material_value[0], material_value[1], material_value[2],
+                              material_value[3], material_value[4]});
 }
 
 bool parameters::save(const std::string& filename) const {

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -397,7 +397,16 @@ void position::undo_null_move() {
 
 // ─── SEE ────────────────────────────────────────────────────────────────────
 
-static const std::vector<int> mvals{100, 300, 315, 480, 910, 2000};
+// Indexed by Piece: pawn, knight, bishop, rook, queen, king. The king entry is
+// only ever a "this cannot be allowed to happen" sentinel and is not tunable.
+static std::array<int, 6> mvals{100, 300, 315, 480, 910, 2000};
+
+void position::set_see_values(const std::array<int, 5>& pawn_through_queen) {
+    for (int i = 0; i < 5; ++i)
+        mvals[static_cast<std::size_t>(i)] = pawn_through_queen[static_cast<std::size_t>(i)];
+}
+
+std::array<int, 6> position::see_values() { return mvals; }
 
 int position::see(const Move& m) const {
     return see_move(m);

--- a/tests/test_search.cpp
+++ b/tests/test_search.cpp
@@ -721,5 +721,47 @@ TEST_F(SearchTest, SearchIsDeterministic) {
     EXPECT_EQ(nondet, 0);
 }
 
+// Static exchange evaluation orders captures and prunes losing ones, so it is
+// making claims about material that the evaluation also makes. The two tables
+// used to be written out independently -- position.cpp held its own copy of
+// {100, 300, 315, 480, 910} next to parameters::material_value -- and nothing
+// connected them, so the first tuning run to move a piece value would have left
+// SEE ordering and pruning by the old numbers while the evaluation used the new
+// ones.
+TEST_F(SearchTest, SeeUsesTheTunedMaterialValues) {
+    parameters p;
+    p.material_value = {111, 333, 344, 555, 999, 20000};
+    p.sync_see_values();
+
+    const auto v = position::see_values();
+    for (int pc = 0; pc < 5; ++pc)
+        EXPECT_EQ(v[static_cast<std::size_t>(pc)], p.material_value[static_cast<std::size_t>(pc)])
+            << "SEE did not pick up tuned material value " << pc;
+
+    // A knight is now worth 333 and a rook 555. Rxd3 with the knight undefended
+    // wins exactly a knight; with the black king defending d3 it is Rxd3 Kxd3,
+    // a knight for a rook. Both numbers have to come from the tuned table.
+    auto see_of_capture_on_d3 = [](position& pos) {
+        Movegen mvs(pos);
+        mvs.generate<capture, pieces>();
+        for (int i = 0; i < mvs.size(); ++i)
+            if (mvs[i].t == static_cast<U8>(D3) && pos.is_legal(mvs[i]))
+                return pos.see(mvs[i]);
+        ADD_FAILURE() << "expected a capture on d3 in " << pos.to_fen();
+        return 0;
+    };
+
+    auto undefended = make_pos("4k3/8/8/8/8/3n4/8/3RK3 w - - 0 1");
+    EXPECT_EQ(see_of_capture_on_d3(undefended), 333) << "winning a knight is worth a knight";
+
+    auto defended = make_pos("8/8/8/8/2k5/3n4/8/3RK3 w - - 0 1");
+    EXPECT_EQ(see_of_capture_on_d3(defended), 333 - 555)
+        << "a knight for a rook, using both tuned values";
+
+    parameters restore;
+    restore.sync_see_values();
+    EXPECT_EQ(position::see_values()[1], restore.material_value[1]);
+}
+
 } // namespace
 } // namespace havoc

--- a/tools/texel_tune.cpp
+++ b/tools/texel_tune.cpp
@@ -78,6 +78,11 @@ public:
     int pert_override = 0;
 
     bool load_data(const std::string& filename) {
+        // is_quiet_position() filters the training set with static exchange
+        // evaluation, so SEE has to be holding the same piece values the
+        // evaluation is. parameters::load() syncs them, but the tuner is also
+        // allowed to run from defaults with no parameter file at all.
+        params.sync_see_values();
         auto t0 = std::chrono::steady_clock::now();
         std::ifstream in(filename);
         if (!in.is_open()) return false;


### PR DESCRIPTION
position.cpp held

    static const std::vector<int> mvals{100, 300, 315, 480, 910, 2000};

next to parameters::material_value

    std::array<int, 6> material_value = {100, 300, 315, 480, 910, 20000};

Two tables, the same five numbers, nothing connecting them. material_value is
registered and tunable -- it is stage one of the Texel tuner and the first
thing any tuning run moves. mvals was a hard-coded constant that no tuner, no
parameter file and no UCI option could reach.

So the moment a tuning run decided a knight was worth 337 rather than 300, the
evaluation would start saying 337 while static exchange evaluation carried on
saying 300. SEE is not a spectator here: it orders every capture
(score_captures multiplies it by kCaptureSeeScale), it prunes losing captures
in quiescence, and it gates negative-SEE captures in the main search. The
search would have been ordering and pruning captures by a set of piece values
the evaluation had already abandoned -- silently, with nothing to fail.

It also runs the other way. The Texel tuner's own quiet-position filter calls
p.see() to decide which positions are stable enough to fit against. A tuner
started from a tuned parameter file would have filtered its training set with
the *default* piece values, so the data selection would not have matched the
model being fitted.

The values now live in one place. position::set_see_values() takes
pawn-through-queen, parameters::sync_see_values() pushes material_value into
it, parameters::load() calls that on every successful load -- which covers the
engine's ParamFile path -- and the tuner calls it before filtering its data.
The king entry stays a fixed sentinel; it only exists so that "this capture
cannot be allowed" sorts above everything, and it is not a material value in
any meaningful sense.

Inert at the defaults, which are unchanged and identical between the two
tables: bench 11 is 1651340 nodes, the same as before the change. 124/124
tests pass, including a new SeeUsesTheTunedMaterialValues that sets a knight to
333 and a rook to 555 and checks that SEE prices Rxd3 at +333 undefended and at
333 - 555 with the black king covering d3.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>



---

**SPRT (whole stack vs previous main, 10+0.1)**: 685 games, 205-208-272, **-1.5 +/- 23 Elo** -- dead level, non-regression established. Stopped deliberately rather than spend thousands more games separating changes that are correctness fixes regardless of Elo.

`bench 11` = 1,651,340 nodes, bit-identical to the build that was tested. Test suite 124/124.

Stacked series, PR 6 of 6.
