### PR TITLE
search: continuation history, and the null move's missing predecessor

### DIFF
--- a/docs/revisit-after-tuning.md
+++ b/docs/revisit-after-tuning.md
@@ -58,6 +58,40 @@ sees no gradient for them and they keep their defaults. Listed in
   `pinned_scaling` is a divisor the tuner could drive to zero. The reasoning is
   recorded in `src/parameters.cpp`; revisit only if a fit wants that freedom.
 
+## The history table lives on the wrong scale for its own thresholds
+
+Measured on a depth-15 bench, at every node where history pruning is
+considered, over 146769 samples:
+
+| `history_malus_pct` | table min | table max | below `lmr_hist_bad` (2000) | below `history_prune_margin` (4096) |
+|---|---|---|---|---|
+| **0 (the shipped default)** | **-194** | 9181 | **0.00%** | **0.00%** |
+| 50  | -4760 | 2946 | 5.08%  | 0.08%  |
+| 100 | -9042 | 2437 | 27.85% | 14.88% |
+| 200 | -13608 | 543 | 60.50% | 51.18% |
+
+With the default, the negative half of the table never leaves the
+neighbourhood of zero, so **history pruning and the LMR bad-history extra
+reduction never fire at all** -- not rarely, never. Both are live code
+reading a threshold two orders of magnitude outside the range the table
+reaches. `history_malus_pct` exists precisely to develop that half and
+ships switched off.
+
+Turning it on is not free, and the table is the reason: the malus is
+applied to every quiet at every fail-low node, which vastly outnumbers
+the bonuses handed out at cutoffs, so the whole distribution slides
+negative rather than widening. At 100 the maximum falls to 2437, which
+kills `lmr_hist_good` (4000) exactly as it revives `lmr_hist_bad`. The
+three thresholds cannot all be reachable at once while bonus and malus
+are this far out of balance.
+
+What this needs is a joint fit over `history_bonus_scale`,
+`history_malus_pct`, `lmr_hist_bad`, `lmr_hist_good` and
+`history_prune_margin`, not five separate guesses -- they are one
+mechanism and SPSA should see them together. Until then, note that three
+SPSA dimensions are being spent on thresholds that cannot move the
+search, which is worse than leaving them out.
+
 ## Test curation that depends on evaluation values
 
 `SearchTest.ExactSearchIsMirrorSymmetric` asserts a curated list of positions.

--- a/include/havoc/move_order.hpp
+++ b/include/havoc/move_order.hpp
@@ -40,6 +40,27 @@ struct SearchNode {
     std::unique_ptr<BestMoveHistory> bmh;
     Move killers[4];
     int16_t static_eval = score::kNegInf;
+    /// Continuation history context: the move that was played *into* this
+    /// node, and the one played two plies before it. A node is handed these by
+    /// its parent rather than reading stack - 1 and stack - 2 itself, because
+    /// only the search guarantees those frames exist -- anything else holding a
+    /// SearchNode* (a test, a tool) would be reading off the front of its own
+    /// array. `no_piece` means "no predecessor at that distance": the frames
+    /// above the root, and null moves, both say so honestly.
+    Piece prev_piece = no_piece;
+    U8 prev_to = 0;
+    Piece prev2_piece = no_piece;
+    U8 prev2_to = 0;
+
+    /// Records `moved`, landing on `to`, as the move this node is playing, and
+    /// hands the resulting context down to the child frame. Call it before
+    /// do_move, while the from square still says what is standing on it.
+    void push_context(Piece moved, U8 to) {
+        (this + 1)->prev_piece = moved;
+        (this + 1)->prev_to = to;
+        (this + 1)->prev2_piece = prev_piece;
+        (this + 1)->prev2_to = prev_to;
+    }
 
     int (&best_move_history())[2][64][64] { return bmh->bm; }
 };
