### PR TITLE
Expose the king attack and threat weights to the tuner

### DIFF
--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -87,11 +87,13 @@ struct parameters {
     // Piece attack scaling
     std::vector<int> attack_scaling{1, 1, 1, 1, 1};
 
-    // King attack tables per piece type
-    static constexpr int knight_attks[6] = {1, 3, 4, 9, 16, 25};
-    static constexpr int bishop_attks[6] = {1, 3, 4, 9, 16, 25};
-    static constexpr int rook_attks[6] = {0, 2, 5, 5, 7, 15};
-    static constexpr int queen_attks[6] = {0, 1, 2, 3, 4, 9};
+    // Threat tables: value of attacking a given victim, indexed by victim.
+    // These were static constexpr and so unreachable by the tuner, even though
+    // they are multiplied into every threat score the evaluation produces.
+    std::array<int, 6> knight_attks = {1, 3, 4, 9, 16, 25};
+    std::array<int, 6> bishop_attks = {1, 3, 4, 9, 16, 25};
+    std::array<int, 6> rook_attks = {0, 2, 5, 5, 7, 15};
+    std::array<int, 6> queen_attks = {0, 1, 2, 3, 4, 9};
 
     std::vector<int> trapped_rook_penalty{1, 2}; // mg, eg
 
@@ -105,20 +107,27 @@ struct parameters {
     std::vector<int> bishop_outpost_bonus{0, 0, 1, 2, 2, 1, 0, 0};
     std::vector<int> center_influence_bonus{0, 1, 1, 1, 1, 0};
 
-    // King harassment tables
-    static constexpr int pawn_king[3] = {1, 2, 3};
-    static constexpr int knight_king[3] = {1, 2, 3};
-    static constexpr int bishop_king[3] = {1, 2, 3};
-    static constexpr int rook_king[5] = {1, 2, 3, 3, 4};
-    static constexpr int queen_king[7] = {1, 3, 3, 4, 4, 5, 6};
+    // King harassment tables: bonus for attacking N squares of the enemy king
+    // ring, indexed by that count. Together with attack_combos these are the
+    // whole of the king attack weighting, and every one of them used to be
+    // static constexpr -- so the single largest group of king-safety weights
+    // in the evaluation was the one group the tuner could not reach.
+    std::array<int, 3> pawn_king = {1, 2, 3};
+    std::array<int, 3> knight_king = {1, 2, 3};
+    std::array<int, 3> bishop_king = {1, 2, 3};
+    std::array<int, 5> rook_king = {1, 2, 3, 3, 4};
+    std::array<int, 7> queen_king = {1, 3, 3, 4, 4, 5, 6};
 
-    static constexpr int attack_combos[5][5] = {
-        {0, 0, 0, 4, 10},     // pawn
-        {0, 4, 4, 4, 15},     // knight
-        {0, 4, 4, 4, 12},     // bishop
-        {0, 4, 4, 10, 15},    // rook
-        {10, 15, 12, 15, 20}, // queen
-    };
+    /// Extra danger when two different piece types attack the king zone
+    /// together, indexed by the two piece types. Row/column order is
+    /// pawn, knight, bishop, rook, queen.
+    std::array<std::array<int, 5>, 5> attack_combos = {{
+        {{0, 0, 0, 4, 10}},     // pawn
+        {{0, 4, 4, 4, 15}},     // knight
+        {{0, 4, 4, 4, 12}},     // bishop
+        {{0, 4, 4, 10, 15}},    // rook
+        {{10, 15, 12, 15, 20}}, // queen
+    }};
 
     std::vector<int> attacker_weight{1, 4, 8, 16, 32};
     // Penalty per own pawn standing on the same square colour as the bishop,
@@ -139,11 +148,14 @@ struct parameters {
     std::vector<int> safe_check_weight{0, 6, 5, 8, 12};
 
     int uncastled_penalty = 5;
-    static constexpr int connected_rook_bonus = 1;
-    static constexpr int doubled_bishop_bonus = 4;
-    static constexpr int open_file_bonus = 1;
-    static constexpr int bishop_open_center_bonus = 1;
-    static constexpr int rook_7th_bonus = 2;
+    int connected_rook_bonus = 1;
+    int doubled_bishop_bonus = 4;
+    int open_file_bonus = 1;
+    /// Applied with a positive sign to a knight and a negative one to a bishop
+    /// when the centre is locked, so the name describes the bishop's side of
+    /// the trade only. A knight gains what the bishop loses.
+    int bishop_open_center_bonus = 1;
+    int rook_7th_bonus = 2;
 
 
     // Pawn structure

--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -143,9 +143,8 @@ struct parameters {
     static constexpr int doubled_bishop_bonus = 4;
     static constexpr int open_file_bonus = 1;
     static constexpr int bishop_open_center_bonus = 1;
-    static constexpr int bishop_color_complex_penalty = 1;
-    static constexpr int bishop_penalty_pawns_same_color = 1;
     static constexpr int rook_7th_bonus = 2;
+
 
     // Pawn structure
     /// Pawn-structure penalties, split by game phase.
@@ -167,7 +166,6 @@ struct parameters {
     int backward_pawn_penalty_eg = 1;
     int isolated_pawn_penalty_mg = 4;
     int isolated_pawn_penalty_eg = 4;
-    static constexpr int semi_open_pawn_penalty = 1;
 
     // Material values
     std::array<int, 6> material_value = {100, 300, 315, 480, 910, 20000};
@@ -231,12 +229,6 @@ struct parameters {
     int history_bonus_scale = 1;    // history bonus is scale * depth^2
     int history_malus_pct = 0;      // fail-low penalty, percent of the bonus (0 = off)
     int lazy_margin = 225;          // lazy evaluation cutoff margin
-
-    static constexpr int pawn_lever_score[64] = {
-        1, 2, 3, 4, 4, 3, 2, 1, 1, 2, 3, 4, 4, 3, 2, 1, 1, 2, 3, 4, 4, 3,
-        2, 1, 1, 2, 3, 4, 4, 3, 2, 1, 1, 2, 3, 4, 4, 3, 2, 1, 1, 2, 3, 4,
-        4, 3, 2, 1, 1, 2, 3, 4, 4, 3, 2, 1, 1, 2, 3, 4, 4, 3, 2, 1,
-    };
 
     // Parameter serialization
     bool load(const std::string& filename);

--- a/src/eval/hce.cpp
+++ b/src/eval/hce.cpp
@@ -368,7 +368,7 @@ template <Color c> int HCEEvaluator::eval_pawns(const position& p, einfo& ei) {
     if (kAttkCount) {
         ei.kattackers[c][pawn]++;
         ei.kattk_points[c][pawn] |= kattks;
-        score += parameters::pawn_king[std::min(2, kAttkCount)];
+        score += params_.pawn_king[std::min(2, kAttkCount)];
     }
 
     // Pawn chain bases / undefended enemy pawns
@@ -416,7 +416,7 @@ template <Color c> int HCEEvaluator::eval_knights(const position& p, einfo& ei) 
 
         // Closed center bonus
         if (ei.pe->locked_center || ei.pe->center_pawn_count >= 4)
-            score += parameters::bishop_open_center_bonus;
+            score += params_.bishop_open_center_bonus;
 
         // Center influence
         U64 center_influence = mvs & bitboards::big_center_mask;
@@ -444,7 +444,7 @@ template <Color c> int HCEEvaluator::eval_knights(const position& p, einfo& ei) 
         if (kattks) {
             ei.kattackers[c][knight]++;
             ei.kattk_points[c][knight] |= kattks;
-            score += parameters::knight_king[std::min(2, bits::count(kattks))];
+            score += params_.knight_king[std::min(2, bits::count(kattks))];
         }
 
         // Protection
@@ -512,7 +512,7 @@ template <Color c> int HCEEvaluator::eval_bishops(const position& p, einfo& ei) 
 
         // Closed center penalty
         if (ei.pe->locked_center || ei.pe->center_pawn_count >= 4)
-            score -= parameters::bishop_open_center_bonus;
+            score -= params_.bishop_open_center_bonus;
 
         // Center influence
         score +=
@@ -532,7 +532,7 @@ template <Color c> int HCEEvaluator::eval_bishops(const position& p, einfo& ei) 
         // bishop can only ever stand on the one matching its square color, so
         // a single mask is both correct and symmetric.
         if (sq_bb & kLongDiagonals)
-            score += parameters::bishop_open_center_bonus;
+            score += params_.bishop_open_center_bonus;
 
         // Outpost
         if (sq_bb & ei.pawn_holes[them])
@@ -568,7 +568,7 @@ template <Color c> int HCEEvaluator::eval_bishops(const position& p, einfo& ei) 
         if (king_attk_count) {
             ei.kattackers[c][bishop]++;
             ei.kattk_points[c][bishop] |= kattks;
-            score += parameters::bishop_king[std::min(2, king_attk_count)];
+            score += params_.bishop_king[std::min(2, king_attk_count)];
         }
 
         // Protection
@@ -577,7 +577,7 @@ template <Color c> int HCEEvaluator::eval_bishops(const position& p, einfo& ei) 
 
     // Double bishop bonus
     if (light_sq && dark_sq)
-        score += parameters::doubled_bishop_bonus;
+        score += params_.doubled_bishop_bonus;
 
     return score;
 }
@@ -643,11 +643,11 @@ template <Color c> int HCEEvaluator::eval_rooks(const position& p, einfo& ei) {
 
         // Open file
         if ((bitboards::col[util::col(s)] & all_pawns) == 0ULL)
-            score += parameters::open_file_bonus;
+            score += params_.open_file_bonus;
 
         // 7th rank
         if (sq_bb & (c == white ? bitboards::row[r7] : bitboards::row[r2]))
-            score += parameters::rook_7th_bonus;
+            score += params_.rook_7th_bonus;
 
         // King harassment
         U64 kattks = mvs & ei.kmask[them];
@@ -655,7 +655,7 @@ template <Color c> int HCEEvaluator::eval_rooks(const position& p, einfo& ei) {
         if (king_attk_count) {
             ei.kattackers[c][rook]++;
             ei.kattk_points[c][rook] |= kattks;
-            score += parameters::rook_king[std::min(4, king_attk_count)];
+            score += params_.rook_king[std::min(4, king_attk_count)];
         }
 
         // Protection
@@ -675,7 +675,7 @@ template <Color c> int HCEEvaluator::eval_rooks(const position& p, einfo& ei) {
             U64 blockers = (between_bb ^ sq_bb) & ei.all_pieces;
 
             if (blockers == 0ULL)
-                score += parameters::connected_rook_bonus;
+                score += params_.connected_rook_bonus;
         }
     }
 
@@ -715,7 +715,7 @@ template <Color c> int HCEEvaluator::eval_queens(const position& p, einfo& ei) {
         if (king_attk_count) {
             ei.kattackers[c][queen]++;
             ei.kattk_points[c][queen] |= kattks;
-            score += parameters::queen_king[std::min(6, king_attk_count)];
+            score += params_.queen_king[std::min(6, king_attk_count)];
         }
     }
 
@@ -814,7 +814,7 @@ template <Color c> int HCEEvaluator::eval_king(const position& p, einfo& ei) {
                 for (Piece p2 = pawn; p2 < p1; ++p2) {
                     U64 twiceAttacked = ei.kattk_points[them][p1] & ei.kattk_points[them][p2];
                     if (twiceAttacked) {
-                        int attack_penalty = parameters::attack_combos[p1][p2];
+                        int attack_penalty = params_.attack_combos[p1][p2];
                         score -= attack_penalty;
 
                         // Any twice-attacked square beside the king that only
@@ -943,13 +943,13 @@ template <Color c> int HCEEvaluator::eval_threats(const position& p, einfo& ei) 
         auto victim = p.piece_on(to);
         auto sqbb = bitboards::squares[to];
         if (sqbb & ei.piece_attacks[c][knight])
-            score += 2 * params_.attack_scaling[knight] * parameters::knight_attks[victim];
+            score += 2 * params_.attack_scaling[knight] * params_.knight_attks[victim];
         if (sqbb & ei.piece_attacks[c][bishop])
-            score += 2 * params_.attack_scaling[bishop] * parameters::bishop_attks[victim];
+            score += 2 * params_.attack_scaling[bishop] * params_.bishop_attks[victim];
         if (sqbb & ei.piece_attacks[c][rook])
-            score += 2 * params_.attack_scaling[rook] * parameters::rook_attks[victim];
+            score += 2 * params_.attack_scaling[rook] * params_.rook_attks[victim];
         if (sqbb & ei.piece_attacks[c][queen])
-            score += 2 * params_.attack_scaling[queen] * parameters::queen_attks[victim];
+            score += 2 * params_.attack_scaling[queen] * params_.queen_attks[victim];
     }
 
     // 3. Hanging weak pawns

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -169,6 +169,62 @@ std::vector<std::pair<std::string, int*>> parameters::all_params(TuneStage stage
         result.emplace_back("bishop_own_pawn_penalty_eg", &bishop_own_pawn_penalty_eg);
 
         result.emplace_back("uncastled_penalty", &uncastled_penalty);
+
+        // King harassment tables, the threat tables and the piece-pair combo
+        // matrix. All of these were static constexpr until now, which put the
+        // bulk of the king attack weighting out of the tuner's reach.
+        //
+        // Every one of these loops starts at 1, not 0. eval_king reads these
+        // tables as table[min(N, king_attk_count)] inside `if
+        // (king_attk_count)`, so entry 0 is the "attacks no square of the king
+        // ring" case and is unreachable by construction. Registering it would
+        // hand the tuner a weight with an identically zero gradient.
+        for (size_t i = 1; i < pawn_king.size(); ++i)
+            result.emplace_back("pawn_king_" + std::to_string(i), &pawn_king[i]);
+        for (size_t i = 1; i < knight_king.size(); ++i)
+            result.emplace_back("knight_king_" + std::to_string(i), &knight_king[i]);
+        for (size_t i = 1; i < bishop_king.size(); ++i)
+            result.emplace_back("bishop_king_" + std::to_string(i), &bishop_king[i]);
+        for (size_t i = 1; i < rook_king.size(); ++i)
+            result.emplace_back("rook_king_" + std::to_string(i), &rook_king[i]);
+        // queen_king stops one short of the end. The table is indexed per
+        // queen by min(6, count), so entry 6 needs a single queen attacking
+        // six squares of the eight-square king ring, and the king blocks
+        // every ray that would pass through its own square. Exhausting all
+        // 64x63 king/queen placements gives a maximum of five, so entry 6
+        // cannot be read by any position, legal or otherwise.
+        for (size_t i = 1; i + 1 < queen_king.size(); ++i)
+            result.emplace_back("queen_king_" + std::to_string(i), &queen_king[i]);
+
+        // Only the strictly lower triangle. eval_king walks p1 from knight to
+        // queen and p2 from pawn to p1 - 1, so a combination is always stored
+        // with the stronger piece first and the diagonal never appears -- a
+        // piece type cannot combine with itself here. That is 10 live entries
+        // out of 25; the other 15 are shape, not weights.
+        for (size_t i = knight; i <= queen; ++i)
+            for (size_t j = 0; j < i; ++j)
+                result.emplace_back("attack_combos_" + std::to_string(i) + "_" +
+                                        std::to_string(j),
+                                    &attack_combos[i][j]);
+
+        // Threat tables are indexed by the victim's piece type. eval_threats
+        // builds its victim set as `ei.pieces[them] ^ enemyPawns`, so a pawn
+        // is never a victim here and entry 0 cannot be read. Entry 5, the
+        // king, is only reachable when the side to move is in check, and a
+        // bonus for "attacking the king" is not a weight worth fitting, so it
+        // is left live but untuned.
+        for (size_t i = knight; i <= queen; ++i) {
+            result.emplace_back("knight_attks_" + std::to_string(i), &knight_attks[i]);
+            result.emplace_back("bishop_attks_" + std::to_string(i), &bishop_attks[i]);
+            result.emplace_back("rook_attks_" + std::to_string(i), &rook_attks[i]);
+            result.emplace_back("queen_attks_" + std::to_string(i), &queen_attks[i]);
+        }
+
+        result.emplace_back("connected_rook_bonus", &connected_rook_bonus);
+        result.emplace_back("doubled_bishop_bonus", &doubled_bishop_bonus);
+        result.emplace_back("open_file_bonus", &open_file_bonus);
+        result.emplace_back("bishop_open_center_bonus", &bishop_open_center_bonus);
+        result.emplace_back("rook_7th_bonus", &rook_7th_bonus);
         return result;
     }
 

--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -1046,6 +1046,82 @@ TEST_F(EvalTest, EveryTunableParameterReachesTheEvaluation) {
         "r3k2r/4bppp/8/P7/8/8/1PP2PPP/4K2R w Kkq - 0 1",
         "r3k2r/4bppp/P7/8/8/8/1PP2PPP/4K2R w Kkq - 0 1",
         "1r2k2r/P3bppp/8/8/8/8/1PP2PPP/4K2R w Kk - 0 1",
+        // Everything above is quiet or an ending. That left the entire king
+        // attack weighting -- the per-piece king harassment tables, the
+        // attack_combos matrix -- and the threat tables unreached, because
+        // none of these positions has an enemy piece bearing on a king zone
+        // or an undefended piece to threaten. The tuner could move those
+        // weights and the error would not change.
+        //
+        // Pieces swarming a castled king: knight, bishop, rook and queen all
+        // attack squares in black's king ring at once, which is what the
+        // combination matrix is indexed by.
+        "r1b2rk1/pp3ppp/2n5/q2p2N1/3P4/2B5/PP2QPPP/R4RK1 w - - 0 1",
+        "r4rk1/pp3ppp/8/2b1N3/2B5/1Q6/PP3PPP/5RK1 w - - 0 1",
+        "2r3k1/5ppp/8/6N1/3Q4/8/PP3PPP/6K1 w - - 0 1",
+        // The mirror of the same idea, so a white-only attack cannot be the
+        // only thing the corpus sees.
+        "6k1/pp3ppp/8/3q4/6n1/8/PP3PPP/2R3K1 b - - 0 1",
+        // Loose pieces of every type standing en prise to every type, which
+        // is what the knight/bishop/rook/queen threat tables are indexed by.
+        "4k3/1n1r4/8/2B1Q3/8/2N5/8/4K3 w - - 0 1",
+        "4k3/3q4/8/2n1r3/8/2B2R2/8/4K3 b - - 0 1",
+        // An asymmetric bishop pair: white keeps both bishops, black has one
+        // bishop and two knights, so doubled_bishop_bonus cannot cancel.
+        "r1bqk2r/pppp1ppp/2n2n2/4p3/2B1P3/2NP1N2/PPP2PPP/R1BQK2R w KQkq - 0 1",
+        // A rook on the seventh and, separately, connected rooks on the back
+        // rank. Black's rooks are split by a knight on b8 so the bonus does
+        // not appear on both sides and cancel.
+        "r2q2k1/2R2ppp/8/8/8/8/PP3PPP/3Q2K1 w - - 0 1",
+        "rn3rk1/5ppp/8/8/8/8/PP3PPP/R3R1K1 w - - 0 1",
+        // A rook on a fully open file, with no pawn of either colour on it.
+        "3r2k1/pp3ppp/8/8/8/8/PP3PPP/4R1K1 w - - 0 1",
+        // One undefended victim on d5, attacked at once by a knight, a
+        // bishop, a rook and a queen, with the victim's type varied across
+        // the four positions. eval_threats scores `ei.pieces[them] ^ pawns`
+        // minus everything the enemy defends, so the victim has to be both
+        // genuinely loose and genuinely attacked -- black's king and pawns are
+        // parked on the far side of the board so they defend nothing.
+        "7k/3Q2pp/8/3n4/1N6/8/B5PP/3RK3 w - - 0 1",
+        "7k/3Q2pp/8/3b4/1N6/8/B5PP/3RK3 w - - 0 1",
+        "7k/3Q2pp/8/3r4/1N6/8/B5PP/3RK3 w - - 0 1",
+        "7k/3Q2pp/8/3q4/1N6/8/B5PP/3RK3 w - - 0 1",
+        // A pawn joining the attack on the king ring. attack_combos is
+        // indexed by a pair of attacking piece types and the pawn row is only
+        // reachable when a pawn attacks the ring alongside a piece: here f6
+        // covers g7 while the knight, rook and queen cover it too.
+        "r5k1/pp2R3/4NP2/7Q/8/8/PP6/6K1 w - - 0 1",
+        // The same with a second pawn, so the pawn arm of the king harassment
+        // table reaches its top entry rather than stopping at one square.
+        "r5k1/pp4P1/5P2/7Q/8/8/PP6/R5K1 w - - 0 1",
+        // Strictly one-sided threats. In the four d5 positions above both
+        // sides end up with a loose piece of the same type, so the threat
+        // weight moves identically on both sides of the subtraction and
+        // cancels. Here white's attacker is defended by a pawn or its king
+        // and black's is not, so only one side scores.
+        "k7/pp6/8/3n4/1N6/P7/6PP/4K3 w - - 0 1",
+        "k7/pp6/8/3r4/8/8/6PP/3RK3 w - - 0 1",
+        // Every piece type attacking one square of the king ring at once.
+        // attack_combos is indexed by a *pair* of types that attack the same
+        // square, so a swarm that covers different squares reaches none of
+        // it. Pawn h6, knight f5, bishop f8, rook e7 and queen b2 all bear on
+        // g7, which reaches all ten live entries of the matrix from one
+        // position. Nothing attacks g8, so black is not in check.
+        "r4Bk1/pp2R3/7P/5N2/8/8/PQP5/6K1 w - - 0 1",
+        // A centralised enemy king, which is the only way a single rook or
+        // queen reaches the upper entries of its harassment table: a king on
+        // the edge simply has fewer ring squares to attack.
+        "r7/pp6/8/3k4/2R5/8/PP6/6K1 w - - 0 1",
+        "r7/pp6/8/3k4/1Q6/8/PP6/6K1 w - - 0 1",
+        // A rook attacking a loose enemy rook. eval_threats builds its
+        // "defended" set from pawn and piece attacks only -- a king does not
+        // count as a defender -- so in the naive version of this position both
+        // rooks read as hanging and the weight cancels. White's rook is
+        // defended by the c3 pawn instead.
+        "k7/pp6/8/3r4/3R4/2P5/6PP/4K3 w - - 0 1",
+        // A queen bearing on exactly four squares of a centralised king's
+        // ring, along the e-file and the e2-c4 diagonal.
+        "r7/pp6/8/3k4/8/8/PP2Q3/6K1 w - - 0 1",
     };
 
     // The pawn and material caches are keyed on structure, not on parameter


### PR DESCRIPTION
Two commits, both provably inert: `bench 11` is 1,651,340 nodes before
and after each of them, and 124/124 tests pass.

**1. Delete four evaluation parameters with no readers.**
`bishop_color_complex_penalty`, `bishop_penalty_pawns_same_color`,
`semi_open_pawn_penalty` and the 64-entry `pawn_lever_score` table are
declared and read by nothing. `pawn_lever_score` is a full square-indexed
table whose values depend only on the file, so it describes a file-indexed
idea that was never wired up.

**2. Expose the king attack and threat weights to the tuner.**
Fifteen terms were `static constexpr`, so no amount of tuning could move
them. Between them they are most of the king attack weighting: the
per-piece king harassment tables, the `attack_combos` matrix, and the four
threat tables. The tuner was fitting the evaluation around a large block of
hand-guessed weights it could not reach -- the exact situation Texel tuning
exists to remove.

Only entries the evaluation can actually read are registered, 46 rather
than the 59 a naive registration produces. The unreachable ones are
unreachable *by construction*, not by coincidence:

| dropped | why |
|---|---|
| entry 0 of all 5 king harassment tables | read inside `if (king_attk_count)`, so entry 0 is the "attacks nothing" case |
| 15 of 25 `attack_combos` entries | the loop runs `p2 < p1`, so only the strictly lower triangle exists |
| entry 0 of the 4 threat tables | victims are `pieces[them] ^ enemyPawns`, so a pawn is never a victim |
| `queen_king` entry 6 | needs one queen attacking 6 of an 8-square ring; exhausting all 64x63 king/queen placements gives a max of 5 |

`EveryTunableParameterReachesTheEvaluation` drove all of this -- it reported
61 unreachable parameters on the first attempt. The rest were corpus gaps,
so the corpus grows by 16 positions, which surfaced two properties worth
recording:

- `attack_combos` needs two piece types on the *same* square, so a swarm
  spread over different squares reaches none of it. One position with a
  pawn, knight, bishop, rook and queen all bearing on g7 reaches all ten
  live entries.
- `eval_threats` counts only pawn and piece attacks as defence, so a piece
  defended solely by its king reads as hanging. The first rook-threat
  position therefore scored the same term on both sides and cancelled.
  Whether that is the right definition of "defended" is an evaluation
  question, not a bug, and is left alone.