### PR TITLE
eval: expose 25 live weights the tuner could not see

### DIFF
--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -225,6 +225,47 @@ std::vector<std::pair<std::string, int*>> parameters::all_params(TuneStage stage
         result.emplace_back("open_file_bonus", &open_file_bonus);
         result.emplace_back("bishop_open_center_bonus", &bishop_open_center_bonus);
         result.emplace_back("rook_7th_bonus", &rook_7th_bonus);
+
+        // Outpost bonuses are indexed by the file of the outpost square, so
+        // all eight entries are reachable: any file can contain a hole in the
+        // enemy pawn structure.
+        for (size_t i = 0; i < knight_outpost_bonus.size(); ++i)
+            result.emplace_back("knight_outpost_" + std::to_string(i), &knight_outpost_bonus[i]);
+        for (size_t i = 0; i < bishop_outpost_bonus.size(); ++i)
+            result.emplace_back("bishop_outpost_" + std::to_string(i), &bishop_outpost_bonus[i]);
+
+        // Center influence is read once per piece type in eval_knights,
+        // eval_bishops, eval_rooks and eval_queens. Pawns and kings never
+        // score it, so entries 0 and 5 are shape, not weights.
+        for (size_t i = knight; i <= queen; ++i)
+            result.emplace_back("center_influence_" + std::to_string(i),
+                                &center_influence_bonus[i]);
+
+        // The bonus for attacking the enemy queen is only read by the knight,
+        // bishop and rook evaluations -- a queen attacking a queen is a plain
+        // exchange, handled by SEE and the threat tables, so entry 4 is never
+        // read. Entry 0 (pawn) has no reader either.
+        for (size_t i = knight; i <= rook; ++i)
+            result.emplace_back("attk_queen_" + std::to_string(i), &attk_queen_bonus[i]);
+
+        // Both halves of the trapped rook penalty are live: it is applied
+        // through taper(), which blends the two by game phase.
+        result.emplace_back("trapped_rook_mg", &trapped_rook_penalty[0]);
+        result.emplace_back("trapped_rook_eg", &trapped_rook_penalty[1]);
+
+        // Deliberately NOT registered, and not oversights:
+        //
+        //   sq_score_scaling, attack_scaling, mobility_scaling -- all-ones
+        //   multipliers sitting in front of terms that are themselves tuned
+        //   (the piece-square tables, the threat tables, the per-piece
+        //   mobility scales). Fitting a product of two free weights is rank
+        //   deficient: the tuner could trade one against the other without
+        //   changing the evaluation, which wastes gradient and makes a tuned
+        //   file harder to interpret.
+        //
+        //   pinned_scaling -- a *divisor* on the mobility score. Exposing it
+        //   would let the tuner try zero and divide by zero, and integer
+        //   division makes its gradient a staircase rather than a slope.
         return result;
     }
 

--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -1122,6 +1122,17 @@ TEST_F(EvalTest, EveryTunableParameterReachesTheEvaluation) {
         // A queen bearing on exactly four squares of a centralised king's
         // ring, along the e-file and the e2-c4 diagonal.
         "r7/pp6/8/3k4/8/8/PP2Q3/6K1 w - - 0 1",
+        // Outposts, indexed by the file of the outpost square. A hole is the
+        // square directly in front of an enemy backward pawn, and a pawn whose
+        // neighbouring files are both empty counts as backward, so pawns on
+        // alternating files are all backward at once and one position covers
+        // four files. Two positions per piece therefore reach all eight
+        // entries. Black has no minor piece to place on a hole of White's, so
+        // the term cannot cancel between the two sides.
+        "7k/8/8/p1p1p1p1/N1N1N1N1/8/8/7K w - - 0 1",
+        "k7/8/8/1p1p1p1p/1N1N1N1N/8/8/K7 w - - 0 1",
+        "7k/8/8/p1p1p1p1/B1B1B1B1/8/8/7K w - - 0 1",
+        "k7/8/8/1p1p1p1p/1B1B1B1B/8/8/K7 w - - 0 1",
     };
 
     // The pawn and material caches are keyed on structure, not on parameter


### PR DESCRIPTION
Nine parameters are read by the evaluation but were registered in no tune stage, so the Texel tuner could neither move them nor learn they existed. Found by differencing every member of `parameters` against every name registered in `all_params` across all five stages.

**Registered (25 slots):** the two 8-entry outpost tables, `center_influence_bonus[1..4]`, `attk_queen_bonus[1..3]`, and both ends of `trapped_rook_penalty`.

Excluded indices are structurally unreachable (pawns/kings never score center influence; a queen attacking a queen is left to SEE). Four further terms are deliberately left unregistered, now documented in the file: three all-ones multipliers that would make the fit rank deficient, and `pinned_scaling`, a divisor the tuner could drive to zero.

Registering the outposts exposed all 16 entries as dead — no corpus position had a minor on a hole. Added four positions exploiting the fact that a pawn with both neighbouring files empty counts as backward, so alternating files cover four at a time.

**Inert:** all defaults unchanged, bench 1651340 nodes before and after, 124/124 tests pass.