### PR TITLE
Fix tactical motifs scoring through blocked lines, unfreeze the king safety and threat weights, add ProbCut

### DIFF
--- a/docs/revisit-after-tuning.md
+++ b/docs/revisit-after-tuning.md
@@ -1,0 +1,70 @@
+# Revisit after tuning
+
+Structural work that was accepted on correctness or coverage grounds rather
+than on measured Elo, and that should be re-examined once the evaluation has
+actually been fit to data.
+
+The reasoning behind the policy: a new evaluation term arrives with weights
+that are a guess. Gating it on a self-play match against the untuned engine
+tests the guess, not the term. A term that describes something real but is
+weighted badly can measure flat or slightly negative and still be the right
+thing to carry into tuning, because the tuner is what decides its weights. So
+a structural improvement is accepted when it is sound, reaches the evaluation,
+and does not regress badly -- and it lands here so the decision is revisited
+with real numbers instead of being forgotten.
+
+Each entry should say what to check and what would count as evidence to change
+course.
+
+## Evaluation terms whose defaults are guesses
+
+| Term | Landed | What to check after tuning |
+| --- | --- | --- |
+| Connected pawns (`phalanx_pawn_*`, `supported_pawn_*`) | `eval/connected-pawns` | 22 registered entries across four rank-indexed tables. Defaults were chosen to sit in scale with the existing pawn terms, which are unusually small here (isolated 4, doubled 4, backward 1). Check the fitted values are not an order of magnitude off the hand-picked ones; if they are, the pawn terms as a group are probably on the wrong scale. |
+| Queen mobility (`queen_mobility_*`) | `eval/connected-pawns` | 18 of 28 buckets are fit; the rest are coverage gaps. The curve was made deliberately flatter than the rook's on the argument that a cramped queen is not a large loss. That argument is a guess and the fit will either support it or not. |
+
+## Known coverage gaps
+
+Buckets that live code reads but the test corpus does not reach, so the tuner
+sees no gradient for them and they keep their defaults. Listed in
+`known_unreached` in `tests/test_eval.cpp`.
+
+- `queen_mobility_23` .. `queen_mobility_27`, plus 5, 10, 11, 15, 17. Positions
+  added specifically to reach the wide end moved none of them: the kings and
+  the remaining pawns keep the real safe-square count below the top buckets.
+  If tuning data covers them, they are worth fitting; otherwise consider
+  shortening the table so the unreachable tail is not carried around.
+- The equivalent knight, bishop and rook mobility gaps, which predate this.
+
+## Structural issues deliberately not fixed yet
+
+- **`isolated` implies `backward`.** `backward_pawn()` treats a pawn whose
+  neighbouring file is empty as backward, so every isolated pawn is charged
+  both penalties, and both are doubled again on a semi-open file. At the
+  current 1cp backward penalty the Elo cost is negligible, but the two weights
+  are collinear, which is a problem for a fit rather than for play. Separating
+  them changes what the two parameters mean, so it should be done *before* the
+  tuning run whose output anyone intends to keep.
+- **Terms left unregistered on purpose.** `sq_score_scaling`, `attack_scaling`
+  and `mobility_scaling` are all-ones multipliers in front of terms that are
+  themselves tuned, so fitting both sides of the product is rank deficient.
+  `pinned_scaling` is a divisor the tuner could drive to zero. The reasoning is
+  recorded in `src/parameters.cpp`; revisit only if a fit wants that freedom.
+
+## Test curation that depends on evaluation values
+
+`SearchTest.ExactSearchIsMirrorSymmetric` asserts a curated list of positions.
+The search it uses is not exact in the strict sense -- the transposition table,
+the aspiration window and the quiescence SEE filter all survive the knobs it
+turns off -- so roughly one position in seventy disagrees with its mirror by a
+few centipawns, and *which* positions do depends on the evaluation's actual
+numbers. Adding queen mobility moved one position into that set and it was
+replaced.
+
+This is worth removing rather than curating around. Making `baseDelta` and
+`smallDelta` in `search.cpp` into parameters, so a test can open the aspiration
+window fully, and giving the test a way to run without the table, would turn
+the assertion from a curated observation into something that follows from a
+symmetric evaluation. Until then, expect to re-curate this list whenever the
+evaluation changes, and check eval-level symmetry first: if the position's
+evaluation still equals minus its mirror's, the search residual is the cause.

--- a/docs/revisit-after-tuning.md
+++ b/docs/revisit-after-tuning.md
@@ -22,6 +22,9 @@ course.
 | --- | --- | --- |
 | Connected pawns (`phalanx_pawn_*`, `supported_pawn_*`) | `eval/connected-pawns` | 22 registered entries across four rank-indexed tables. Defaults were chosen to sit in scale with the existing pawn terms, which are unusually small here (isolated 4, doubled 4, backward 1). Check the fitted values are not an order of magnitude off the hand-picked ones; if they are, the pawn terms as a group are probably on the wrong scale. |
 | Queen mobility (`queen_mobility_*`) | `eval/connected-pawns` | 18 of 28 buckets are fit; the rest are coverage gaps. The curve was made deliberately flatter than the rook's on the argument that a cramped queen is not a large loss. That argument is a guess and the fit will either support it or not. |
+| King safety constants (`pawnless_flank_penalty`, `king_storm_penalty`, `king_shelter`) | `fix/king-safety-untunable` | These were literals in the evaluation and are now parameters at exactly the values they had, so nothing about them was ever measured. `king_shelter` in particular spent its life halved by integer division, which means the array's tuned history was fit against a truncated version of itself; treat its current values as arbitrary. The storm penalty ignores how far advanced the storming pawns are, which is the signal that actually matters -- worth adding once the flat version has been fit. |
+| `eval_threats` weights (`threat_by_pawn`, `threat_weak_pawn`, `queen_pin_*`, `discovered_check_bonus`, `restriction_weight`, `skewer_bonus`) | `fix/threat-weights-untunable` | An entire evaluation component that was frozen at unmeasured literals. `restriction_weight` is the one to watch: it multiplies a difference of attacked-square counts that can reach several dozen, so it is the highest-leverage single number in the file and a fit may want it well below 1, which the integer type cannot express. If the fit pushes it to zero, the term probably needs a divisor or the counts need scaling down. |
+| ProbCut (`probcut_min_depth`, `probcut_margin`, `probcut_depth_reduction`) | `feat/probcut` | Search parameters, so SPSA rather than Texel. Measured node-neutral on bench (1884909 -> 1871476) with a 61% cutoff rate on entry, which says the technique works but that the verification search costs about what it saves at these settings. The margin and the reduction are the two knobs that decide whether it pays; if SPSA cannot find a profitable setting, the honest conclusion is that haVoc's tree is too shallow at fixed depth for ProbCut to earn its keep. |
 
 ## Known coverage gaps
 
@@ -38,13 +41,15 @@ sees no gradient for them and they keep their defaults. Listed in
 
 ## Structural issues deliberately not fixed yet
 
-- **`isolated` implies `backward`.** `backward_pawn()` treats a pawn whose
-  neighbouring file is empty as backward, so every isolated pawn is charged
-  both penalties, and both are doubled again on a semi-open file. At the
-  current 1cp backward penalty the Elo cost is negligible, but the two weights
-  are collinear, which is a problem for a fit rather than for play. Separating
-  them changes what the two parameters mean, so it should be done *before* the
-  tuning run whose output anyone intends to keep.
+- **Endgame heuristics are still hardcoded.** `eval_passed_kpk`,
+  `eval_passed_krrk`, `eval_passed_knbk`, `eval_kpk`, `eval_krrk` and
+  `eval_knbk` between them hold thirteen `constexpr` constants -- opposition
+  bonuses, pawn spread bonuses, blockade penalties, advanced passer bonuses --
+  that the tuner cannot see. They were left alone deliberately: they fire only
+  in narrow material configurations that a Texel corpus will barely contain, so
+  registering them would add thirteen parameters with almost no gradient and a
+  matching thirteen entries to the coverage corpus. Revisit if a fit ever has
+  enough endgame data to support them, or if these endgames measure badly.
 - **Terms left unregistered on purpose.** `sq_score_scaling`, `attack_scaling`
   and `mobility_scaling` are all-ones multipliers in front of terms that are
   themselves tuned, so fitting both sides of the product is rank deficient.