@@ -84,7 +105,7 @@ inline void apply_history_bonus(int& h, int bonus) {
 }
 
 struct Movehistory {
-    Movehistory() { clear(); }
+    Movehistory();
     Movehistory& operator=(const Movehistory& mh);
 
     /// `bonus` is the magnitude applied to the cutoff move, and subtracted
@@ -101,16 +122,53 @@ struct Movehistory {
     /// develops and any threshold read against it is unreachable.
     void malus(const Color& c, int bonus, const std::vector<Move>& quiets);
 
+    /// Continuation history counterparts. `stack` is the node whose move loop
+    /// produced the cutoff (or fail-low); it carries the predecessor context.
+    /// `p` must be the position at that node, with every searched move undone,
+    /// so that piece_on(from) still identifies the piece each quiet moved.
+    void update_continuation(const position& p, const SearchNode* stack, const Move& best,
+                             int bonus, const std::vector<Move>& quiets);
+    void malus_continuation(const position& p, const SearchNode* stack, int bonus,
+                            const std::vector<Move>& quiets);
+
     void clear();
 
     int score(const Move& m, const Color& c, const Move& previous, const Move& followup,
               const Move& threat) const;
     int score(const Move& m, const Color& c) const;
 
+    /// Sum of the two continuation tables for a candidate quiet `m`, scaled by
+    /// the weights set through `set_continuation_weights`.
+    int continuation_score(const position& p, const Move& m, const SearchNode* stack) const;
+
+    /// The scoring functions are plain function pointers with a fixed
+    /// signature and no route to the parameter block, so the search hands the
+    /// tunable continuation weights to the table itself.
+    void set_continuation_weights(int pct1, int pct2) {
+        cont_pct1_ = pct1;
+        cont_pct2_ = pct2;
+    }
+
   private:
+    /// One continuation plane per predecessor distance: [0] is keyed on the
+    /// move our opponent just played, [1] on our own move two plies back.
+    /// Heap-allocated -- 2.4 MB will not fit on the stack, and SearchEngine is
+    /// an ordinary local in main().
+    struct ContinuationHistory {
+        int table[2][pieces][squares][colors][pieces][squares] = {};
+    };
+
+    int* continuation_slot(int plane, const SearchNode* stack, Color c, Piece moved,
+                           const Move& m);
+    const int* continuation_slot(int plane, const SearchNode* stack, Color c, Piece moved,
+                                 const Move& m) const;
+
     std::array<std::array<std::array<int, squares>, squares>, colors> history_;
     // Countermove table: indexed by [color_of_previous_move][from][to] -> best response
     std::array<std::array<std::array<Move, 64>, 64>, 2> countermoves{};
+    std::unique_ptr<ContinuationHistory> continuation_;
+    int cont_pct1_ = 100;
+    int cont_pct2_ = 100;
 };
 
 // ─── Scored move ────────────────────────────────────────────────────────────

--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -359,6 +359,13 @@ struct parameters {
     int history_bonus_scale = 1;    // history bonus is scale * depth^2
     int history_malus_pct = 0;      // fail-low penalty, percent of the bonus (0 = off)
 
+    /// Continuation history weights, as a percentage of the raw table value.
+    /// Plane 1 is keyed on the opponent's reply we are answering, plane 2 on
+    /// our own move two plies back. They are separate because the two planes
+    /// carry different amounts of signal and only a fit can say how much.
+    int cont_hist1_pct = 100;
+    int cont_hist2_pct = 100;
+
     // Parameter serialization
     bool load(const std::string& filename);
 

--- a/src/move_order.cpp
+++ b/src/move_order.cpp
@@ -3,15 +3,92 @@
 #include "havoc/position.hpp"
 
 #include <cmath>
+#include <cstring>
 
 namespace havoc {
 
 // ─── Movehistory ────────────────────────────────────────────────────────────
 
+Movehistory::Movehistory() : continuation_(std::make_unique<ContinuationHistory>()) {
+    clear();
+}
+
 Movehistory& Movehistory::operator=(const Movehistory& mh) {
     std::copy(std::begin(mh.history_), std::end(mh.history_), std::begin(history_));
     countermoves = mh.countermoves;
+    *continuation_ = *mh.continuation_;
+    cont_pct1_ = mh.cont_pct1_;
+    cont_pct2_ = mh.cont_pct2_;
     return *this;
+}
+
+// ─── Continuation history ───────────────────────────────────────────────────
+//
+// The plain history table is keyed on (color, from, to) alone, so every quiet
+// carries a single score averaged over every context it was ever tried in. A
+// knight retreat that refutes one particular bishop sortie is indistinguishable
+// from the same retreat played into an unrelated structure.
+//
+// Continuation history keys the same evidence on the move that preceded it:
+// plane 0 on the opponent's reply we are answering, plane 1 on our own move two
+// plies back. The two are kept apart because a predecessor played by the
+// opponent and one played by us mean opposite things about the position.
+
+const int* Movehistory::continuation_slot(int plane, const SearchNode* stack, Color c, Piece moved,
+                                          const Move& m) const {
+    Piece prev = plane == 0 ? stack->prev_piece : stack->prev2_piece;
+    U8 to = plane == 0 ? stack->prev_to : stack->prev2_to;
+    if (prev == no_piece || moved == no_piece)
+        return nullptr;
+    return &continuation_->table[plane][prev][to][c][moved][m.t];
+}
+
+int* Movehistory::continuation_slot(int plane, const SearchNode* stack, Color c, Piece moved,
+                                    const Move& m) {
+    return const_cast<int*>(
+        static_cast<const Movehistory*>(this)->continuation_slot(plane, stack, c, moved, m));
+}
+
+int Movehistory::continuation_score(const position& p, const Move& m, const SearchNode* stack) const {
+    if (m.type != static_cast<U8>(Movetype::quiet))
+        return 0;
+    Color c = p.to_move();
+    Piece moved = p.piece_on(static_cast<Square>(m.f));
+    int s = 0;
+    if (const int* a = continuation_slot(0, stack, c, moved, m))
+        s += *a * cont_pct1_ / 100;
+    if (const int* b = continuation_slot(1, stack, c, moved, m))
+        s += *b * cont_pct2_ / 100;
+    return s;
+}
+
+void Movehistory::update_continuation(const position& p, const SearchNode* stack, const Move& best,
+                                      int bonus, const std::vector<Move>& quiets) {
+    if (best.type != static_cast<U8>(Movetype::quiet))
+        return;
+    Color c = p.to_move();
+    for (int plane = 0; plane < 2; ++plane) {
+        if (int* h = continuation_slot(plane, stack, c, p.piece_on(static_cast<Square>(best.f)),
+                                       best))
+            apply_history_bonus(*h, bonus);
+        for (const auto& q : quiets) {
+            if (q == best)
+                continue;
+            if (int* h =
+                    continuation_slot(plane, stack, c, p.piece_on(static_cast<Square>(q.f)), q))
+                apply_history_bonus(*h, -bonus);
+        }
+    }
+}
+
+void Movehistory::malus_continuation(const position& p, const SearchNode* stack, int bonus,
+                                     const std::vector<Move>& quiets) {
+    Color c = p.to_move();
+    for (int plane = 0; plane < 2; ++plane)
+        for (const auto& q : quiets)
+            if (int* h =
+                    continuation_slot(plane, stack, c, p.piece_on(static_cast<Square>(q.f)), q))
+                apply_history_bonus(*h, -bonus);
 }
 
 void Movehistory::update(const Color& c, const Move& m, const Move& previous, int bonus,
@@ -53,6 +130,9 @@ void Movehistory::clear() {
     for (auto& v : history_)
         for (auto& w : v)
             std::fill(w.begin(), w.end(), 0);
+
+    if (continuation_)
+        std::memset(continuation_->table, 0, sizeof(continuation_->table));
 
     Move empty;
     empty.set(0, 0, no_type);
@@ -98,7 +178,7 @@ int score_quiets(const position& p, const Move& m, const Move& prev, const Move&
     auto tomove = p.to_move();
     int s = 0;
     if (hist)
-        s = hist->score(m, tomove, prev, followup, threat);
+        s = hist->score(m, tomove, prev, followup, threat) + hist->continuation_score(p, m, stack);
     return s + stack->best_move_history()[tomove][m.f][m.t];
 }
 

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -381,6 +381,8 @@ std::vector<std::pair<std::string, int*>> parameters::all_params(TuneStage stage
         result.emplace_back("best_move_bonus", &best_move_bonus);
         result.emplace_back("history_bonus_scale", &history_bonus_scale);
         result.emplace_back("history_malus_pct", &history_malus_pct);
+        result.emplace_back("cont_hist1_pct", &cont_hist1_pct);
+        result.emplace_back("cont_hist2_pct", &cont_hist2_pct);
         return result;
     }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -155,6 +155,7 @@ void SearchEngine::start(position& p, const SearchLimits& lims, bool silent) {
     // through a game and is reset between games.
 
     signals_.stop = false;
+    history_.set_continuation_weights(params_.cont_hist1_pct, params_.cont_hist2_pct);
     tt_.new_search();
 
     p.set_nodes_searched(0);
@@ -590,6 +591,7 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
                     history_.update(pos.to_move(), ttm, (stack - 1)->curr_move,
                                     history_bonus(depth), static_cast<int16_t>(ttvalue), quiets,
                                     stack->killers);
+                    history_.update_continuation(pos, stack, ttm, history_bonus(depth), quiets);
                     return ttvalue;
                 }
             }
@@ -675,6 +677,7 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
         // predecessor, off a move that was never played on the board it is
         // looking at. Record the null explicitly.
         stack->curr_move = Move{};
+        stack->push_context(no_piece, 0);
         pos.do_null_move();
         int null_eval =
             (ndepth <= 0 ? -qsearch<non_pv>(pos, -beta, -beta + 1, 0, stack + 1, thread_id)
@@ -739,6 +742,7 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
             if (pos.see(pc_move) < see_threshold)
                 continue;
 
+            stack->push_context(pos.piece_on(static_cast<Square>(pc_move.f)), pc_move.t);
             pos.do_move(pc_move);
             stack->curr_move = pc_move;
 
@@ -856,6 +860,7 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
             }
         }
 
+        stack->push_context(pos.piece_on(static_cast<Square>(move.f)), move.t);
         pos.do_move(move);
         stack->curr_move = move;
 
@@ -1019,6 +1024,7 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
                 history_.update(pos.to_move(), best_move, (stack - 1)->curr_move,
                                 history_bonus(depth), static_cast<int16_t>(bestScore), quiets,
                                 stack->killers);
+                history_.update_continuation(pos, stack, best_move, history_bonus(depth), quiets);
                 break;
             }
 
@@ -1039,6 +1045,8 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
     // fired 0 times in 4240374 opportunities.
     if (bestScore <= alpha_orig && !quiets.empty())
         history_.malus(to_mv, history_bonus(depth) * params_.history_malus_pct / 100, quiets);
+        history_.malus_continuation(pos, stack, history_bonus(depth) * params_.history_malus_pct / 100,
+                                    quiets);
 
     // Best move bonus
     if (bestScore >= alpha && bestScore < beta && best_move.f != best_move.t) {
@@ -1200,6 +1208,7 @@ int SearchEngine::qsearch(position& p, int alpha, int beta, U16 depth, SearchNod
         // whose parent was also a qsearch node read whatever move some unrelated
         // subtree left at this ply and used it to key the counter-move bonus.
         stack->curr_move = move;
+        stack->push_context(p.piece_on(static_cast<Square>(move.f)), move.t);
 
         auto hashOrKiller = (move == ttm) || (move == stack->killers[0]) ||
                             (move == stack->killers[1]) || (move == stack->killers[2]) ||

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -668,6 +668,13 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
         // in the slot, so clear it: a threat should only be adopted when this
         // null search actually produced one.
         (stack + 1)->best_move = Move{};
+        // A null move is not a move, but this slot is what the child reads as
+        // "the move my parent just played". Leaving the real move that was
+        // searched here earlier in this node's own move loop makes the child
+        // key its counter-move bonus, and every history term derived from the
+        // predecessor, off a move that was never played on the board it is
+        // looking at. Record the null explicitly.
+        stack->curr_move = Move{};
         pos.do_null_move();
         int null_eval =
             (ndepth <= 0 ? -qsearch<non_pv>(pos, -beta, -beta + 1, 0, stack + 1, thread_id)

--- a/tests/test_search.cpp
+++ b/tests/test_search.cpp
@@ -306,6 +306,68 @@ TEST_F(SearchTest, MoveOrderYieldsEveryLegalMove) {
 }
 
 
+// The plain history table is keyed on (colour, from, to) alone, so a quiet
+// move carries one score averaged over every context it was ever played in.
+// Continuation history exists to separate those contexts: evidence gathered
+// while answering one predecessor must not leak into an unrelated one.
+//
+// This also pins the ownership rule that makes the table safe. A node reads its
+// predecessors from fields its parent wrote into it, never by walking back to
+// stack - 1 and stack - 2. Only the search guarantees those frames exist; the
+// first version of this code walked back and crashed here, on a four-element
+// stack, which is exactly the kind of caller that must keep working.
+TEST_F(SearchTest, ContinuationHistoryIsKeyedOnThePredecessor) {
+    std::istringstream fen("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1");
+    position pos(fen);
+
+    SearchNode stack[4];
+    for (auto& n : stack)
+        n.ply = 1;
+    SearchNode* node = &stack[1];
+
+    // A quiet move by a piece that is actually on the board: the a1 rook to b1.
+    Move quiet;
+    quiet.set(A1, B1, Movetype::quiet);
+    ASSERT_EQ(pos.piece_on(A1), rook);
+
+    Movehistory hist;
+    hist.set_continuation_weights(100, 100);
+
+    // Nothing has been played into this node yet, so there is no context to key
+    // on and the table must stay silent rather than index off some default.
+    EXPECT_EQ(hist.continuation_score(pos, quiet, node), 0)
+        << "a node with no predecessor must not read the continuation table";
+
+    // Now say the opponent answered with a knight landing on f6, and reward the
+    // rook move as the refutation of it.
+    stack[0].push_context(knight, F6);
+    std::vector<Move> none;
+    hist.update_continuation(pos, node, quiet, kMaxHistory / 4, none);
+
+    int in_context = hist.continuation_score(pos, quiet, node);
+    EXPECT_GT(in_context, 0) << "the cutoff move gained nothing in its own context";
+
+    // Same move, same node, different predecessor: a bishop landing on f6. The
+    // evidence above says nothing about this position and must not be read.
+    stack[0].push_context(bishop, F6);
+    EXPECT_EQ(hist.continuation_score(pos, quiet, node), 0)
+        << "continuation evidence leaked across predecessors";
+
+    // ...nor across the square the predecessor landed on.
+    stack[0].push_context(knight, D7);
+    EXPECT_EQ(hist.continuation_score(pos, quiet, node), 0)
+        << "continuation evidence leaked across predecessor destinations";
+
+    // Restoring the original context restores the score.
+    stack[0].push_context(knight, F6);
+    EXPECT_EQ(hist.continuation_score(pos, quiet, node), in_context);
+
+    // A weight of zero has to switch the plane off completely, or SPSA cannot
+    // ever tell us the plane was not worth its dimensions.
+    hist.set_continuation_weights(0, 0);
+    EXPECT_EQ(hist.continuation_score(pos, quiet, node), 0);
+}
+
 // ─── Time management ────────────────────────────────────────────────────────
 
 TEST(TimeManagement, SpentClockStillReturnsABudget) {


### PR DESCRIPTION
Two search fixes and the measurement note that came out of them.

**1. `2ae0712` the null search inherited a stale predecessor move**

Every node reads `(stack - 1)->curr_move` as "the move my parent just
played" and keys the counter-move bonus, the follow-up penalty and the
threat-escape bonus off it. A node writes that slot from inside its move
loop -- and null move pruning runs *before* that loop. It called
`do_null_move`, recursed with `stack + 1`, and never touched
`stack->curr_move`, so the child read whatever an unrelated subtree left
at this ply and looked up a countermove for a move that was never played
on the board it was looking at.

The null is now recorded explicitly. Every consumer already guards on
`type != no_type`, so they correctly decline to use a predecessor.

**2. `aec3ca1` index the history heuristic on the preceding move**

The history table is keyed on `(colour, from, to)` and nothing else, so a
quiet carries one score averaged over every position it was ever tried
in. The countermove table was the engine's only context-aware quiet
ordering, and it holds exactly one move per predecessor.

Continuation history keys the same cutoff evidence on the move before it:
plane 0 on the opponent's reply we are answering, plane 1 on our own move
two plies back. They are kept apart because a predecessor played by the
opponent and one played by us mean opposite things.

A node is handed its predecessors by its parent via `push_context`,
rather than walking back to `stack - 1` and `stack - 2` itself. Only the
search guarantees those frames exist; the first version walked back and
segfaulted the move ordering test, which holds a four-element stack. Null
moves push `no_piece`.

Both weights are registered parameters, not constants, and zero switches
a plane off so SPSA can say whether the second plane earns its dimensions.

**3. `5a1f5ef` docs: the history thresholds are outside the table's range**

Fell out of measuring the above. On a depth-15 bench, with the shipped
`history_malus_pct = 0`, the history table's minimum over 146769 samples
is **-194** against a `lmr_hist_bad` of 2000 and a `history_prune_margin`
of 4096. History pruning and the LMR bad-history reduction do not fire
rarely; they never fire at all. Turning the malus on slides the whole
distribution negative rather than widening it, killing `lmr_hist_good`
instead. Table and reasoning in `docs/revisit-after-tuning.md`.

**Testing.** Bench 1100791 -> 1012421 nodes, an 8.0% reduction at fixed
depth. 127/127 tests pass, including a new one pinning that continuation
evidence does not leak across predecessors. SPRT against current main,
gain bounds (elo0 = 0, elo1 = 5): **+13.4 +/- 26.1 over 454 games**,
LOS 84%.
