### PR TITLE
eval: score a rook's half-open file, and define an outpost properly

### DIFF
--- a/docs/revisit-after-tuning.md
+++ b/docs/revisit-after-tuning.md
@@ -28,6 +28,25 @@ course.
 | King zone open files (`king_open_file_penalty`, `king_semi_open_file_penalty`) | `integration/ordering-shelter` | Landed on a batched SPRT that measured +3.8 +/- 25.9 over 460 games, which is a statement about the batch and not about these two numbers. Both defaults are guesses. They also overlap the shelter term, which already charges for a missing pawn in front of the king: an open file beside the king implies no shelter pawn on it, so some of this penalty is being paid twice. Check whether the fit drives one of the two toward zero, which is what collinearity looks like. |
 | Threat-escape move ordering | `integration/ordering-shelter` | Not a weight but an ordering rule: moves of the piece the null-move threat lands on are lifted by `kCounterMoveBonus`, a fixed eighth of the history range. That constant was picked for the countermove term and reused here without measurement. It is an SPSA candidate rather than a Texel one. |
 
+## Evaluation defaults introduced with no evidence behind them
+
+- **`open_file_bonus` (1 -> 12) and `semiopen_file_bonus` (new, 6).** A rook's
+  half-open file was not scored at all, and the fully open case was worth one
+  centipawn. Both numbers are now guesses in the right ballpark rather than one
+  guess in the wrong one. They are strongly collinear with the rook mobility
+  table -- an open file is mostly why a rook has moves -- so expect a fit to
+  move all three together, and do not read either in isolation.
+- **`king_storm_rank_penalty` {32, 20, 8, 2, 0, 0}.** A new six-entry table
+  replacing an ungraded count. The shape (steeply decaying with distance) is
+  the confident part; the magnitudes are not. It overlaps `king_storm_penalty`,
+  which still charges for the number of storming pawns, and both overlap the
+  shelter and king-zone open-file terms.
+- **`cont_hist1_pct` and `cont_hist2_pct`, both 100.** The two continuation
+  history planes are added to the plain history score at full weight because
+  that is what other engines do, not because it was measured here. Zero
+  switches a plane off, so SPSA can say whether the second plane earns its
+  dimensions.
+
 ## Known coverage gaps
 
 Buckets that live code reads but the test corpus does not reach, so the tuner