@@ -59,7 +64,9 @@ the aspiration window and the quiescence SEE filter all survive the knobs it
 turns off -- so roughly one position in seventy disagrees with its mirror by a
 few centipawns, and *which* positions do depends on the evaluation's actual
 numbers. Adding queen mobility moved one position into that set and it was
-replaced.
+replaced; the tactical motif line-clear fix then moved a different one, which
+was removed with its reasoning written into the list. That is twice in one
+session, which is the argument for fixing the test properly.
 
 This is worth removing rather than curating around. Making `baseDelta` and
 `smallDelta` in `search.cpp` into parameters, so a test can open the aspiration

--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -158,6 +158,18 @@ struct parameters {
     std::vector<int> safe_check_weight{0, 6, 5, 8, 12};
 
     int uncastled_penalty = 5;
+    /// eval_threats weights. Every one of these was a bare literal in the
+    /// evaluation, so none of them could be tuned. The defaults reproduce the
+    /// values that were hardcoded. The three tables are indexed
+    /// 0 = knight, 1 = bishop, 2 = rook, 3 = queen rather than by Piece, so
+    /// that no entry is structurally unreachable.
+    int threat_by_pawn = 1;
+    std::vector<int> threat_weak_pawn{1, 1, 1, 1};
+    int queen_pin_minor = 6;
+    int queen_pin_rook = 18;
+    int discovered_check_bonus = 10;
+    int restriction_weight = 1;
+    std::vector<int> skewer_bonus{4, 6, 8}; // minor, rook, queen skewered
     int connected_rook_bonus = 1;
     int doubled_bishop_bonus = 4;
     int open_file_bonus = 1;

--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -229,10 +229,17 @@ struct parameters {
     //
     // Entries 0 and 7 are unreachable: relative rank 0 is a side's own back
     // rank and 7 is the promotion square, and no pawn ever stands on either.
-    std::array<int, 8> phalanx_pawn_mg = {0, 2, 3, 5, 9, 16, 26, 0};
-    std::array<int, 8> phalanx_pawn_eg = {0, 2, 4, 7, 13, 24, 40, 0};
-    std::array<int, 8> supported_pawn_mg = {0, 2, 3, 4, 6, 10, 16, 0};
-    std::array<int, 8> supported_pawn_eg = {0, 2, 3, 5, 8, 14, 24, 0};
+    // Scaled to haVoc's own pawn structure magnitudes, not to the values these
+    // tables conventionally carry elsewhere. haVoc charges 4 for an isolated
+    // pawn, 4 for a doubled one and 1 for a backward one, so a phalanx bonus
+    // peaking at 40 would have been an order of magnitude larger than every
+    // other pawn term and would simply have overridden them. Measured: at the
+    // conventional scale the term was worth -12.6 +/- 22.9 Elo over 581 games.
+    // The shape is unchanged; only the scale is haVoc's.
+    std::array<int, 8> phalanx_pawn_mg = {0, 0, 1, 1, 2, 4, 6, 0};
+    std::array<int, 8> phalanx_pawn_eg = {0, 1, 1, 2, 3, 6, 10, 0};
+    std::array<int, 8> supported_pawn_mg = {0, 0, 1, 1, 2, 3, 4, 0};
+    std::array<int, 8> supported_pawn_eg = {0, 1, 1, 1, 2, 4, 6, 0};
 
     // Material values
     std::array<int, 6> material_value = {100, 300, 315, 480, 910, 20000};

--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -139,7 +139,17 @@ struct parameters {
     int bishop_own_pawn_penalty_mg = 1;
     int bishop_own_pawn_penalty_eg = 3;
 
-    std::vector<int> king_shelter{-3, -2, 2, 3}; // 0,1,2,3 pawns
+    /// Shelter bonus by the number of own pawns in the king's zone, capped at
+    /// three. These used to be halved at the point of use, which truncated:
+    /// -3 and -2 both became -1, so two distinct parameter values produced an
+    /// identical evaluation and the tuner had no gradient between them. The
+    /// halving is gone and these are the values it produced.
+    std::vector<int> king_shelter{-1, -1, 1, 1}; // 0,1,2,3 pawns
+    /// Charged when the king's flank holds no friendly pawn at all.
+    int pawnless_flank_penalty = 2;
+    /// Charged by the number of enemy pawns bearing down on the king's side of
+    /// the board, capped at three.
+    std::vector<int> king_storm_penalty{0, 0, 2, 4};
     std::vector<int> king_safe_sqs{-4, -2, -1, 0, 0, 1, 2, 4};
 
     /// Danger per square from which an enemy piece could give check without

--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -201,6 +201,26 @@ struct parameters {
     int isolated_pawn_penalty_mg = 4;
     int isolated_pawn_penalty_eg = 4;
 
+    // Connected pawns, indexed by the pawn's rank relative to its own side.
+    // Until these were added the pawn evaluation was made entirely of
+    // penalties -- doubled, isolated, backward, undefended -- with no term
+    // that rewarded a healthy structure. That left the tuner able to express
+    // only "less bad" and never "good", and it biased the evaluation against
+    // having pawns at all.
+    //
+    // Two separate cases rather than one bonus with a hardcoded multiplier,
+    // so that every number here is something Texel can fit:
+    //   phalanx   -- a friendly pawn abreast on an adjacent file
+    //   supported -- a friendly pawn defending this one from behind
+    // A pawn can be both, and then it collects both.
+    //
+    // Entries 0 and 7 are unreachable: relative rank 0 is a side's own back
+    // rank and 7 is the promotion square, and no pawn ever stands on either.
+    std::array<int, 8> phalanx_pawn_mg = {0, 2, 3, 5, 9, 16, 26, 0};
+    std::array<int, 8> phalanx_pawn_eg = {0, 2, 4, 7, 13, 24, 40, 0};
+    std::array<int, 8> supported_pawn_mg = {0, 2, 3, 4, 6, 10, 16, 0};
+    std::array<int, 8> supported_pawn_eg = {0, 2, 3, 5, 8, 14, 24, 0};
+
     // Material values
     std::array<int, 6> material_value = {100, 300, 315, 480, 910, 20000};
 

--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -234,6 +234,9 @@ struct parameters {
     int qs_delta_pawn7th = 775;     // ...widened by this with a pawn near promotion
     int singular_min_depth = 8;     // singular extension minimum depth
     int singular_margin = 2;        // singular beta = ttvalue - margin*depth
+    int probcut_min_depth = 5;      // ProbCut needs at least this much depth
+    int probcut_margin = 180;       // probcut beta = beta + this
+    int probcut_depth_reduction = 4; // verification search depth = depth - this
     int lmr_min_depth = 3;          // late move reductions minimum depth
     int lmr_hist_bad = 2000;        // reduce one extra ply below -this
     int lmr_hist_good = 4000;       // reduce one less ply above this

--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -81,6 +81,19 @@ struct parameters {
                                                  20,  22,  24,  25, 26, 27, 28};
     std::array<int, 15> rook_mobility_table = {0, 1, 2, 3, 5, 6, 8, 9, 10, 11, 13, 14, 15, 17, 18};
 
+    // The queen had no mobility term at all: eval_queens computed its attack
+    // set and stored it into piece_attacks, but never scored how many squares
+    // it actually had. Knight, bishop and rook each had a table and a scale.
+    // A queen on an open board reaches up to 27 squares, so the table is
+    // sized to the widest fan-out any single piece can have. The curve is
+    // deliberately flatter than the rook's: a queen is already worth so much
+    // that being slightly cramped should not read as a large loss, and the
+    // shape is a starting point for tuning rather than a fitted answer.
+    int queen_mobility_scale = 98;
+    std::array<int, 28> queen_mobility_table = {-20, -16, -12, -9, -6, -4, -2, 0, 1,  2,
+                                                3,   4,   5,   6,  7,  8,  9,  9, 10, 10,
+                                                11,  11,  12,  12, 13, 13, 14, 14};
+
     // Square attack bonuses (pawn, knight, bishop, rook, queen)
     std::vector<int> square_attks{7, 4, 3, 2, 1};
 

--- a/src/eval/hce.cpp
+++ b/src/eval/hce.cpp
@@ -951,7 +951,7 @@ template <Color c> int HCEEvaluator::eval_threats(const position& p, einfo& ei) 
     // 1. Pieces under attack by pawns
     auto attackedByPawns = enemies & pawnAttacks;
     if (attackedByPawns != 0ULL)
-        score += 1;
+        score += params_.threat_by_pawn;
 
     // 2. Hanging pieces under attack
     auto defendendEnemies = enemies & (enemyPawnAttacks | enemyPieceAttacks);
@@ -975,14 +975,14 @@ template <Color c> int HCEEvaluator::eval_threats(const position& p, einfo& ei) 
     auto defendendWeakPawns = weakPawns & (enemyPawnAttacks | enemyPieceAttacks);
     auto undefendendWeakPawns = weakPawns ^ defendendWeakPawns;
     if (undefendendWeakPawns) {
-        if (undefendendWeakPawns & ei.piece_attacks[c][knight])
-            score += bits::count(undefendendWeakPawns & ei.piece_attacks[c][knight]);
-        if (undefendendWeakPawns & ei.piece_attacks[c][bishop])
-            score += bits::count(undefendendWeakPawns & ei.piece_attacks[c][bishop]);
-        if (undefendendWeakPawns & ei.piece_attacks[c][rook])
-            score += bits::count(undefendendWeakPawns & ei.piece_attacks[c][rook]);
-        if (undefendendWeakPawns & ei.piece_attacks[c][queen])
-            score += bits::count(undefendendWeakPawns & ei.piece_attacks[c][queen]);
+        score += params_.threat_weak_pawn[0] *
+                 bits::count(undefendendWeakPawns & ei.piece_attacks[c][knight]);
+        score += params_.threat_weak_pawn[1] *
+                 bits::count(undefendendWeakPawns & ei.piece_attacks[c][bishop]);
+        score += params_.threat_weak_pawn[2] *
+                 bits::count(undefendendWeakPawns & ei.piece_attacks[c][rook]);
+        score += params_.threat_weak_pawn[3] *
+                 bits::count(undefendendWeakPawns & ei.piece_attacks[c][queen]);
     }
 
     // 4. Pieces pinned to queen
@@ -1000,7 +1000,7 @@ template <Color c> int HCEEvaluator::eval_threats(const position& p, einfo& ei) 
             if (pinnedByRook && bits::count(pinnedByRook) == 1) {
                 auto pp = p.piece_on(Square(bits::pop_lsb(pinnedByRook)));
                 if (pp == bishop || pp == knight)
-                    score += 6;
+                    score += params_.queen_pin_minor;
             }
         }
         while (bishopPinners) {
@@ -1010,9 +1010,9 @@ template <Color c> int HCEEvaluator::eval_threats(const position& p, einfo& ei) 
             if (pinnedByBishop && bits::count(pinnedByBishop) == 1) {
                 auto pp = p.piece_on(Square(bits::pop_lsb(pinnedByBishop)));
                 if (pp == knight)
-                    score += 6;
+                    score += params_.queen_pin_minor;
                 if (pp == rook)
-                    score += 18;
+                    score += params_.queen_pin_rook;
             }
         }
     }
@@ -1029,7 +1029,7 @@ template <Color c> int HCEEvaluator::eval_threats(const position& p, einfo& ei) 
         auto between = bitboards::between[bishopSq][enemyKing] & (ourRooks | ourKnights);
         if (between && bits::count(between) == 1) {
             hasDiscovery = true;
-            score += 10;
+            score += params_.discovered_check_bonus;
         }
     }
     while (rookCheckers && !hasDiscovery) {
@@ -1037,7 +1037,7 @@ template <Color c> int HCEEvaluator::eval_threats(const position& p, einfo& ei) 
         auto between = bitboards::between[rookSq][enemyKing] & (ourBishops | ourKnights);
         if (between && bits::count(between) == 1) {
             hasDiscovery = true;
-            score += 10;
+            score += params_.discovered_check_bonus;
         }
     }
     auto queenCheckers = (bitboards::rattks[enemyKing] | bitboards::battks[enemyKing]) & ourQueens;
@@ -1046,14 +1046,14 @@ template <Color c> int HCEEvaluator::eval_threats(const position& p, einfo& ei) 
         auto between = bitboards::between[queenSq][enemyKing] & ourKnights;
         if (between && bits::count(between) == 1) {
             hasDiscovery = true;
-            score += 10;
+            score += params_.discovered_check_bonus;
         }
     }
 
     // 6. Restriction
     auto ourAttacks = pawnAttacks | ourPieceAttacks;
     auto theirAttacks = enemyPawnAttacks | enemyPieceAttacks;
-    score += bits::count(ourAttacks) - bits::count(theirAttacks);
+    score += params_.restriction_weight * (bits::count(ourAttacks) - bits::count(theirAttacks));
 
     // 7. Skewer detection
     bishopCheckers = bitboards::battks[enemyKing] & ourBishops;
@@ -1072,11 +1072,11 @@ template <Color c> int HCEEvaluator::eval_threats(const position& p, einfo& ei) 
             if (between && bits::count(between) == 1) {
                 auto pp = p.piece_on(Square(enemy));
                 if (pp == bishop || pp == knight)
-                    score += 4;
+                    score += params_.skewer_bonus[0];
                 if (pp == rook)
-                    score += 6;
+                    score += params_.skewer_bonus[1];
                 if (pp == queen)
-                    score += 8;
+                    score += params_.skewer_bonus[2];
             }
         }
     }

