### PR TITLE
perf: stop rebuilding 4.7 KB of move buffers at every search node (+24.5% nps)

### DIFF
--- a/include/havoc/move_order.hpp
+++ b/include/havoc/move_order.hpp
@@ -143,10 +143,31 @@ using MoveFilters = std::array<Move, kNumFilters>;
 // ─── Scored moves array ─────────────────────────────────────────────────────
 
 class ScoredMoves {
-    std::array<ScoredMove, kMaxMoves> m_moves;
+    /// Uninitialised storage for the move list.
+    ///
+    /// `Move` carries default member initialisers, so `ScoredMove` is not
+    /// trivially default-constructible and a plain `std::array` of them cannot
+    /// be left alone: every construction writes all kMaxMoves entries. A
+    /// Moveorder holds two of these and one is built at essentially every
+    /// search node, which made this initialisation alone the single largest
+    /// entry in the profile -- more self time than the whole evaluation.
+    ///
+    /// The union suppresses it. Entries are constructed on write in
+    /// load_and_score(), and every read is bounded by m_start/m_end, which
+    /// never exceed m_size -- the count actually written. ScoredMove is
+    /// trivially destructible, so the entries need no cleanup.
+    union Storage {
+        Storage() {}
+        ~Storage() {}
+        std::array<ScoredMove, kMaxMoves> moves;
+    };
+    Storage m_store;
     unsigned m_size = 0;
     unsigned m_start = 0;
     unsigned m_end = 0;
+
+    std::array<ScoredMove, kMaxMoves>& m_moves() { return m_store.moves; }
+    const std::array<ScoredMove, kMaxMoves>& m_moves() const { return m_store.moves; }
 
     void load_and_score(const position& p, Movegen* moves, const MoveFilters& filters,
                         const Move& previous, const Move& followup, const Move& threat,
@@ -165,7 +186,7 @@ class ScoredMoves {
     void clear() { m_size = m_start = m_end = 0; }
 
     int operator++() { return m_start++; }
-    const ScoredMove& front() const { return m_moves[m_start]; }
+    const ScoredMove& front() const { return m_moves()[m_start]; }
     bool end() const { return m_start >= m_end; }
     unsigned size() const { return m_end - m_start; }
     void skip_rest() { m_start = m_end; }

--- a/include/havoc/movegen.hpp
+++ b/include/havoc/movegen.hpp
@@ -6,6 +6,7 @@
 #include "havoc/types.hpp"
 
 #include <iostream>
+#include <memory>
 #include <vector>
 
 namespace havoc {
@@ -16,7 +17,25 @@ enum Dir { N, S, NN, SS, NW, NE, SW, SE, no_dir };
 /// Move generator — generates pseudo-legal moves for a position.
 class Movegen {
     int last = 0;
-    Move list[218];
+    /// Uninitialised storage for the generated moves. `Move` has default
+    /// member initialisers, so a plain `Move list[218]` is rewritten in full
+    /// every time a Movegen is built -- once per search node, on top of the
+    /// two move lists Moveorder already holds. Entries are constructed on
+    /// write by the encode helpers, and `operator[]` is only ever called with
+    /// an index below `last`, the count actually written.
+    union Storage {
+        Storage() {}
+        ~Storage() {}
+        Move moves[218];
+    };
+    Storage store;
+
+    /// Constructs the next move in place. The storage is deliberately
+    /// uninitialised, so this is the write that begins the entry's lifetime.
+    void add(int f, int t, Movetype mt) {
+        std::construct_at(&store.moves[last++], static_cast<U8>(f), static_cast<U8>(t),
+                          static_cast<U8>(mt));
+    }
     Color us, them;
     U64 rank2, rank7;
     U64 empty, pawns, pawns2, pawns7;
@@ -50,7 +69,7 @@ class Movegen {
 
     Movegen& operator=(const Movegen&) = delete;
     Movegen& operator=(Movegen&&) = delete;
-    Move& operator[](int idx) { return list[idx]; }
+    Move& operator[](int idx) { return store.moves[idx]; }
 
     template <Movetype mt, Piece p> inline void generate();
     template <Piece p> inline void generate();
@@ -95,13 +114,13 @@ template <> inline void shift<SE>(U64& b) {
 
 template <Movetype mt> inline void Movegen::encode(U64& b, const int& f) {
     while (b)
-        list[last++].set(f, bits::pop_lsb(b), mt);
+        add(f, bits::pop_lsb(b), mt);
 }
 
 template <Movetype mt> inline void Movegen::encode_pawn_pushes(U64& b, const int& dir) {
     while (b) {
         int to = bits::pop_lsb(b);
-        list[last++].set(to + dir, to, mt);
+        add(to + dir, to, mt);
     }
 }
 
@@ -109,10 +128,10 @@ inline void Movegen::encode_promotions(U64& b, const int& dir) {
     while (b) {
         Square to = Square(bits::pop_lsb(b));
         Square f = Square(to + dir);
-        list[last++].set(f, to, promotion_q);
-        list[last++].set(f, to, promotion_r);
-        list[last++].set(f, to, promotion_b);
-        list[last++].set(f, to, promotion_n);
+        add(f, to, promotion_q);
+        add(f, to, promotion_r);
+        add(f, to, promotion_b);
+        add(f, to, promotion_n);
     }
 }
 
@@ -120,10 +139,10 @@ inline void Movegen::encode_capture_promotions(U64& b, const int& dir) {
     while (b) {
         Square to = Square(bits::pop_lsb(b));
         Square f = Square(to + dir);
-        list[last++].set(f, to, capture_promotion_q);
-        list[last++].set(f, to, capture_promotion_r);
-        list[last++].set(f, to, capture_promotion_b);
-        list[last++].set(f, to, capture_promotion_n);
+        add(f, to, capture_promotion_q);
+        add(f, to, capture_promotion_r);
+        add(f, to, capture_promotion_b);
+        add(f, to, capture_promotion_n);
     }
 }
 
@@ -482,9 +501,9 @@ template <> inline void Movegen::generate<quiet, king>() {
 
 template <> inline void Movegen::generate<castles, king>() {
     if (can_castle_ks_)
-        list[last++].set(kings[0], (us == white ? G1 : G8), castle_ks);
+        add(kings[0], (us == white ? G1 : G8), castle_ks);
     if (can_castle_qs_)
-        list[last++].set(kings[0], (us == white ? C1 : C8), castle_qs);
+        add(kings[0], (us == white ? C1 : C8), castle_qs);
 }
 
 template <> inline void Movegen::generate<capture, king>() {

--- a/src/move_order.cpp
+++ b/src/move_order.cpp
@@ -128,22 +128,26 @@ void ScoredMoves::load_and_score(const position& p, Movegen* moves,
             continue;
 
         int sc = score_lambda(p, m, previous, followup, threat, stack, hist);
-        m_moves[m_size++] = ScoredMove(m, sc);
+        // Placement construction rather than assignment: the storage is
+        // deliberately left uninitialised, so this is the write that begins
+        // the entry's lifetime.
+        std::construct_at(&m_moves()[m_size++], m, sc);
     }
 }
 
 void ScoredMoves::sort(int cutoff) {
     const unsigned N = m_size;
+    auto& moves = m_moves();
     ScoredMove key;
     int j;
     for (unsigned i = m_start + 1; i < N; ++i) {
-        key = m_moves[i];
+        key = moves[i];
         j = static_cast<int>(i) - 1;
-        while (j >= 0 && m_moves[j] < key) {
-            m_moves[j + 1] = m_moves[j];
+        while (j >= 0 && moves[j] < key) {
+            moves[j + 1] = moves[j];
             --j;
         }
-        m_moves[j + 1] = key;
+        moves[j + 1] = key;
     }
     create_chunk(cutoff);
 }
@@ -151,7 +155,7 @@ void ScoredMoves::sort(int cutoff) {
 void ScoredMoves::create_chunk(int cutoff) {
     m_start = m_end;
     for (unsigned i = m_start; i < m_size; ++i) {
-        if (m_moves[i].s >= cutoff)
+        if (m_moves()[i].s >= cutoff)
             m_end++;
     }
 }

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -4,15 +4,15 @@ namespace havoc {
 
 void Movegen::print() {
     for (int j = 0; j < last; ++j) {
-        std::cout << kSanSquares[list[j].f] << kSanSquares[list[j].t] << " ";
+        std::cout << kSanSquares[store.moves[j].f] << kSanSquares[store.moves[j].t] << " ";
     }
     std::cout << "\n";
 }
 
 void Movegen::print_legal(position& p) {
     for (int j = 0; j < last; ++j) {
-        if (p.is_legal(list[j]))
-            std::cout << kSanSquares[list[j].f] << kSanSquares[list[j].t] << " ";
+        if (p.is_legal(store.moves[j]))
+            std::cout << kSanSquares[store.moves[j].f] << kSanSquares[store.moves[j].t] << " ";
     }
     std::cout << "\n";
 }


### PR DESCRIPTION
The largest single performance defect in the engine, found by profiling
`bench` rather than by reading the search.

### What was wrong

`Moveorder` holds two `ScoredMoves` lists and a `Movegen`, and one is
constructed at essentially every search node. All three buffers are arrays
of types that carry default member initialisers -- `Move` sets `f`/`t`/`type`,
`ScoredMove` sets `s` -- so none of them is trivially default-constructible.
That means the compiler cannot leave them alone: **every construction wrote
all 4992 bytes before a single move had been generated.**

`sizeof(Moveorder)` is 4992: 2 x 256 x 8 bytes of `ScoredMove` plus 218 x 3
bytes of `Move`. The `_platform_memset_pattern16` entry in the profile is the
`{0, 0, no_type, pad, kNegInf}` pattern being splatted across 4 KB, once per
node.

The profile put `Moveorder::Moveorder` at the **top of self time** -- above
magic attack generation, above the transposition table, above the entire
evaluation, and 4x the search function itself. Constructing the buffers in
isolation costs **4.1 s per bench-worth of nodes**.

### The fix

Give the three buffers uninitialised storage and construct entries on write.

The obvious fix -- making `Move` trivially default-constructible -- is a trap:
`no_type` is **17, not 0**, so zero-initialisation would silently turn every
default `Move` into `promotion_q`. A per-ply arena is also unsafe here,
because the singular-extension re-search at `search.cpp:840` recurses with the
**same** `stack` pointer while the main loop's `Moveorder` is still alive, so
ply does not uniquely identify a live move list. Keeping the storage per
object and merely uninitialised avoids both problems.

Nothing reads past what was written: `ScoredMoves` bounds every read by
`m_start`/`m_end`, which never exceed the `m_size` it counted while filling,
and `Movegen::operator[]` is only ever called with an index below `last`.
Both element types are trivially destructible, so entries need no cleanup.

### Measurement

Bench node count is **identical** before and after -- 1956649 -- which is what
makes this provably a pure performance change and not a search change.

Interleaved A/B on an idle machine, 3 reps each:

| | nps |
| --- | --- |
| main | 678858 / 736167 / 730057 |
| this branch | 899395 / 892378 / 879635 |

**+24.5% nps.**

SPRT vs main, 10+0.1, bounds elo0=0 elo1=5:

```
+51.3 +/- 31.0 Elo over 300 games, LOS 99.9%
```

126/126 tests pass, including all 36 perft tests.