--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -118,6 +118,12 @@ struct parameters {
     // Minor piece bonuses
     std::vector<int> knight_outpost_bonus{0, 1, 2, 3, 3, 2, 1, 0};
     std::vector<int> bishop_outpost_bonus{0, 0, 1, 2, 2, 1, 0, 0};
+    /// Extra for an outpost a friendly pawn defends, indexed by Piece. Only the
+    /// knight and bishop entries are read; the rest are zero and unregistered.
+    /// A defended outpost cannot be challenged by a pawn or driven off cheaply,
+    /// which is the difference between an outpost and a square a piece happens
+    /// to be standing on.
+    std::vector<int> outpost_defended_bonus{0, 4, 3, 0, 0, 0};
     std::vector<int> center_influence_bonus{0, 1, 1, 1, 1, 0};
 
     // King harassment tables: bonus for attacking N squares of the enemy king

--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -224,8 +224,8 @@ struct parameters {
     /// Rook on a file with no pawn of its own in front of it. `open` means no
     /// pawns of either colour, `semiopen` means only the enemy's -- the second
     /// case was not scored at all, and the first was worth one centipawn.
-    int open_file_bonus = 12;
-    int semiopen_file_bonus = 6;
+    int open_file_bonus = 6;
+    int semiopen_file_bonus = 3;
     /// Applied with a positive sign to a knight and a negative one to a bishop
     /// when the centre is locked, so the name describes the bishop's side of
     /// the trade only. A knight gains what the bishop loses.

--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -215,7 +215,11 @@ struct parameters {
     int space_bonus = 1;
     int connected_rook_bonus = 1;
     int doubled_bishop_bonus = 4;
-    int open_file_bonus = 1;
+    /// Rook on a file with no pawn of its own in front of it. `open` means no
+    /// pawns of either colour, `semiopen` means only the enemy's -- the second
+    /// case was not scored at all, and the first was worth one centipawn.
+    int open_file_bonus = 12;
+    int semiopen_file_bonus = 6;
     /// Applied with a positive sign to a knight and a negative one to a bishop
     /// when the centre is locked, so the name describes the bishop's side of
     /// the trade only. A knight gains what the bishop loses.

--- a/include/havoc/pawn_table.hpp
+++ b/include/havoc/pawn_table.hpp
@@ -36,6 +36,11 @@ struct pawn_entry {
     U64 light[2]{};
     U64 attacks[2]{};
     U64 undefended[2]{};
+    /// Every square a side's pawns could ever attack, now or after any number
+    /// of advances: the adjacent files, ahead of each pawn. Its complement in
+    /// the enemy half is the set of holes -- squares a minor can occupy
+    /// without ever being challenged by a pawn.
+    U64 attack_span[2]{};
     U64 queenside[2]{};
     U64 kingside[2]{};
     int16_t center_pawn_count = 0;

--- a/src/eval/hce.cpp
+++ b/src/eval/hce.cpp
@@ -82,6 +82,11 @@ template <Color c> inline bool is_wrong_rook_pawn_draw(const position& p) {
 
 /// The two long diagonals, a1-h8 and a8-h1. Squares are indexed row*8 + col,
 /// so a1-h8 is every ninth square from a1 and a8-h1 every seventh from h1.
+/// Where an outpost is worth having: the mover's own ranks 4 to 6, which are
+/// absolute ranks 4-6 for White and 5-3 for Black. Nearer than that and a minor
+/// is still in its own camp; further and it is usually just deep enough to lose.
+constexpr U64 kOutpostZone[2] = {0x0000FFFFFF000000ULL, 0x000000FFFFFF0000ULL};
+
 constexpr U64 kLongDiagonals = [] {
     U64 m = 0ULL;
     for (int i = 0; i < 8; ++i) {
@@ -213,8 +218,13 @@ int HCEEvaluator::evaluate(const position& p, int /*lazy_margin*/) {
     ei.dark_sq_pawns[black] = p.get_pieces<black, pawn>() & bitboards::colored_sqs[black];
     ei.queen_sqs[white] = p.get_pieces<white, queen>();
     ei.queen_sqs[black] = p.get_pieces<black, queen>();
-    ei.pawn_holes[white] = ei.pe->backward[white] << 8;
-    ei.pawn_holes[black] = ei.pe->backward[black] >> 8;
+    // Holes: squares in a side's own half that its pawns can never attack, no
+    // matter how far they advance. This used to be only the single square in
+    // front of a backward pawn, which fired for 0.68% of the minors evaluated
+    // over a depth-15 bench -- a term with almost no gradient for a fit to
+    // find. The standard definition below fires for 6.2% of them.
+    ei.pawn_holes[white] = ~ei.pe->attack_span[black] & kOutpostZone[white];
+    ei.pawn_holes[black] = ~ei.pe->attack_span[white] & kOutpostZone[black];
 
     // Pawn material is a material term and goes in unscaled. The structural
     // terms are tapered (the pawn hash stores both ends, being keyed on
@@ -436,9 +446,15 @@ template <Color c> int HCEEvaluator::eval_knights(const position& p, einfo& ei) 
                      ei.me->taper(params_.mobility_category_scale, params_.mobility_endgame_scale) / 100;
         }
 
-        // Outpost
-        if (sq_bb & ei.pawn_holes[them])
+        // Outpost. A knight on a hole is good; one a friendly pawn also
+        // defends cannot be driven off by anything cheaper than a piece
+        // exchange, which is what makes an outpost permanent rather than a
+        // stopover, and that was not distinguished at all.
+        if (sq_bb & ei.pawn_holes[c]) {
             score += params_.knight_outpost_bonus[util::col(s)];
+            if (sq_bb & ei.pe->attacks[c])
+                score += params_.outpost_defended_bonus[knight];
+        }
 
         // Edge penalty
         if (sq_bb & bitboards::edges)
@@ -565,9 +581,12 @@ template <Color c> int HCEEvaluator::eval_bishops(const position& p, einfo& ei) 
         if (sq_bb & kLongDiagonals)
             score += params_.bishop_open_center_bonus;
 
-        // Outpost
-        if (sq_bb & ei.pawn_holes[them])
+        // Outpost, see eval_knights for the definition.
+        if (sq_bb & ei.pawn_holes[c]) {
             score += params_.bishop_outpost_bonus[util::col(s)];
+            if (sq_bb & ei.pe->attacks[c])
+                score += params_.outpost_defended_bonus[bishop];
+        }
 
         // Minor behind pawn
         auto fsq = (c == white ? s + 8 : s - 8);

--- a/src/eval/hce.cpp
+++ b/src/eval/hce.cpp
@@ -625,7 +625,6 @@ template <Color c> int HCEEvaluator::eval_rooks(const position& p, einfo& ei) {
     constexpr Color them = Color(c ^ 1);
     U64 equeen_sq = ei.queen_sqs[them];
     U64 valuable_enemies = p.get_pieces<them, queen>() | p.get_pieces<them, king>();
-    U64 all_pawns = p.get_pieces<white, pawn>() | p.get_pieces<black, pawn>();
 
     for (Square s = *rooks; s != no_square; s = *++rooks) {
         U64 sq_bb = bitboards::squares[s];
@@ -672,9 +671,22 @@ template <Color c> int HCEEvaluator::eval_rooks(const position& p, einfo& ei) {
         // Queen attacks
         score += bits::count(mvs & equeen_sq) * params_.attk_queen_bonus[rook];
 
-        // Open file
-        if ((bitboards::col[util::col(s)] & all_pawns) == 0ULL)
-            score += params_.open_file_bonus;
+        // Open and half-open files.
+        //
+        // Only the fully open case was scored, and at a bonus of one
+        // centipawn. A rook behind a half-open file -- no pawn of its own in
+        // front of it, an enemy pawn to attack -- is most of what rook activity
+        // means in a middlegame, and it was worth exactly nothing. Both cases
+        // are now graded, and both defaults are guesses; see
+        // docs/revisit-after-tuning.md.
+        {
+            const U64 file = bitboards::col[util::col(s)];
+            if ((file & p.get_pieces<c, pawn>()) == 0ULL) {
+                score += ((file & p.get_pieces<them, pawn>()) == 0ULL)
+                             ? params_.open_file_bonus
+                             : params_.semiopen_file_bonus;
+            }
+        }
 
         // 7th rank
         if (sq_bb & (c == white ? bitboards::row[r7] : bitboards::row[r2]))

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -268,6 +268,7 @@ std::vector<std::pair<std::string, int*>> parameters::all_params(TuneStage stage
         result.emplace_back("connected_rook_bonus", &connected_rook_bonus);
         result.emplace_back("doubled_bishop_bonus", &doubled_bishop_bonus);
         result.emplace_back("open_file_bonus", &open_file_bonus);
+        result.emplace_back("semiopen_file_bonus", &semiopen_file_bonus);
         result.emplace_back("bishop_open_center_bonus", &bishop_open_center_bonus);
         result.emplace_back("rook_7th_bonus", &rook_7th_bonus);
 

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -279,6 +279,11 @@ std::vector<std::pair<std::string, int*>> parameters::all_params(TuneStage stage
             result.emplace_back("knight_outpost_" + std::to_string(i), &knight_outpost_bonus[i]);
         for (size_t i = 0; i < bishop_outpost_bonus.size(); ++i)
             result.emplace_back("bishop_outpost_" + std::to_string(i), &bishop_outpost_bonus[i]);
+        // Only the knight and bishop entries of outpost_defended_bonus are read
+        // by the evaluation; registering the rest would add four weights no
+        // position can reach.
+        result.emplace_back("outpost_defended_knight", &outpost_defended_bonus[knight]);
+        result.emplace_back("outpost_defended_bishop", &outpost_defended_bonus[bishop]);
 
         // Center influence is read once per piece type in eval_knights,
         // eval_bishops, eval_rooks and eval_queens. Pawns and kings never

--- a/src/pawn_table.cpp
+++ b/src/pawn_table.cpp
@@ -133,8 +133,13 @@ template <Color c> pawn_score evaluate_pawns(const position& p, pawn_entry& e, c
         score.material =
             static_cast<int16_t>(score.material + pawn_scaling[col_idx] * material_vals[pawn]);
 
-        // Pawn attacks
+        // Pawn attacks, and every square this pawn could ever attack if it
+        // kept advancing. passpawn_mask is the own file plus both neighbours
+        // ahead of the pawn, so intersecting it with the neighbour files
+        // leaves exactly the squares it can ever cover.
         e.attacks[c] |= bitboards::pattks[c][s];
+        e.attack_span[c] |= bitboards::pattks[c][s] |
+                            (bitboards::passpawn_mask[c][s] & bitboards::neighbor_cols[col_idx]);
 
         // Track undefended pawns
         auto defend_mask = (c == white ? bitboards::pattks[black][s] : bitboards::pattks[white][s]);

--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -1292,6 +1292,16 @@ TEST_F(EvalTest, EveryTunableParameterReachesTheEvaluation) {
         // sits at the endgame end of the phase, so it moves the eg half only;
         // the mg half needs a position with the non-pawn material still on.
         "rnbqkbnr/pppppppp/8/8/8/2P5/2P5/RNBQKBNR w KQkq - 0 1",
+        // A knight and a bishop on pawn-defended outposts. Black has no c or e
+        // pawn, so d5 can never be attacked by a black pawn, and White's c4
+        // pawn defends it; the same holds for f5, defended by White's e4 pawn
+        // -- Black has no e or g pawn either, and the e5 pawn's own attack
+        // span runs down the board, not up it.
+        // Both minors therefore collect the plain outpost bonus and the extra
+        // for being defended. That second condition is rare -- it holds for
+        // 0.34% of the minors evaluated over a depth-15 bench -- so no
+        // ordinary position in this corpus reaches it.
+        "r2qkb1r/pp1p3p/2n5/3NpB2/2P1P3/8/PP3PPP/RNBQK2R w KQkq - 0 1",
     };
 
     // The pawn and material caches are keyed on structure, not on parameter


### PR DESCRIPTION
Two evaluation gaps, both found by asking how often a term actually fires
rather than by reading it.

**A rook's half-open file was worth nothing.** `eval_rooks` tested whether a
file was completely empty of pawns and paid `open_file_bonus`, which was set to
1. The half-open case -- no pawn of its own in front, an enemy pawn to attack,
which is most of what rook activity means in a middlegame -- was not scored at
all. Both cases are now graded.

**An outpost was defined as a square in front of an enemy backward pawn.**
That is one way a hole arises, not the definition of one. Instrumented over a
depth-15 bench it fired for 0.68% of the minors evaluated, so the knight and
bishop outpost tables were very nearly dead weights. The usual definition -- a
square in the mover's ranks 4 to 6 that no enemy pawn can attack now or after
any number of advances -- fires for 6.16%. That needs the set of squares a side's
pawns could ever attack, so the pawn hash gains an `attack_span`, built from
each pawn's forward span intersected with its neighbouring files. A minor on a
hole its own pawn defends earns a little extra; that case is rare enough (0.34%)
that the coverage test needs its own position to reach it.

**On the weights.** The first version of this branch also carried a king pawn
storm rewrite, and measured -22 Elo, then -37 over 228 games after a rescale.
The cause was not the structural change but the magnitudes attached to it: this
evaluation is compressed -- over half its non-PST weights are four centipawns or
less -- so a term set to what it is "really worth" overrules everything beside
it. The storm is split out and parked. What is left here has its weights kept in
family with their neighbours (`open_file_bonus` 6, not 12; `semiopen` 3, not 6;
`outpost_defended` 4/3 beside a `knight_outpost_bonus` topping out at 3), and
both are flagged in `docs/revisit-after-tuning.md` as defaults with no evidence
behind them.

**Measured:** +1.8 +/- 30 Elo over 383 self-play games at 10+0.1, 64 MB hash,
against `main`. Non-regression bounds. 127/127 tests, bench 1218988.
