### PR TITLE
eval: judge a backward pawn by its rearmost neighbour, not its most advanced

### DIFF
--- a/docs/revisit-after-tuning.md
+++ b/docs/revisit-after-tuning.md
@@ -130,3 +130,42 @@ the assertion from a curated observation into something that follows from a
 symmetric evaluation. Until then, expect to re-curate this list whenever the
 evaluation changes, and check eval-level symmetry first: if the position's
 evaluation still equals minus its mirror's, the search residual is the cause.
+
+## Half the evaluation is written in units it cannot speak in
+
+Counting every non-PST tunable in `parameters.hpp` against a pawn worth 100:
+
+| range | count | share |
+| --- | --- | --- |
+| exactly 0 | 18 | 6% |
+| 1 to 4 | 154 | 52% |
+| 5 to 15 | 79 | 27% |
+| 16 to 50 | 30 | 10% |
+| above 50 | 34 | 11% |
+
+Over half the evaluation's weights are worth four centipawns or less. That is
+not a tuning observation, it is a structural one: a term that spans two
+centipawns end to end cannot express a judgement at all, whatever the position.
+`king_shelter` is `{-1, -1, 1, 1}` -- a king with no pawns in front of it and a
+king behind three are two centipawns apart. `threat_weak_pawn` is `{1, 1, 1, 1}`,
+so a queen attacking a hanging pawn says the same thing as a knight. Terms like
+these are outvoted by a single piece-square entry.
+
+This is the most likely reason a large body of chess knowledge in this
+evaluation never showed up in the rating, and the most likely place for Texel
+tuning to find a lot at once: the shapes are mostly right and the magnitudes are
+mostly placeholders. It also says something about what to do *before* tuning.
+Every dead or near-dead term found this session -- outposts firing for 0.68% of
+minors, a rook's open file worth 1 and its half-open file worth nothing, two
+storming pawns worth nothing, a passer on rank 4 worth 2 with the rest of its
+evaluation skipped entirely -- would have been fitted as noise by a tuner rather
+than fixed by one. Structure first, magnitudes second.
+
+The corollary is the trap this session fell into twice. Correcting a structural
+defect invites setting the new weight to what the term "should" be worth, which
+in a compressed evaluation means setting it far above its neighbours. A king
+storm table peaking at 32 beside a `king_open_file_penalty` of 9 measured -22
+Elo; at 12, which is 36 centipawns summed over three pawns against a previous
+maximum of 4, it measured -37 over 228 games. Fix the shape, keep the magnitude
+in family with whatever sits beside it, and let the tuner raise the whole block
+together.

--- a/src/pawn_table.cpp
+++ b/src/pawn_table.cpp
@@ -19,62 +19,22 @@ inline size_t prev_pow2(size_t x) {
     return prev_pow2(x >> 1) << 1;
 }
 
+/// A pawn is backward when no pawn on a neighbouring file can ever defend it,
+/// which is to say every one of them stands strictly in front of it.
+///
+/// The old implementation scanned each neighbouring file for its *most
+/// advanced* pawn and asked whether that one was ahead. That is the wrong end
+/// of the file: with white pawns on a2, a5 and b3, the a-file's most advanced
+/// pawn is a5, which is ahead of b3, so b3 was called backward -- while a2 was
+/// defending it. What decides the question is the rearmost neighbour, so the
+/// test is simply whether any neighbouring pawn stands on this pawn's rank or
+/// behind it. A pawn with no neighbours at all satisfies it vacuously, which
+/// is deliberate and matches the old behaviour: the square in front of an
+/// isolated pawn is as much a hole as the one in front of a backward pawn.
 template <Color c> bool backward_pawn(int row, int col, U64 pawns) {
-    int left = col - 1 < Col::A ? -1 : col - 1;
-    int right = col + 1 > Col::H ? -1 : col + 1;
-    bool left_greater = false;
-    bool right_greater = false;
-
-    if constexpr (c == white) {
-        if (left != -1) {
-            int sq = -1;
-            U64 left_pawns = bitboards::col[left] & pawns;
-            bool no_left_pawns = (left_pawns == 0ULL);
-            while (left_pawns) {
-                int tmp = bits::pop_lsb(left_pawns);
-                if (tmp > sq)
-                    sq = tmp;
-            }
-            left_greater = (sq > 0 && util::row(sq) > row) || no_left_pawns;
-        }
-        if (right != -1) {
-            int sq = -1;
-            U64 right_pawns = bitboards::col[right] & pawns;
-            bool no_right_pawns = (right_pawns == 0ULL);
-            while (right_pawns) {
-                int tmp = bits::pop_lsb(right_pawns);
-                if (tmp > sq)
-                    sq = tmp;
-            }
-            right_greater = (sq > 0 && util::row(sq) > row) || no_right_pawns;
-        }
-    } else {
-        if (left != -1) {
-            int sq = 100;
-            U64 left_pawns = bitboards::col[left] & pawns;
-            bool no_left_pawns = (left_pawns == 0ULL);
-            while (left_pawns) {
-                int tmp = bits::pop_lsb(left_pawns);
-                if (tmp < sq)
-                    sq = tmp;
-            }
-            left_greater = (sq < 100 && util::row(sq) < row) || no_left_pawns;
-        }
-        if (right != -1) {
-            int sq = 100;
-            U64 right_pawns = bitboards::col[right] & pawns;
-            bool no_right_pawns = (right_pawns == 0ULL);
-            while (right_pawns) {
-                int tmp = bits::pop_lsb(right_pawns);
-                if (tmp < sq)
-                    sq = tmp;
-            }
-            right_greater = (sq < 100 && util::row(sq) < row) || no_right_pawns;
-        }
-    }
-
-    return (left == -1 && right_greater) || (right == -1 && left_greater) ||
-           (left_greater && right_greater);
+    const U64 behind_or_level = (c == white) ? ((row == 7) ? ~0ULL : ((1ULL << (8 * (row + 1))) - 1))
+                                             : ~((1ULL << (8 * row)) - 1);
+    return (bitboards::neighbor_cols[col] & pawns & behind_or_level) == 0ULL;
 }
 
 const float pawn_scaling[8] = {0.86f, 0.90f, 0.95f, 1.00f, 1.00f, 0.95f, 0.90f, 0.86f};

