### PR TITLE
eval: make the piece and pawn structure weights reachable by a tuner

### DIFF
--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -243,6 +243,29 @@ struct parameters {
     int backward_pawn_penalty_eg = 1;
     int isolated_pawn_penalty_mg = 4;
     int isolated_pawn_penalty_eg = 4;
+    /// A pawn no friendly pawn defends. This was a bare `score -= 1` applied
+    /// identically to both accumulators, so it could neither be tuned nor
+    /// tapered.
+    int undefended_pawn_penalty_mg = 1;
+    int undefended_pawn_penalty_eg = 1;
+    /// The extra charge for a weak pawn standing on a file the enemy has no
+    /// pawn on, where it cannot be defended by a pawn and is exposed to the
+    /// heavy pieces. Each of these was `2 * ` the corresponding base penalty,
+    /// which froze the aggravation at exactly double and left the tuner unable
+    /// to fit it at all: the whole term moved only when the base penalty
+    /// moved. The defaults reproduce the doubling, so nothing changes until a
+    /// fit says otherwise.
+    int backward_pawn_semiopen_mg = 2;
+    int backward_pawn_semiopen_eg = 2;
+    int isolated_pawn_semiopen_mg = 8;
+    int isolated_pawn_semiopen_eg = 8;
+    int doubled_pawn_semiopen_mg = 8;
+    int doubled_pawn_semiopen_eg = 8;
+    /// A doubled pawn that is also isolated -- no neighbour on either side and
+    /// a friend stacked in front of it. Also frozen at double the plain
+    /// doubled penalty.
+    int doubled_isolated_penalty_mg = 8;
+    int doubled_isolated_penalty_eg = 8;
 
     // Connected pawns, indexed by the pawn's rank relative to its own side.
     // Until these were added the pawn evaluation was made entirely of

--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -189,6 +189,30 @@ struct parameters {
     int discovered_check_bonus = 10;
     int restriction_weight = 1;
     std::vector<int> skewer_bonus{4, 6, 8}; // minor, rook, queen skewered
+    /// Per-piece evaluation weights that were bare literals. Every one of
+    /// these fires in ordinary middlegame positions -- protection counts, king
+    /// distance, x-rays -- so unlike the endgame constants they carry real
+    /// gradient and were simply invisible to the tuner. The defaults reproduce
+    /// the values that were hardcoded.
+    ///
+    /// `pawn_attacks_undefended` keeps the `/ 2` it always had so the default
+    /// of 1 reproduces the old score exactly. The division is the reason it
+    /// needs a parameter at all: as a bare count halved by integer division it
+    /// had no gradient below one point per two attacks, and the tuner can now
+    /// reach the odd multiples the truncation used to swallow.
+    int pawn_attacks_undefended = 1;
+    int knight_edge_penalty = 12;
+    int knight_king_distance_penalty = 1;
+    int knight_behind_pawn_bonus = 12;
+    int knight_protection_bonus = 1;
+    int bishop_xray_bonus = 1;
+    int bishop_king_distance_penalty = 1;
+    int bishop_behind_pawn_bonus = 12;
+    int bishop_protection_bonus = 1;
+    int rook_xray_bonus = 1;
+    int rook_protection_bonus = 1;
+    int weak_queen_penalty = 1;
+    int space_bonus = 1;
     int connected_rook_bonus = 1;
     int doubled_bishop_bonus = 4;
     int open_file_bonus = 1;

--- a/src/eval/hce.cpp
+++ b/src/eval/hce.cpp
@@ -403,7 +403,7 @@ template <Color c> int HCEEvaluator::eval_pawns(const position& p, einfo& ei) {
 
     // Pawn chain bases / undefended enemy pawns
     U64 baseAttks = pawnAttacks & ei.pe->undefended[them];
-    score += bits::count(baseAttks) / 2;
+    score += (bits::count(baseAttks) * params_.pawn_attacks_undefended) / 2;
     return score;
 }
 
@@ -442,7 +442,7 @@ template <Color c> int HCEEvaluator::eval_knights(const position& p, einfo& ei) 
 
         // Edge penalty
         if (sq_bb & bitboards::edges)
-            score -= 12;
+            score -= params_.knight_edge_penalty;
 
         // Closed center bonus
         if (ei.pe->locked_center || ei.pe->center_pawn_count >= 4)
@@ -458,7 +458,7 @@ template <Color c> int HCEEvaluator::eval_knights(const position& p, einfo& ei) 
 
         // King distance
         int dist = std::max(util::row_dist(s, ks), util::col_dist(s, ks));
-        score -= dist;
+        score -= dist * params_.knight_king_distance_penalty;
 
         // Minor behind pawn
         auto fsq = (c == white ? s + 8 : s - 8);
@@ -466,7 +466,7 @@ template <Color c> int HCEEvaluator::eval_knights(const position& p, einfo& ei) 
             auto bbs = bitboards::squares[fsq];
             auto pawninfront = p.get_pieces<c, pawn>() & bbs;
             if (pawninfront && util::row(s) != Row::r1 && util::row(s) != Row::r8)
-                score += 12;
+                score += params_.knight_behind_pawn_bonus;
         }
 
         // King harassment
@@ -478,7 +478,7 @@ template <Color c> int HCEEvaluator::eval_knights(const position& p, einfo& ei) 
         }
 
         // Protection