--- a/src/eval/hce.cpp
+++ b/src/eval/hce.cpp
@@ -731,6 +731,26 @@ template <Color c> int HCEEvaluator::eval_queens(const position& p, einfo& ei) {
             magics::attacks<bishop>(ei.all_pieces, s) | magics::attacks<rook>(ei.all_pieces, s);
         ei.piece_attacks[c][queen] |= mvs;
 
+        // The attack set above was computed and stored but never scored, so
+        // the queen was the one piece whose mobility did not count. Safe
+        // squares are the empty ones the enemy pawns do not cover, the same
+        // definition the rook uses.
+        {
+            U64 mobility = (mvs & ei.empty) & (~ei.pe->attacks[them]);
+            int free_sqs = bits::count(mobility);
+            int mob_q = (static_cast<unsigned>(free_sqs) < params_.queen_mobility_table.size())
+                            ? params_.queen_mobility_table[free_sqs]
+                            : params_.queen_mobility_table.back();
+            int mobility_score =
+                ((params_.queen_mobility_scale * params_.mobility_scaling[queen] * mob_q) / 100) *
+                ei.me->taper(params_.mobility_category_scale, params_.mobility_endgame_scale) / 100;
+
+            if (bitboards::squares[s] & p.pinned<c>())
+                mobility_score /= params_.pinned_scaling[queen];
+
+            score += mobility_score;
+        }
+
         // Weak queen penalty
         U64 attackers = p.attackers_of2(s, them) & weakEnemies;
         score -= bits::count(attackers);

--- a/src/eval/hce.cpp
+++ b/src/eval/hce.cpp
@@ -102,6 +102,13 @@ constexpr U64 kLongDiagonals = [] {
 /// starting position at any depth. Giving the score a gradient -- drive the
 /// defending king to the edge, and walk the attacking king in behind it --
 /// turns the plateau into a hill, which is all the search needs to find mate.
+/// Squares strictly between two aligned squares. bitboards::between includes
+/// both endpoints, so every caller that wants to know whether a line is clear
+/// has to strip them first.
+inline U64 strictly_between(int a, int b) {
+    return bitboards::between[a][b] & ~bitboards::squares[a] & ~bitboards::squares[b];
+}
+
 inline int eval_bare_king(const position& p, Color strong, const parameters& params) {
     const int sk = static_cast<int>(p.king_square(strong));
     const int wk = static_cast<int>(p.king_square(strong == white ? black : white));
@@ -995,24 +1002,32 @@ template <Color c> int HCEEvaluator::eval_threats(const position& p, einfo& ei) 
         auto bishopPinners = bitboards::battks[queenSq] & ourBishops;
         while (rookPinners) {
             auto rookSq = bits::pop_lsb(rookPinners);
-            auto betweenMask = bitboards::between[rookSq][queenSq];
-            auto pinnedByRook = (enemies & betweenMask) ^ bitboards::squares[queenSq];
-            if (pinnedByRook && bits::count(pinnedByRook) == 1) {
-                auto pp = p.piece_on(Square(bits::pop_lsb(pinnedByRook)));
-                if (pp == bishop || pp == knight)
-                    score += params_.queen_pin_minor;
+            // Every piece on the line matters, not just the enemy's non-pawn
+            // pieces. Masking with `enemies` alone made a pawn of either
+            // colour, or one of our own pieces, invisible, so the term fired
+            // on lines that were not pins at all.
+            U64 blockers = strictly_between(rookSq, queenSq) & ei.all_pieces;
+            if (bits::count(blockers) == 1) {
+                auto sq = Square(bits::lsb(blockers));
+                if (bitboards::squares[sq] & ei.pieces[them]) {
+                    auto pp = p.piece_on(sq);
+                    if (pp == bishop || pp == knight)
+                        score += params_.queen_pin_minor;
+                }
             }
         }
         while (bishopPinners) {
             auto bishopSq = bits::pop_lsb(bishopPinners);
-            auto betweenMask = bitboards::between[bishopSq][queenSq];
-            auto pinnedByBishop = (enemies & betweenMask) ^ bitboards::squares[queenSq];
-            if (pinnedByBishop && bits::count(pinnedByBishop) == 1) {
-                auto pp = p.piece_on(Square(bits::pop_lsb(pinnedByBishop)));
-                if (pp == knight)
-                    score += params_.queen_pin_minor;
-                if (pp == rook)
-                    score += params_.queen_pin_rook;
+            U64 blockers = strictly_between(bishopSq, queenSq) & ei.all_pieces;
+            if (bits::count(blockers) == 1) {
+                auto sq = Square(bits::lsb(blockers));
+                if (bitboards::squares[sq] & ei.pieces[them]) {
+                    auto pp = p.piece_on(sq);
+                    if (pp == knight)
+                        score += params_.queen_pin_minor;
+                    if (pp == rook)
+                        score += params_.queen_pin_rook;
+                }
             }
         }
     }
@@ -1026,16 +1041,16 @@ template <Color c> int HCEEvaluator::eval_threats(const position& p, einfo& ei) 
     auto ourKnights = p.get_pieces<c, knight>();
     while (bishopCheckers && !hasDiscovery) {
         auto bishopSq = bits::pop_lsb(bishopCheckers);
-        auto between = bitboards::between[bishopSq][enemyKing] & (ourRooks | ourKnights);
-        if (between && bits::count(between) == 1) {
+        U64 blockers = strictly_between(bishopSq, enemyKing) & ei.all_pieces;
+        if (bits::count(blockers) == 1 && (blockers & (ourRooks | ourKnights))) {
             hasDiscovery = true;
             score += params_.discovered_check_bonus;
         }
     }
     while (rookCheckers && !hasDiscovery) {
         auto rookSq = bits::pop_lsb(rookCheckers);
-        auto between = bitboards::between[rookSq][enemyKing] & (ourBishops | ourKnights);
-        if (between && bits::count(between) == 1) {
+        U64 blockers = strictly_between(rookSq, enemyKing) & ei.all_pieces;
+        if (bits::count(blockers) == 1 && (blockers & (ourBishops | ourKnights))) {
             hasDiscovery = true;
             score += params_.discovered_check_bonus;
         }
@@ -1043,8 +1058,8 @@ template <Color c> int HCEEvaluator::eval_threats(const position& p, einfo& ei) 
     auto queenCheckers = (bitboards::rattks[enemyKing] | bitboards::battks[enemyKing]) & ourQueens;
     while (queenCheckers && !hasDiscovery) {
         auto queenSq = bits::pop_lsb(queenCheckers);
-        auto between = bitboards::between[queenSq][enemyKing] & ourKnights;
-        if (between && bits::count(between) == 1) {
+        U64 blockers = strictly_between(queenSq, enemyKing) & ei.all_pieces;
+        if (bits::count(blockers) == 1 && (blockers & ourKnights)) {
             hasDiscovery = true;
             score += params_.discovered_check_bonus;
         }
@@ -1068,8 +1083,8 @@ template <Color c> int HCEEvaluator::eval_threats(const position& p, einfo& ei) 
         U64 ep_copy = enemyPieces;
         while (ep_copy) {
             auto enemy = bits::pop_lsb(ep_copy);
-            auto between = bitboards::between[bishopSq][enemy] & enemyKingSq;
-            if (between && bits::count(between) == 1) {
+            U64 blockers = strictly_between(bishopSq, enemy) & ei.all_pieces;
+            if (bits::count(blockers) == 1 && (blockers & enemyKingSq)) {
                 auto pp = p.piece_on(Square(enemy));
                 if (pp == bishop || pp == knight)
                     score += params_.skewer_bonus[0];

--- a/src/eval/hce.cpp
+++ b/src/eval/hce.cpp
@@ -879,12 +879,12 @@ template <Color c> int HCEEvaluator::eval_king(const position& p, einfo& ei) {
             // against wherever the king stood when that entry was filled.
             U64 pawn_shelter = p.get_pieces<c, pawn>() & ei.kmask[c];
             int n = std::min(3, bits::count(pawn_shelter));
-            int shelter = params_.king_shelter[n] / 2;
+            int shelter = params_.king_shelter[n];
 
             // Pawnless flank penalty
             U64 kflank = bitboards::kflanks[util::col(s)] & p.get_pieces<c, pawn>();
             if (!kflank)
-                shelter -= 2;
+                shelter -= params_.pawnless_flank_penalty;
 
             score += (shelter * mg) / material_entry::kPhaseMax;
         }
@@ -896,12 +896,7 @@ template <Color c> int HCEEvaluator::eval_king(const position& p, einfo& ei) {
             auto pawnStormMask = bitboards::kpawnstorm[c][!(util::col(s) >= Col::E)];
             auto pawnStorm = pawnStormMask & enemyPawns;
             auto numAttackers = bits::count(pawnStorm);
-            int storm = 0;
-            if (numAttackers >= 2) {
-                storm -= 2;
-                if (numAttackers >= 3)
-                    storm -= 2;
-            }
+            int storm = -params_.king_storm_penalty[std::min(3, numAttackers)];
             score += (storm * mg) / material_entry::kPhaseMax;
         }
     }

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -158,9 +158,19 @@ std::vector<std::pair<std::string, int*>> parameters::all_params(TuneStage stage
         // King shelter
         for (size_t i = 0; i < king_shelter.size(); ++i)
             result.emplace_back("king_shelter_" + std::to_string(i), &king_shelter[i]);
-        result.emplace_back("pawnless_flank_penalty", &pawnless_flank_penalty);
-        for (size_t i = 0; i < king_storm_penalty.size(); ++i)
+        result.emplace_back("pawnless_flank_penalty", &pawnless_flank_penalty);        for (size_t i = 0; i < king_storm_penalty.size(); ++i)
             result.emplace_back("king_storm_penalty_" + std::to_string(i), &king_storm_penalty[i]);
+
+        // eval_threats weights, all of which used to be bare literals.
+        result.emplace_back("threat_by_pawn", &threat_by_pawn);
+        for (size_t i = 0; i < threat_weak_pawn.size(); ++i)
+            result.emplace_back("threat_weak_pawn_" + std::to_string(i), &threat_weak_pawn[i]);
+        result.emplace_back("queen_pin_minor", &queen_pin_minor);
+        result.emplace_back("queen_pin_rook", &queen_pin_rook);
+        result.emplace_back("discovered_check_bonus", &discovered_check_bonus);
+        result.emplace_back("restriction_weight", &restriction_weight);
+        for (size_t i = 0; i < skewer_bonus.size(); ++i)
+            result.emplace_back("skewer_bonus_" + std::to_string(i), &skewer_bonus[i]);
 
         // King safe squares
         for (size_t i = 0; i < king_safe_sqs.size(); ++i)

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -158,6 +158,9 @@ std::vector<std::pair<std::string, int*>> parameters::all_params(TuneStage stage
         // King shelter
         for (size_t i = 0; i < king_shelter.size(); ++i)
             result.emplace_back("king_shelter_" + std::to_string(i), &king_shelter[i]);
+        result.emplace_back("pawnless_flank_penalty", &pawnless_flank_penalty);
+        for (size_t i = 0; i < king_storm_penalty.size(); ++i)
+            result.emplace_back("king_storm_penalty_" + std::to_string(i), &king_storm_penalty[i]);
 
         // King safe squares
         for (size_t i = 0; i < king_safe_sqs.size(); ++i)

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -266,6 +266,24 @@ std::vector<std::pair<std::string, int*>> parameters::all_params(TuneStage stage
         result.emplace_back("trapped_rook_mg", &trapped_rook_penalty[0]);
         result.emplace_back("trapped_rook_eg", &trapped_rook_penalty[1]);
 
+        // Connected pawns, by rank relative to the pawn's own side. Relative
+        // rank 0 is that side's back rank and 7 is the promotion square; a
+        // pawn stands on neither, so those two entries have no reader.
+        //
+        // The supported tables start at 2 rather than 1 for a second reason: a
+        // pawn on relative rank 1 is on its own second rank, and the pawns
+        // that would defend it would have to stand on the first rank, where no
+        // pawn can ever be. Relative rank 1 is reachable for a phalanx, which
+        // only needs a neighbour abreast.
+        for (size_t r = 1; r < 7; ++r) {
+            result.emplace_back("phalanx_pawn_mg_" + std::to_string(r), &phalanx_pawn_mg[r]);
+            result.emplace_back("phalanx_pawn_eg_" + std::to_string(r), &phalanx_pawn_eg[r]);
+            if (r >= 2) {
+                result.emplace_back("supported_pawn_mg_" + std::to_string(r), &supported_pawn_mg[r]);
+                result.emplace_back("supported_pawn_eg_" + std::to_string(r), &supported_pawn_eg[r]);
+            }
+        }
+
         // Deliberately NOT registered, and not oversights:
         //
         //   sq_score_scaling, attack_scaling, mobility_scaling -- all-ones

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -119,6 +119,7 @@ std::vector<std::pair<std::string, int*>> parameters::all_params(TuneStage stage
         result.emplace_back("knight_mobility_scale", &knight_mobility_scale);
         result.emplace_back("bishop_mobility_scale", &bishop_mobility_scale);
         result.emplace_back("rook_mobility_scale", &rook_mobility_scale);
+        result.emplace_back("queen_mobility_scale", &queen_mobility_scale);
 
         // Mobility curve entries
         for (size_t i = 0; i < knight_mobility_table.size(); ++i)
@@ -130,6 +131,9 @@ std::vector<std::pair<std::string, int*>> parameters::all_params(TuneStage stage
         for (size_t i = 0; i < rook_mobility_table.size(); ++i)
             result.emplace_back("rook_mobility_" + std::to_string(i),
                                 &rook_mobility_table[i]);
+        for (size_t i = 0; i < queen_mobility_table.size(); ++i)
+            result.emplace_back("queen_mobility_" + std::to_string(i),
+                                &queen_mobility_table[i]);
 
         // Endgame scaling
         result.emplace_back("opposite_bishop_scale", &opposite_bishop_scale);

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -309,6 +309,9 @@ std::vector<std::pair<std::string, int*>> parameters::all_params(TuneStage stage
     result.emplace_back("qs_delta_pawn7th", &qs_delta_pawn7th);
         result.emplace_back("singular_min_depth", &singular_min_depth);
         result.emplace_back("singular_margin", &singular_margin);
+        result.emplace_back("probcut_min_depth", &probcut_min_depth);
+        result.emplace_back("probcut_margin", &probcut_margin);
+        result.emplace_back("probcut_depth_reduction", &probcut_depth_reduction);
         result.emplace_back("lmr_min_depth", &lmr_min_depth);
         result.emplace_back("lmr_hist_bad", &lmr_hist_bad);
         result.emplace_back("lmr_hist_good", &lmr_hist_good);

--- a/src/pawn_table.cpp
+++ b/src/pawn_table.cpp
@@ -101,6 +101,11 @@ struct pawn_score {
         mg = static_cast<int16_t>(mg - v_mg);
         eg = static_cast<int16_t>(eg - v_eg);
     }
+    /// Add a bonus that differs between the middlegame and the endgame.
+    void add(int v_mg, int v_eg) {
+        mg = static_cast<int16_t>(mg + v_mg);
+        eg = static_cast<int16_t>(eg + v_eg);
+    }
 };
 
 template <Color c> pawn_score evaluate_pawns(const position& p, pawn_entry& e, const parameters& par) {
@@ -137,6 +142,20 @@ template <Color c> pawn_score evaluate_pawns(const position& p, pawn_entry& e, c
         if (defenders == 0ULL) {
             score -= 1;
             e.undefended[c] |= fbb;
+        }
+
+        // Connected pawns. `defenders` above is exactly the set of friendly
+        // pawns defending this square, so support costs nothing extra to
+        // detect; a phalanx is a friendly pawn on an adjacent file and the
+        // same rank. Both are scored by the pawn's rank relative to its own
+        // side, since a connected pair matters more the further it has
+        // advanced. A pawn that is both defended and abreast collects both.
+        {
+            int rel_rank = (c == white ? row : 7 - row);
+            if (bitboards::neighbor_cols[col_idx] & pawns & bitboards::row[row])
+                score.add(par.phalanx_pawn_mg[rel_rank], par.phalanx_pawn_eg[rel_rank]);
+            if (defenders)
+                score.add(par.supported_pawn_mg[rel_rank], par.supported_pawn_eg[rel_rank]);
         }
 
         // Passed pawns

--- a/src/pawn_table.cpp
+++ b/src/pawn_table.cpp
@@ -147,17 +147,24 @@ template <Color c> pawn_score evaluate_pawns(const position& p, pawn_entry& e, c
 
         // Isolated pawns
         U64 neighbors_bb = bitboards::neighbor_cols[col_idx] & pawns;
-        if (neighbors_bb == 0ULL) {
+        const bool is_isolated = (neighbors_bb == 0ULL);
+        if (is_isolated) {
             e.isolated[c] |= fbb;
             score.sub(par.isolated_pawn_penalty_mg, par.isolated_pawn_penalty_eg);
-
         }
 
-        // Backward pawns
-        if (backward_pawn<c>(row, col_idx, pawns)) {
+        // Backward pawns. An isolated pawn trivially satisfies the backward
+        // test (no neighbour can ever defend it), so charging both would levy
+        // two penalties for one weakness and make the two weights collinear --
+        // a tuner can then only ever fit their sum. The bitboard still records
+        // it, because the square in front of an isolated pawn is just as much
+        // a hole as the one in front of a backward pawn and the outpost code
+        // reads that; only the penalty is made exclusive.
+        const bool is_backward = backward_pawn<c>(row, col_idx, pawns);
+        if (is_backward) {
             e.backward[c] |= fbb;
-            score.sub(par.backward_pawn_penalty_mg, par.backward_pawn_penalty_eg);
-
+            if (!is_isolated)
+                score.sub(par.backward_pawn_penalty_mg, par.backward_pawn_penalty_eg);
         }
 
         // Square color
@@ -179,7 +186,7 @@ template <Color c> pawn_score evaluate_pawns(const position& p, pawn_entry& e, c
         // Semi-open files
         U64 column = bitboards::col[col_idx];
         if ((column & epawns) == 0ULL) {
-            if (fbb & e.backward[c])
+            if ((fbb & e.backward[c]) && !is_isolated)
                 score.sub(2 * par.backward_pawn_penalty_mg, 2 * par.backward_pawn_penalty_eg);
             if (fbb & e.isolated[c])
                 score.sub(2 * par.isolated_pawn_penalty_mg, 2 * par.isolated_pawn_penalty_eg);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -686,6 +686,80 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
         }
     }
 
+    // ProbCut. If a capture, searched shallowly, already beats beta by a wide
+    // margin, it is very likely that a full-depth search would also fail high,
+    // so the whole node can be cut. The margin is what makes this safe: a
+    // shallow search that only just reaches beta proves nothing, but one that
+    // clears beta + margin has room for the shallow search to be wrong by a
+    // piece and still be right about the cutoff.
+    //
+    // Only captures are tried. Quiet moves rarely swing a score by a margin
+    // this large in a few plies, so searching them here would cost nodes
+    // without producing cutoffs.
+    const int probcut_beta = beta + params_.probcut_margin;
+    if (!pvNode && !in_check && !singular_search && hasStaticValue &&
+        depth >= params_.probcut_min_depth && std::abs(beta) < score::kMateMaxPly &&
+        probcut_beta < score::kMateMaxPly &&
+        // If the table already knows, from a search deep enough to be worth
+        // more than the verification search below, that this node does not
+        // reach probcut_beta, the verification cannot be trusted over it.
+        !(ttvalue != score::kNegInf && tt_depth >= depth - params_.probcut_depth_reduction &&
+          ttvalue < probcut_beta)) {
+
+        // A capture can only reach probcut_beta if the material it wins covers
+        // the gap between the static eval and that bound.
+        const int see_threshold = probcut_beta - static_eval_val;
+        const int probcut_depth = static_cast<int>(depth) - params_.probcut_depth_reduction;
+
+        Moveorder pc_mvs(pos, ttm, stack, &history_);
+        Move pc_move;
+        Move pc_prev = (stack - 1)->curr_move;
+        Move pc_prevprev = (stack - 2)->curr_move;
+
+        while (pc_mvs.next_move(pos, pc_move, pc_prev, pc_prevprev, stack->threat_move,
+                                /*skipQuiets=*/true, /*rootMvs=*/false)) {
+            if (signals_.stop.load())
+                return score::kDraw;
+            if (pc_move.type == static_cast<U8>(no_type) || pc_move == excluded_move)
+                continue;
+            // skipQuiets still lets the hash move and the killers through, and
+            // those are usually quiet, so the capture test cannot be skipped.
+            const bool pc_is_capture = (pc_move.type == static_cast<U8>(capture)) ||
+                                       (pc_move.type == static_cast<U8>(ep)) ||
+                                       pos.is_cap_promotion(static_cast<Movetype>(pc_move.type));
+            if (!pc_is_capture || !pos.is_legal(pc_move))
+                continue;
+            if (pos.see(pc_move) < see_threshold)
+                continue;
+
+            pos.do_move(pc_move);
+            stack->curr_move = pc_move;
+
+            // Qsearch first: it is nearly free and rejects most candidates, so
+            // the expensive verification only runs on moves that survive it.
+            int pc_score =
+                -qsearch<non_pv>(pos, -probcut_beta, -probcut_beta + 1, 0, stack + 1, thread_id);
+            if (pc_score >= probcut_beta && probcut_depth > 0) {
+                pc_score = -search<non_pv>(pos, -probcut_beta, -probcut_beta + 1,
+                                           static_cast<U16>(probcut_depth), stack + 1, thread_id);
+            }
+            pos.undo_move(pc_move);
+
+            if (signals_.stop.load())
+                return score::kDraw;
+
+            if (pc_score >= probcut_beta) {
+                // The verification searched probcut_depth plies below this
+                // node, plus the one this move consumed, so the entry is worth
+                // that much depth -- not `depth`, which was never searched.
+                tt_.save(pos.key(), static_cast<U8>(std::max(0, probcut_depth) + 1),
+                         static_cast<U8>(bound_low), pc_move, score_to_tt(pc_score, stack->ply),
+                         pvNode);
+                return pc_score;
+            }
+        }
+    }
+
     // Main search
     U16 moves_searched = 0;
     Moveorder mvs(pos, ttm, stack, &history_);

--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -1207,6 +1207,19 @@ TEST_F(EvalTest, EveryTunableParameterReachesTheEvaluation) {
         "7n/p7/8/8/3k4/8/6K1/B7 b - - 0 1",
         "7r/8/8/8/3k4/8/6K1/B7 b - - 0 1",
         "7q/8/8/8/3k4/8/6K1/B7 b - - 0 1",
+        // Connected pawns, reached by rank relative to the mover. Black has no
+        // pawns in any of these, so the term cannot cancel between the sides.
+        // The first has both sides' full non-pawn material, so the phase sits
+        // at the middlegame end and the mg halves of the tables are what move;
+        // the second is the same pawn structure with the pieces stripped, so
+        // the phase sits at the endgame end and the eg halves move instead.
+        // a5/b5, c6/d6 and e7/f7 are phalanxes on relative ranks 4, 5 and 6;
+        // h5 is supported by g4, c6 by b5 and e7 by d6.
+        "rnbqkbnr/4PP2/2PP4/PP5P/6P1/8/8/RNBQKBNR w KQkq - 0 1",
+        "4k3/4PP2/2PP4/PP5P/6P1/8/8/4K3 w - - 0 1",
+        // A bare endgame reaching the low ranks: b3/c3 is a phalanx on
+        // relative rank 2 and d4 is supported by c3 on relative rank 3.
+        "4k3/8/8/8/3P4/1PP5/8/4K3 w - - 0 1",
     };
 
     // The pawn and material caches are keyed on structure, not on parameter

--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -51,6 +51,7 @@ using havoc::testing::mirror_fen;
 /// opposite-colored bishops and a range of endgames.
 const std::vector<std::string>& mirror_test_positions() {
     static const std::vector<std::string> fens = {
+        "r1bq1rk1/pp2ppbp/2np1np1/8/2PNP3/2N1B3/PP2BPPP/R2QK2R w KQ - 0 9",
         "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
         "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",
         // Direct proof that this position's evaluation is symmetric. It is the
@@ -1301,6 +1302,14 @@ TEST_F(EvalTest, EveryTunableParameterReachesTheEvaluation) {
         "knight_mobility_0", "knight_mobility_6", "knight_mobility_7", "knight_mobility_8",
         "bishop_mobility_5", "bishop_mobility_9", "bishop_mobility_11", "bishop_mobility_12",
         "bishop_mobility_14", "rook_mobility_3", "rook_mobility_11", "rook_mobility_13",
+        // The queen's buckets gap the same way the other three pieces do. The
+        // wide end is the interesting part: reaching bucket 23 and above needs
+        // a queen with that many *safe* empty squares at once, and adding
+        // open-board positions specifically to chase it moved none of them,
+        // because the king and the remaining pawns keep the real count lower.
+        "queen_mobility_5", "queen_mobility_10", "queen_mobility_11", "queen_mobility_15",
+        "queen_mobility_17", "queen_mobility_23", "queen_mobility_24", "queen_mobility_25",
+        "queen_mobility_26", "queen_mobility_27",
         "attacker_weight_1", "king_shelter_0", "king_shelter_3", "king_safe_sqs_0",
         "king_safe_sqs_4", "king_safe_sqs_5", "king_safe_sqs_6", "king_safe_sqs_7",
         "no_pawn_scale", "minor_advantage_no_pawn_scale",

--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -1172,6 +1172,14 @@ TEST_F(EvalTest, EveryTunableParameterReachesTheEvaluation) {
         "k7/8/8/1p1p1p1p/1N1N1N1N/8/8/K7 w - - 0 1",
         "7k/8/8/p1p1p1p1/B1B1B1B1/8/8/7K w - - 0 1",
         "k7/8/8/1p1p1p1p/1B1B1B1B/8/8/K7 w - - 0 1",
+        // Three enemy pawns storming the king's flank, the top entry of
+        // king_storm_penalty. White's king is on the kingside with Black's f,
+        // g and h pawns advancing on it, while Black's king sits on the
+        // opposite flank where White has nothing storming, so the two sides do
+        // not cancel. The queens and rooks are there to keep the middlegame
+        // weight high enough for the term, which tapers to nothing in the
+        // endgame, to survive the phase interpolation.
+        "k6r/7q/8/8/5ppp/8/PP3PPP/R2Q2K1 w - - 0 1",
     };
 
     // The pawn and material caches are keyed on structure, not on parameter

--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -1180,6 +1180,26 @@ TEST_F(EvalTest, EveryTunableParameterReachesTheEvaluation) {
         // weight high enough for the term, which tapers to nothing in the
         // endgame, to survive the phase interpolation.
         "k6r/7q/8/8/5ppp/8/PP3PPP/R2Q2K1 w - - 0 1",
+        // eval_threats tactical motifs. Each gives the motif to White only,
+        // and in every case Black lacks the piece that would let it score the
+        // mirror image, so the weight cannot cancel across the subtraction.
+        // A rook pinning a knight against the enemy queen.
+        "k3q3/8/8/4n3/8/8/8/4R1K1 w - - 0 1",
+        // A bishop pinning a rook against the enemy queen, which is scored
+        // more heavily than a pinned minor.
+        "k6q/8/8/8/3r4/8/8/B5K1 w - - 0 1",
+        // A discovered check: the knight stands between the bishop and the
+        // enemy king, so moving it uncovers the check. Black needs the a7
+        // pawn -- a bare enemy king diverts the evaluation into the mating
+        // heuristic, which never runs eval_threats at all.
+        "7k/p7/8/8/3N4/8/6K1/B7 w - - 0 1",
+        // Skewers, by the value of the piece standing behind the king. The
+        // b2 pawn blocks the diagonal so that the king is not actually in
+        // check, which would make the position illegal with White to move;
+        // the term reads pseudo-attacks and is unaffected by the blocker.
+        "7n/8/8/8/3k4/8/1P4K1/B7 w - - 0 1",
+        "7r/8/8/8/3k4/8/1P4K1/B7 w - - 0 1",
+        "7q/8/8/8/3k4/8/1P4K1/B7 w - - 0 1",
     };
 
     // The pawn and material caches are keyed on structure, not on parameter

--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -53,6 +53,13 @@ const std::vector<std::string>& mirror_test_positions() {
     static const std::vector<std::string> fens = {
         "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
         "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",
+        // Direct proof that this position's evaluation is symmetric. It is the
+        // one ExactSearchIsMirrorSymmetric currently disagrees on, and that
+        // test documents its own residual: the transposition table, the
+        // aspiration window and the qsearch SEE filter all survive the knobs
+        // it turns off. Keeping the FEN here means that if a real asymmetry is
+        // ever introduced, this test catches it rather than the search one.
+        "2rq1rk1/pp1bppbp/3p1np1/8/3NP3/1BN1BP2/PPPQ2PP/2KR3R w - - 0 1",
         "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1",
         "r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1",
         "rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8",
@@ -1194,12 +1201,12 @@ TEST_F(EvalTest, EveryTunableParameterReachesTheEvaluation) {
         // heuristic, which never runs eval_threats at all.
         "7k/p7/8/8/3N4/8/6K1/B7 w - - 0 1",
         // Skewers, by the value of the piece standing behind the king. The
-        // b2 pawn blocks the diagonal so that the king is not actually in
-        // check, which would make the position illegal with White to move;
-        // the term reads pseudo-attacks and is unaffected by the blocker.
-        "7n/8/8/8/3k4/8/1P4K1/B7 w - - 0 1",
-        "7r/8/8/8/3k4/8/1P4K1/B7 w - - 0 1",
-        "7q/8/8/8/3k4/8/1P4K1/B7 w - - 0 1",
+        // diagonal has to be genuinely clear -- a blocker on it means there
+        // is no skewer -- which puts the enemy king in check, so these are
+        // Black to move rather than White.
+        "7n/p7/8/8/3k4/8/6K1/B7 b - - 0 1",
+        "7r/8/8/8/3k4/8/6K1/B7 b - - 0 1",
+        "7q/8/8/8/3k4/8/6K1/B7 b - - 0 1",
     };
 
     // The pawn and material caches are keyed on structure, not on parameter

--- a/tests/test_search.cpp
+++ b/tests/test_search.cpp
@@ -635,7 +635,17 @@ TEST_F(SearchTest, QuiescenceIsMirrorSymmetricOverRandomPlay) {
 
 const std::vector<std::string> kSymmetryPositions = {
     "r1bqkbnr/pppp1ppp/2n5/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 4 4",
-    "r1bq1rk1/pp2ppbp/2np1np1/8/2PNP3/2N1B3/PP2BPPP/R2QK2R w KQ - 0 9",
+    // This slot held r1bq1rk1/pp2ppbp/2np1np1/8/2PNP3/2N1B3/PP2BPPP/R2QK2R,
+    // which stopped agreeing with its mirror by 2cp once the queen gained a
+    // mobility term. That is curation, not a symmetry bug: the evaluation of
+    // that exact position is bit-for-bit equal to minus the evaluation of its
+    // mirror, which is now asserted directly in the eval mirror corpus in
+    // test_eval.cpp, and the mirror tests over a thousand random positions
+    // still pass. The residual is the one documented below -- the table, the
+    // aspiration window and the quiescence filter all survive the knobs that
+    // exact_search_score turns off -- so which positions come out clean
+    // depends on the evaluation's actual numbers and moves when they do.
+    "r1bq1rk1/ppp2ppp/2np1n2/2b1p3/2B1P3/2NP1N2/PPP2PPP/R1BQ1RK1 w - - 0 1",
     "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1",
     "4rrk1/pp1n1ppp/2p1bn2/q7/3P4/2NBPN2/PP3PPP/R2Q1RK1 w - - 0 1",
     "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",

--- a/tests/test_search.cpp
+++ b/tests/test_search.cpp
@@ -639,7 +639,16 @@ const std::vector<std::string> kSymmetryPositions = {
     "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1",
     "4rrk1/pp1n1ppp/2p1bn2/q7/3P4/2NBPN2/PP3PPP/R2Q1RK1 w - - 0 1",
     "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",
-    "2rq1rk1/pp1bppbp/3p1np1/8/3NP3/1BN1BP2/PPPQ2PP/2KR3R w - - 0 1",
+    // 2rq1rk1/pp1bppbp/3p1np1/8/3NP3/1BN1BP2/PPPQ2PP/2KR3R belongs here by
+    // theme but is deliberately absent. This list is a curated sample, not a
+    // theorem: exact_search_score cannot turn off the transposition table, the
+    // aspiration window or the qsearch SEE filter, so a small number of
+    // positions disagree with their mirror by a few centipawns, and which ones
+    // depends on the eval's actual numbers rather than on anything being
+    // wrong. That FEN started disagreeing when the tactical motif line-clear
+    // fix changed its score. Its evaluation is symmetric, and it is now in the
+    // eval mirror corpus in test_eval.cpp as direct proof of that, which is a
+    // stronger check than this one and does not depend on search internals.
     "r2q1rk1/1b1nbppp/p2ppn2/1p6/3NPP2/1BN1B3/PPPQ2PP/2KR3R w - - 0 1",
     "r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 1",
     "8/3k4/8/8/8/8/3PK3/8 w - - 0 1",


### PR DESCRIPTION
Nine commits that take the evaluation and search a step closer to being safe to tune. One real bug, two pure-refactor commits that unfreeze parts of the evaluation the tuner could never see, one new pruning technique, and two new evaluation terms.

## The bug

`bitboards::between[a][b]` is **inclusive of both endpoints**, and three tactical motifs in `eval_threats` used it without ever asking whether the line was otherwise clear. Each looked only for the one piece it wanted and was blind to everything else on the segment:

- **Queen pins** masked the segment with `enemies`, the opponent's non-pawn pieces. A pawn of either colour between the rook and the queen was invisible, and so was any piece of our own, so a rook was credited with a pin through a wall of pawns.
- **Discovered checks** looked for exactly one of our rooks or knights on the segment and stopped there. Anything else in the way did not stop it claiming a check that could not be uncovered.
- **Skewers** asked only whether the enemy king lay on the segment, so a bishop with three pawns in front of it was credited with skewering a queen eight squares away.

All three now count every occupant of the segment and require the piece they care about to be the only one there. A `strictly_between` helper does the endpoint stripping in one place, since the inclusive convention is what made the original code look correct.

Every other use of `between` in the codebase was audited — `position.cpp` 836/844/874 and `hce.cpp` 703/1172 — and all of them strip the endpoints correctly. This was the only offender.

## Weights the tuner could not reach

This has been the dominant defect class in this engine, and two more instances turned up.

**`king_shelter` was halved at the point of use with integer division.** Its defaults were `{-3, -2, 2, 3}`, and truncation toward zero maps -3 and -2 both to -1, and 2 and 3 both to 1. Two distinct parameter values produced an identical evaluation, so half the array's range had no gradient at all — a tuner moving through it would see nothing happen. Worse, whatever history those values have was fit against a truncated version of itself. The halving is gone and the defaults are the values it actually produced. The pawnless flank penalty and the pawn storm penalty were bare literals and are now parameters, the storm expressed as the table it always implicitly was.

**Every weight in `eval_threats` apart from the hanging piece table was a bare literal** — an entire evaluation component frozen at values nobody had measured. All are now registered. Two gain resolution rather than just visibility: the weak pawn threat was four counts each added with an implicit weight of one, so a knight attacking a weak pawn was worth exactly what a queen doing so was; it is now indexed by the attacking piece.

Both commits are intended to be exactly behaviour-preserving, and **bench is identical across both** (verified independently by building the intermediate commits and diffing).

## The rest

- **`isolated` no longer implies `backward`.** `backward_pawn()` returns true whenever both adjacent files are empty, which is the definition of an isolated pawn, so every isolated pawn was charged both penalties — and both again, doubled, on a semi-open file. Beyond double-charging one weakness, it made the two weights perfectly collinear, so a tuner could only ever identify their sum and the split it returned would be arbitrary. The `backward[]` bitboard still records isolated pawns, because the outpost code reads it to find holes and the square in front of an isolated pawn is just as permanently unguardable.
- **ProbCut**, the last major forward-pruning technique haVoc lacked, with three SPSA-registered parameters. Instrumented over the bench suite: 8120 nodes qualify, 2894 survive the guards, 1754 cut — a 61% hit rate on entry. Bench barely moves because nodes deep enough to qualify are a small fraction of the tree.
- **Connected pawns and queen mobility.** The connected pawn bonus first went in at the scale these tables conventionally carry, peaking at 40. haVoc charges 4 for an isolated pawn and 1 for a backward one, so that term was an order of magnitude larger than everything around it and did not add a judgement so much as replace one. Measured **-12.6 ± 22.9 over 581 games** at that scale; rescaled to haVoc's own magnitudes with the shape left alone, since the shape is the part that encodes the chess idea.

## Measurement

Batched non-regression SPRT against `main`, 10+0.1, bounds `[-5, 0]`:

```
196 - 197 - 220   613 games   0.499
Elo -0.6 +/- 22.3
```

Dead neutral, which is the intended result: this batch is mostly correctness and tunability work, and the two new terms are carried on the agreed policy that a term arriving with guessed weights should be judged by a fit rather than by a match against the untuned engine. Both are recorded in `docs/revisit-after-tuning.md`, along with the king safety and threat weights (whose current values have now never been measured by anyone), ProbCut's parameters, and the thirteen hardcoded endgame constants that were deliberately left alone with the reasoning written down.

125/125 tests pass. The Texel tuner builds and enumerates 221 shape parameters.

## Test notes

Ten coverage positions were added for the new weights. Three details cost a debugging cycle each and are written into the comments so they are not rediscovered:

- The skewer positions need a genuinely clear diagonal, which puts the enemy king in check, so they are Black to move — with White to move they would be illegal.
- The discovered check position needs a Black pawn: against a bare king the evaluation diverts into the mating heuristic and never reaches `eval_threats` at all. The knight skewer needs one too, since knight and king against bishop and king is scaled toward a draw and the term was multiplied away to nothing.
- `ExactSearchIsMirrorSymmetric` moved to a different position. That test documents its own residual — the TT, the aspiration window and the qsearch SEE filter survive the knobs it turns off, so which positions disagree depends on the eval's actual numbers. The position's evaluation is symmetric and it has been added to the eval mirror corpus as direct proof, which is a stronger check that does not depend on search internals.
