### PR TITLE
search: bring the last four search literals into the parameter block

### DIFF
--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -368,6 +368,16 @@ struct parameters {
     int best_move_bonus = 2;        // best-move history bonus, times depth
     int history_bonus_scale = 1;    // history bonus is scale * depth^2
     int history_malus_pct = 0;      // fail-low penalty, percent of the bonus (0 = off)
+    /// Internal iterative reduction: with no hash move, search one ply shallower
+    /// so the next visit has one. Both of these were bare literals in search.cpp
+    /// and so invisible to SPSA, which is the whole reason this block exists.
+    int iir_min_depth = 4;          // IIR only at or above this depth
+    int iir_cut_margin = 200;       // ...and at a cut node only if eval + this >= beta
+    /// The two shallow-quiet rules near the bottom of the move loop: one extra
+    /// reduction for an uninteresting quiet, one extra ply for a quiet that
+    /// answers a threat or pushes a pawn. Both were spelled `depth <= 2`.
+    int lmr_extra_max_depth = 2;    // extra reduction for dull quiets at or below this
+    int quiet_ext_max_depth = 2;    // extension for dangerous quiets at or below this
 
     /// Continuation history weights, as a percentage of the raw table value.
     /// Plane 1 is keyed on the opponent's reply we are answering, plane 2 on

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -382,6 +382,10 @@ std::vector<std::pair<std::string, int*>> parameters::all_params(TuneStage stage
         result.emplace_back("probcut_margin", &probcut_margin);
         result.emplace_back("probcut_depth_reduction", &probcut_depth_reduction);
         result.emplace_back("lmr_min_depth", &lmr_min_depth);
+        result.emplace_back("iir_min_depth", &iir_min_depth);
+        result.emplace_back("iir_cut_margin", &iir_cut_margin);
+        result.emplace_back("lmr_extra_max_depth", &lmr_extra_max_depth);
+        result.emplace_back("quiet_ext_max_depth", &quiet_ext_max_depth);
         result.emplace_back("lmr_hist_bad", &lmr_hist_bad);
         result.emplace_back("lmr_hist_good", &lmr_hist_good);
         result.emplace_back("best_move_bonus", &best_move_bonus);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -632,8 +632,9 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
     bool hasStaticValue = static_eval_val != score::kNegInf;
 
     // IIR: If we have no hash move at a PV or cut node, reduce depth.
-    if (!singular_search && depth >= 4 && ttm.type == static_cast<U8>(no_type) &&
-        (pvNode || (!pvNode && static_eval_val + 200 >= beta))) {
+    if (!singular_search && depth >= params_.iir_min_depth &&
+        ttm.type == static_cast<U8>(no_type) &&
+        (pvNode || (!pvNode && static_eval_val + params_.iir_cut_margin >= beta))) {
         depth -= 1;
     }
 
@@ -871,14 +872,16 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
 
         // Reduce uninteresting quiet moves
         if (!pvNode && !improving && !hashOrKiller && !isCapture && !isEvasion && !givesCheck &&
-            !isPromotion && !advancedPawnPush && depth <= 2 && bestScore <= alpha)
+            !isPromotion && !advancedPawnPush && depth <= params_.lmr_extra_max_depth &&
+            bestScore <= alpha)
             reductions_val += 1;
 
         // Extend likely interesting quiet moves
         auto threatResponse = (stack->threat_move.type != static_cast<U8>(no_type) &&
                                stack->threat_move.f == move.t) &&
                               isCapture;
-        if (!pvNode && !improving && !hashOrKiller && !isCapture && depth <= 2 &&
+        if (!pvNode && !improving && !hashOrKiller && !isCapture &&
+            depth <= params_.quiet_ext_max_depth &&
             bestScore < alpha && bestScore > score::kMatedMaxPly &&
             (dangerousQuietCheck || advancedPawnPush || threatResponse))
             extensions += 1;


### PR DESCRIPTION
The search parameter block exists because these constants have no Texel
gradient: changing one changes *which nodes get visited*, not what any position
is worth, so SPSA is the only thing that can fit them -- and it can only fit
what it can see. Four constants were still bare literals in `search.cpp`:

| literal | what it controls |
| --- | --- |
| `depth >= 4` | internal iterative reduction minimum depth |
| `static_eval_val + 200 >= beta` | ...and its cut-node margin |
| `depth <= 2` | extra reduction for an uninteresting quiet move |
| `depth <= 2` | extension for a quiet move that answers a threat |

The two `depth <= 2` rules are unrelated to one another and equal only by
coincidence, so they get separate names rather than a shared constant.

This matters now because the next piece of search work is a joint SPSA fit over
the history block -- `history_bonus_scale`, `history_malus_pct`, `lmr_hist_bad`,
`lmr_hist_good` and `history_prune_margin`, which measurement has shown are one
mechanism and are currently set so that two of them never fire at all. Anything
still hidden from the tuner at that point is a dimension the fit silently cannot
use.

**No SPRT.** Defaults reproduce the literals exactly and bench is unchanged at
1218988, identical to `main`. A parameterisation commit that moves a single node
has a bug in it; this one moves none. 127/127 tests.