-        score += bits::count(p.attackers_of2(s, c));
+        score += bits::count(p.attackers_of2(s, c)) * params_.knight_protection_bonus;
     }
     return score;
 }
@@ -518,7 +518,7 @@ template <Color c> int HCEEvaluator::eval_bishops(const position& p, einfo& ei) 
             dark_sq = true;
 
         // X-Ray attacks on valuable pieces
-        score += bits::count(bitboards::battks[s] & valuable_enemies);
+        score += bits::count(bitboards::battks[s] & valuable_enemies) * params_.bishop_xray_bonus;
 
         // Mobility
         U64 mvs = magics::attacks<bishop>(ei.all_pieces, s);
@@ -538,7 +538,8 @@ template <Color c> int HCEEvaluator::eval_bishops(const position& p, einfo& ei) 
         score += mobility_score;
 
         // King distance
-        score -= std::max(util::row_dist(s, ks), util::col_dist(s, ks));
+        score -= std::max(util::row_dist(s, ks), util::col_dist(s, ks)) *
+                 params_.bishop_king_distance_penalty;
 
         // Closed center penalty
         if (ei.pe->locked_center || ei.pe->center_pawn_count >= 4)
@@ -574,7 +575,7 @@ template <Color c> int HCEEvaluator::eval_bishops(const position& p, einfo& ei) 
             auto bbs = bitboards::squares[fsq];
             auto pawninfront = p.get_pieces<c, pawn>() & bbs;
             if (pawninfront && util::row(s) != Row::r1 && util::row(s) != Row::r8)
-                score += 12;
+                score += params_.bishop_behind_pawn_bonus;
         }
 
         // Penalty for bishops on same color as own pawns.
@@ -602,7 +603,7 @@ template <Color c> int HCEEvaluator::eval_bishops(const position& p, einfo& ei) 
         }
 
         // Protection
-        score += bits::count(p.attackers_of2(s, c));
+        score += bits::count(p.attackers_of2(s, c)) * params_.bishop_protection_bonus;
     }
 
     // Double bishop bonus
@@ -635,7 +636,7 @@ template <Color c> int HCEEvaluator::eval_rooks(const position& p, einfo& ei) {
         rookSquares[rookIdx++] = s;
 
         // X-Ray attacks on valuable pieces
-        score += bits::count(bitboards::rattks[s] & valuable_enemies);
+        score += bits::count(bitboards::rattks[s] & valuable_enemies) * params_.rook_xray_bonus;
 
         // Mobility
         U64 mvs = magics::attacks<rook>(ei.all_pieces, s);
@@ -689,7 +690,7 @@ template <Color c> int HCEEvaluator::eval_rooks(const position& p, einfo& ei) {
         }
 
         // Protection
-        score += bits::count(p.attackers_of2(s, c));
+        score += bits::count(p.attackers_of2(s, c)) * params_.rook_protection_bonus;
     }
 
     // Connected rook bonus
@@ -753,7 +754,7 @@ template <Color c> int HCEEvaluator::eval_queens(const position& p, einfo& ei) {
 
         // Weak queen penalty
         U64 attackers = p.attackers_of2(s, them) & weakEnemies;
-        score -= bits::count(attackers);
+        score -= bits::count(attackers) * params_.weak_queen_penalty;
 
         // Center influence
         score +=
@@ -986,7 +987,7 @@ template <Color c> int HCEEvaluator::eval_space(const position& p, einfo& ei) {
         int s = bits::pop_lsb(pawns);
         space |= util::squares_behind(bitboards::col[util::col(s)], c, s);
     }
-    score += bits::count(space);
+    score += bits::count(space) * params_.space_bonus;
     return (score * mg) / material_entry::kPhaseMax;
 }
 

--- a/src/eval/hce.cpp
+++ b/src/eval/hce.cpp
@@ -1005,10 +1005,12 @@ template <Color c> int HCEEvaluator::eval_threats(const position& p, einfo& ei) 
     auto enemyPieceAttacks = (ei.piece_attacks[them][knight] | ei.piece_attacks[them][bishop] |
                               ei.piece_attacks[them][rook] | ei.piece_attacks[them][queen]);
 
