### PR TITLE
eval: delete four pawn-hash fields nothing ever read

### DIFF
--- a/include/havoc/pawn_table.hpp
+++ b/include/havoc/pawn_table.hpp
@@ -36,12 +36,8 @@ struct pawn_entry {
     U64 light[2]{};
     U64 attacks[2]{};
     U64 undefended[2]{};
-    U64 weak_squares[2]{};
-    U64 chaintips[2]{};
-    U64 chainbases[2]{};
     U64 queenside[2]{};
     U64 kingside[2]{};
-    U64 semiopen[2]{};
     int16_t center_pawn_count = 0;
     bool locked_center = false;
 };

--- a/src/pawn_table.cpp
+++ b/src/pawn_table.cpp
@@ -116,7 +116,6 @@ template <Color c> pawn_score evaluate_pawns(const position& p, pawn_entry& e, c
 
     for (Square s = *sqs; s != no_square; s = *++sqs) {
         U64 fbb = bitboards::squares[s];
-        U64 front = (c == white ? bitboards::squares[s + 8] : bitboards::squares[s - 8]);
         int row = util::row(s);
         int col_idx = util::col(s);
 
@@ -144,7 +143,6 @@ template <Color c> pawn_score evaluate_pawns(const position& p, pawn_entry& e, c
         U64 mask = bitboards::passpawn_mask[c][s] & epawns;
         if (mask == 0ULL) {
             e.passed[c] |= fbb;
-            e.weak_squares[c] |= front;
         }
 
         // Isolated pawns
@@ -152,14 +150,14 @@ template <Color c> pawn_score evaluate_pawns(const position& p, pawn_entry& e, c
         if (neighbors_bb == 0ULL) {
             e.isolated[c] |= fbb;
             score.sub(par.isolated_pawn_penalty_mg, par.isolated_pawn_penalty_eg);
-            e.weak_squares[c] |= front;
+
         }
 
         // Backward pawns
         if (backward_pawn<c>(row, col_idx, pawns)) {
             e.backward[c] |= fbb;
             score.sub(par.backward_pawn_penalty_mg, par.backward_pawn_penalty_eg);
-            e.weak_squares[c] |= front;
+
         }
 
         // Square color
@@ -181,14 +179,13 @@ template <Color c> pawn_score evaluate_pawns(const position& p, pawn_entry& e, c
         // Semi-open files
         U64 column = bitboards::col[col_idx];
         if ((column & epawns) == 0ULL) {
-            e.semiopen[c] |= fbb;
             if (fbb & e.backward[c])
                 score.sub(2 * par.backward_pawn_penalty_mg, 2 * par.backward_pawn_penalty_eg);
             if (fbb & e.isolated[c])
                 score.sub(2 * par.isolated_pawn_penalty_mg, 2 * par.isolated_pawn_penalty_eg);
             if (fbb & e.doubled[c])
                 score.sub(2 * par.doubled_pawn_penalty_mg, 2 * par.doubled_pawn_penalty_eg);
-            e.weak_squares[c] |= front;
+
         }
 
         // King/queen side pawns


### PR DESCRIPTION
`pawn_entry` carried four fields no consumer ever looked at. `chaintips` and `chainbases` were never written either — declared and abandoned. `semiopen` was written once per pawn and read nowhere.

`weak_squares` is the interesting one: written in four places, read nowhere, and unusable as written — it OR'd in the front span of *passed* pawns alongside isolated, backward and semi-open-file pawns, so any consumer would have scored a strong passed pawn as a structural weakness. That is very likely why it was abandoned rather than finished. The sound half of the idea already exists and is live under another name: `ei.pawn_holes`, which feeds the outpost terms.

Removing the writes left a local `front` with no remaining use, which the compiler flagged immediately — independent confirmation the chain was dead.

`pawn_entry` shrinks from 248 to 184 bytes, so more of the pawn hash fits in cache.

**Inert:** bench 1651340 nodes before and after, 124/124 tests pass. This removes state, not behaviour.