--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -113,6 +113,50 @@ TEST_F(EvalTest, StartposIsApproximatelyZero) {
     EXPECT_LE(score, 50) << "Startpos eval too high: " << score;
 }
 
+// ─── Backward pawns ────────────────────────────────────────────────────────
+
+// A pawn is backward when no pawn on a neighbouring file can ever defend it.
+// The old test scanned each neighbouring file for its most advanced pawn and
+// asked whether that one stood in front -- the wrong end of the file. With
+// pawns on a2, a5 and b3, a5 is ahead of b3 and so b3 was called backward,
+// while a2 was attacking b3 at the time.
+TEST_F(EvalTest, ABackwardPawnIsOneNoNeighbourCanDefend) {
+    havoc::parameters params;
+    havoc::pawn_table pt(params);
+
+    struct Case {
+        const char* fen;
+        const char* square;
+        int sq;
+        bool backward;
+        const char* why;
+    };
+    const Case cases[] = {
+        {"4k3/8/8/P7/8/1P6/8/4K3 w - - 0 1", "b3", havoc::B3, true,
+         "the only neighbour is a5, which is strictly in front"},
+        {"4k3/8/8/P7/8/1P6/P7/4K3 w - - 0 1", "b3", havoc::B3, false,
+         "a2 is behind b3 -- in fact it attacks it. The old code looked at "
+         "a5, the most advanced a-pawn, and called b3 backward anyway"},
+        {"4k3/8/8/P7/8/1P6/8/4K3 w - - 0 1", "a5", havoc::A5, false,
+         "b3 is behind a5 and can advance to b4 beside it"},
+        {"4k3/8/8/8/8/1P6/8/4K3 w - - 0 1", "b3", havoc::B3, true,
+         "no neighbouring pawns at all: vacuously backward, which the "
+         "outpost code relies on"},
+        {"4k3/8/8/8/1P6/2P5/8/4K3 w - - 0 1", "c3", havoc::C3, true,
+         "b4 is the only neighbour and it is strictly in front"},
+        {"4k3/8/8/8/1P6/2P5/8/4K3 w - - 0 1", "b4", havoc::B4, false,
+         "c3 is behind b4"},
+    };
+
+    for (const auto& c : cases) {
+        auto pos = make_pos(c.fen);
+        const auto* e = pt.fetch(pos);
+        const bool got = (e->backward[havoc::white] & havoc::bitboards::squares[c.sq]) != 0ULL;
+        EXPECT_EQ(got, c.backward)
+            << c.square << " in " << c.fen << ": " << c.why;
+    }
+}
+
 // ─── Evaluation must be a function of the position ─────────────────────────
 
 // has_castled is set only by do_move when a castling move is played, and is


### PR DESCRIPTION
`backward_pawn` scanned each neighbouring file for the pawn **furthest up the
board** and asked whether that one stood in front. That is the wrong end of the
file. What decides whether a pawn is backward is the *rearmost* neighbour,
because that is the one that can still come up beside it -- or is already
defending it.

With white pawns on a2, a5 and b3, the a-file's most advanced pawn is a5, which
is in front of b3, so b3 was called backward while a2 was attacking it. Any file
with a pawn ahead of the one being asked about produced a false positive, and
the wrecked structures engines actually see are exactly the ones with pawns
scattered up a file.

The corrected test is a single mask: is there any neighbouring pawn on this
pawn's rank or behind it. A pawn with no neighbours at all still satisfies it,
which is deliberate and unchanged -- the square in front of an isolated pawn is
as much a hole as the one in front of a backward pawn.

This feeds `backward_pawn_penalty` and `backward_pawn_semiopen`. It used to feed
the outpost definition too, until #45 replaced that with a proper one.

Also included: a `docs/revisit-after-tuning.md` section recording that **over
half the evaluation's non-PST weights are four centipawns or less** against a
pawn worth 100, and eighteen are exactly zero. `king_shelter` is
`{-1, -1, 1, 1}` -- a king with no pawns in front of it and a king behind three
are two centipawns apart. That is the most likely reason a large body of chess
knowledge in this evaluation never showed up in the rating, and the most likely
place for tuning to find a lot at once.

**Measured:** -5.3 +/- 30 Elo over 391 self-play games at 10+0.1, non-regression
bounds, against `main`. A correctness fix that removes false positives from a
penalty is expected to read neutral. 128/128 tests including a new unit test
pinning six cases.