-    // 1. Pieces under attack by pawns
+    // 1. Pieces under attack by pawns. Counted, not flagged: a pawn fork
+    // attacking two pieces is worth about twice a pawn attacking one, and the
+    // weak-pawn term below already counts its victims the same way. As a bare
+    // flag this could not tell a fork from a single nudge.
     auto attackedByPawns = enemies & pawnAttacks;
-    if (attackedByPawns != 0ULL)
-        score += params_.threat_by_pawn;
+    score += params_.threat_by_pawn * bits::count(attackedByPawns);
 
     // 2. Hanging pieces under attack
     auto defendendEnemies = enemies & (enemyPawnAttacks | enemyPieceAttacks);

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -176,6 +176,21 @@ std::vector<std::pair<std::string, int*>> parameters::all_params(TuneStage stage
         for (size_t i = 0; i < skewer_bonus.size(); ++i)
             result.emplace_back("skewer_bonus_" + std::to_string(i), &skewer_bonus[i]);
 
+        // Per-piece weights that used to be bare literals in the evaluation.
+        result.emplace_back("pawn_attacks_undefended", &pawn_attacks_undefended);
+        result.emplace_back("knight_edge_penalty", &knight_edge_penalty);
+        result.emplace_back("knight_king_distance_penalty", &knight_king_distance_penalty);
+        result.emplace_back("knight_behind_pawn_bonus", &knight_behind_pawn_bonus);
+        result.emplace_back("knight_protection_bonus", &knight_protection_bonus);
+        result.emplace_back("bishop_xray_bonus", &bishop_xray_bonus);
+        result.emplace_back("bishop_king_distance_penalty", &bishop_king_distance_penalty);
+        result.emplace_back("bishop_behind_pawn_bonus", &bishop_behind_pawn_bonus);
+        result.emplace_back("bishop_protection_bonus", &bishop_protection_bonus);
+        result.emplace_back("rook_xray_bonus", &rook_xray_bonus);
+        result.emplace_back("rook_protection_bonus", &rook_protection_bonus);
+        result.emplace_back("weak_queen_penalty", &weak_queen_penalty);
+        result.emplace_back("space_bonus", &space_bonus);
+
         // King safe squares
         for (size_t i = 0; i < king_safe_sqs.size(); ++i)
             result.emplace_back("king_safe_sqs_" + std::to_string(i), &king_safe_sqs[i]);

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -105,6 +105,16 @@ std::vector<std::pair<std::string, int*>> parameters::all_params(TuneStage stage
         result.emplace_back("backward_pawn_penalty_eg", &backward_pawn_penalty_eg);
         result.emplace_back("isolated_pawn_penalty_mg", &isolated_pawn_penalty_mg);
         result.emplace_back("isolated_pawn_penalty_eg", &isolated_pawn_penalty_eg);
+        result.emplace_back("undefended_pawn_penalty_mg", &undefended_pawn_penalty_mg);
+        result.emplace_back("undefended_pawn_penalty_eg", &undefended_pawn_penalty_eg);
+        result.emplace_back("backward_pawn_semiopen_mg", &backward_pawn_semiopen_mg);
+        result.emplace_back("backward_pawn_semiopen_eg", &backward_pawn_semiopen_eg);
+        result.emplace_back("isolated_pawn_semiopen_mg", &isolated_pawn_semiopen_mg);
+        result.emplace_back("isolated_pawn_semiopen_eg", &isolated_pawn_semiopen_eg);
+        result.emplace_back("doubled_pawn_semiopen_mg", &doubled_pawn_semiopen_mg);
+        result.emplace_back("doubled_pawn_semiopen_eg", &doubled_pawn_semiopen_eg);
+        result.emplace_back("doubled_isolated_penalty_mg", &doubled_isolated_penalty_mg);
+        result.emplace_back("doubled_isolated_penalty_eg", &doubled_isolated_penalty_eg);
         result.emplace_back("space_category_scale", &space_category_scale);
         result.emplace_back("king_danger_divisor", &king_danger_divisor);
         return result;

--- a/src/pawn_table.cpp
+++ b/src/pawn_table.cpp
@@ -140,7 +140,7 @@ template <Color c> pawn_score evaluate_pawns(const position& p, pawn_entry& e, c
         auto defend_mask = (c == white ? bitboards::pattks[black][s] : bitboards::pattks[white][s]);
         auto defenders = pawns & defend_mask;
         if (defenders == 0ULL) {
-            score -= 1;
+            score.sub(par.undefended_pawn_penalty_mg, par.undefended_pawn_penalty_eg);
             e.undefended[c] |= fbb;
         }
 
@@ -197,7 +197,7 @@ template <Color c> pawn_score evaluate_pawns(const position& p, pawn_entry& e, c
         if (bits::more_than_one(doubled)) {
             e.doubled[c] |= doubled;
             if (e.isolated[c] & doubled)
-                score.sub(2 * par.doubled_pawn_penalty_mg, 2 * par.doubled_pawn_penalty_eg);
+                score.sub(par.doubled_isolated_penalty_mg, par.doubled_isolated_penalty_eg);
             else
                 score.sub(par.doubled_pawn_penalty_mg, par.doubled_pawn_penalty_eg);
         }
@@ -206,11 +206,11 @@ template <Color c> pawn_score evaluate_pawns(const position& p, pawn_entry& e, c
         U64 column = bitboards::col[col_idx];
         if ((column & epawns) == 0ULL) {
             if ((fbb & e.backward[c]) && !is_isolated)
-                score.sub(2 * par.backward_pawn_penalty_mg, 2 * par.backward_pawn_penalty_eg);
+                score.sub(par.backward_pawn_semiopen_mg, par.backward_pawn_semiopen_eg);
             if (fbb & e.isolated[c])
-                score.sub(2 * par.isolated_pawn_penalty_mg, 2 * par.isolated_pawn_penalty_eg);
+                score.sub(par.isolated_pawn_semiopen_mg, par.isolated_pawn_semiopen_eg);
             if (fbb & e.doubled[c])
-                score.sub(2 * par.doubled_pawn_penalty_mg, 2 * par.doubled_pawn_penalty_eg);
+                score.sub(par.doubled_pawn_semiopen_mg, par.doubled_pawn_semiopen_eg);
 
         }
 

--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -1280,6 +1280,18 @@ TEST_F(EvalTest, EveryTunableParameterReachesTheEvaluation) {
         // A bare endgame reaching the low ranks: b3/c3 is a phalanx on
         // relative rank 2 and d4 is supported by c3 on relative rank 3.
         "4k3/8/8/8/3P4/1PP5/8/4K3 w - - 0 1",
+        // A pawn that is both doubled and isolated. The two conditions are
+        // scored together -- a stacked pawn with no neighbour on either file
+        // is charged once for the pair rather than the plain doubled rate --
+        // so neither a doubled pawn with neighbours nor a lone isolated pawn
+        // reaches it. White's c2/c3 are stacked with no b or d pawn; Black
+        // keeps a pawn so the evaluation does not divert into the bare-king
+        // mating heuristic, which never reads the pawn structure at all.
+        "4k3/4p3/8/8/8/2P5/2P5/4K3 w - - 0 1",
+        // The same structure with both armies intact. The bare version above
+        // sits at the endgame end of the phase, so it moves the eg half only;
+        // the mg half needs a position with the non-pawn material still on.
+        "rnbqkbnr/pppppppp/8/8/8/2P5/2P5/RNBQKBNR w KQkq - 0 1",
     };
 
     // The pawn and material caches are keyed on structure, not on parameter


### PR DESCRIPTION
Three changes that make the evaluation reachable by a tuner, plus one real gap.

**1. `94da0c5` make the remaining piece evaluation weights tunable** *(bench-identical)*

13 bare literals across the knight, bishop, rook, queen, pawn and space
terms were adjusting the score by a number no tuner could ever see. They
are now registered parameters; the shape stage grows 224 -> 237.

**2. `00875ac` unfreeze the pawn structure aggravation weights** *(bench-identical)*

Four penalties were written as `2 * <some other parameter>`. That is
worse than a bad default: the term cannot move unless its base moves, so
no fit can separate "a doubled pawn is bad" from "a doubled pawn on a
semi-open file is much worse". Each aggravation now owns its mg/eg pair.
The untunable `score -= 1` undefended-pawn penalty is registered too.

Two coverage FENs were needed. No ordinary position has a pawn that is
both doubled and isolated, and a bare-king endgame only exercises the
`_eg` half of a tapered pair - the middlegame half is interpolated away -
so a middlegame counterpart with both armies on the board is included.

**3. `a180902` count the pieces a side's pawns attack** *(bench 1956649 -> 1859340)*

`threat_by_pawn` paid a flat bonus regardless of how many pieces the
pawns were actually attacking, so a fork scored exactly the same as a
nudge. Its sibling weak-pawn term already counted. Now it does too.

**Testing.** 126/126 tests pass. SPRT against current main, non-regression
bounds (elo0 = -5, elo1 = 0): **+1.9 +/- 27.8 over 360 games**. Commits 1
and 2 are provably inert, so this measures commit 3 alone.
