### PR TITLE
search: put the continuation malus inside the condition it belongs to

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1043,13 +1043,19 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
     // Every quiet tried at a node that failed low is evidence against that
     // move. Without this the table only learns from beta cutoffs, and since a
     // cutoff node has tried a mean of 0.34 quiets before it cuts, the negative
-    // side of the table never develops: over a depth-15 bench it bottoms out
-    // at -1769 against a history pruning threshold of -12288, so that pruning
-    // fired 0 times in 4240374 opportunities.
-    if (bestScore <= alpha_orig && !quiets.empty())
-        history_.malus(to_mv, history_bonus(depth) * params_.history_malus_pct / 100, quiets);
-        history_.malus_continuation(pos, stack, history_bonus(depth) * params_.history_malus_pct / 100,
-                                    quiets);
+    // side of the table never develops -- see docs/revisit-after-tuning.md for
+    // the measured distribution and why history_malus_pct is still 0.
+    //
+    // The braces matter: malus_continuation sat outside the condition and ran
+    // at every node, including the ones that cut. It is only harmless today
+    // because history_malus_pct is 0, which makes the malus itself 0 -- so the
+    // first thing an SPSA fit does when it raises that parameter is corrupt the
+    // continuation tables at every cutoff node in the search.
+    if (bestScore <= alpha_orig && !quiets.empty()) {
+        const int malus = history_bonus(depth) * params_.history_malus_pct / 100;
+        history_.malus(to_mv, malus, quiets);
+        history_.malus_continuation(pos, stack, malus, quiets);
+    }
 
     // Best move bonus
     if (bestScore >= alpha && bestScore < beta && best_move.f != best_move.t) {


### PR DESCRIPTION
Missing braces, and mine -- introduced with continuation history in #44.

```cpp
if (bestScore <= alpha_orig && !quiets.empty())
    history_.malus(to_mv, ..., quiets);
    history_.malus_continuation(pos, stack, ..., quiets);   // always runs
```

`malus_continuation` sat one line below a single-statement `if`, so it ran at
**every** node rather than only at the ones that failed low -- including every
node that produced a beta cutoff, where the quiets tried are evidence *for* the
move that cut, not against it.

It is invisible today only because `history_malus_pct` is 0, which makes the
malus 0, and `apply_history_bonus(h, 0)` is `h += 0 - h * 0 / kMaxHistory` --
an exact no-op. Bench is unchanged at 823170 for that reason, so this cannot
change play at shipped defaults and is merged without an SPRT.

Set the parameter to 100 and the two diverge immediately:

| `history_malus_pct=100` | bench |
| --- | --- |
| before | 827944 |
| after | 901467 |

Which is the point. The next piece of search work queued is a **joint SPSA fit
over the five history parameters** -- `history_bonus_scale`,
`history_malus_pct`, `lmr_hist_bad`, `lmr_hist_good`, `history_prune_margin` --
because measurement showed two of them currently never fire at all. Raising
`history_malus_pct` is the first thing that fit will do, and it would have been
tuning against continuation tables corrupted at every cutoff node, reading the
result as a property of the parameters.

Also replaces a stale comment quoting a `-12288` threshold and a `-1769` floor
from an earlier instrumentation run with a pointer to the measured table in
`docs/revisit-after-tuning.md`, and computes the malus once instead of twice.

128/128 tests.
