### PR TITLE
eval: score a passed pawn on every rank, not just the last three

### DIFF
--- a/docs/revisit-after-tuning.md
+++ b/docs/revisit-after-tuning.md
@@ -169,3 +169,39 @@ Elo; at 12, which is 36 centipawns summed over three pawns against a previous
 maximum of 4, it measured -37 over 228 games. Fix the shape, keep the magnitude
 in family with whatever sits beside it, and let the tuner raise the whole block
 together.
+
+## Passed pawn ladder and blocked penalty
+
+`eval_passed_pawns` used to stop at `row_dist > 3`, so a passer four or more
+ranks from promotion collected 2 centipawns and skipped the rest of the
+function entirely -- no rook-behind credit, no connected-passer bonus, no
+control of the square in front, and no penalty for losing it. Both tables are
+now six entries covering every rank a passer can stand on.
+
+| | old | new |
+| --- | --- | --- |
+| `passed_pawn_rank_bonus` | `{2, 45, 90, 180}` | `{5, 11, 22, 45, 90, 180}` |
+| `passed_pawn_blocked_penalty` | `{30, 55, 120}` | `{3, 7, 15, 30, 55, 120}` |
+
+The three new entries in each continue the existing ladder's roughly doubling
+shape downward. That is a guess about shape, not a fitted answer, and the
+shape is the part worth re-examining: it assumes the value of a passer grows
+geometrically with advancement, which is the usual assumption but not a
+measured one.
+
+The first version of this change widened only the bonus table and left the
+penalty at three entries with a clamped index, which charged a passer six ranks
+out the same 30 centipawns that a passer three ranks out pays -- against a
+bonus of 5. That measured -30 Elo over 127 games. Widening both tables together
+brought it back to neutral. Worth remembering as the same lesson in a different
+costume: extending a term's *scope* is as much a weight change as editing its
+value, because every constant that term touches now applies to positions it
+never applied to before.
+
+## Outpost defended bonus
+
+`outpost_defended_bonus` is `{0, 4, 3, 0, 0, 0}` -- a knight or bishop on a hole
+that one of its own pawns defends. The case is rare (0.34% of minors over a
+depth-15 bench) and the two values were chosen to sit beside
+`knight_outpost_bonus`, which tops out at 3, rather than from any evidence that
+a defended outpost is worth about as much again as the outpost itself.

--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -337,9 +337,18 @@ struct parameters {
     int passed_pawn_rook_support = 30;  ///< own rook behind with a clear path
     int passed_pawn_connected = 30;     ///< another passer on a neighbouring file
     /// Penalty when the square in front is controlled by the opponent, by
-    /// distance to promotion, indexed [3 - row_dist]: entry 0 is three ranks
-    /// out and entry 2 is one step from queening.
-    std::array<int, 3> passed_pawn_blocked_penalty = {30, 55, 120};
+    /// distance to promotion, indexed [6 - row_dist] to match the rank ladder
+    /// above: entry 0 is a passer on its starting rank and entry 5 is one step
+    /// from queening.
+    ///
+    /// This had three entries covering the last three ranks, because that was
+    /// all eval_passed_pawns looked at. Widening the ladder without widening
+    /// this would charge a passer six ranks from promotion the same 30 that a
+    /// passer three ranks out pays, against a rank bonus of 5 -- a pawn worth
+    /// five centipawns losing thirty for a square it was never going to reach
+    /// this move. The three new entries stay in proportion to the bonuses they
+    /// sit beside.
+    std::array<int, 6> passed_pawn_blocked_penalty = {3, 7, 15, 30, 55, 120};
 
     // Search
     int fixed_depth = -1;

--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -331,6 +331,19 @@ struct parameters {
     /// A passed pawn is the single most decisive structural feature on the
     /// board, and every term below the rank ladder was fixed at a number
     /// nobody could fit. Defaults reproduce the previous literals exactly.
+    /// The five terms below are flat: they say the same thing about a passer on
+    /// rank 2 as about one on rank 7. That was harmless while eval_passed_pawns
+    /// only looked at the last three ranks, and became wrong the moment it
+    /// looked at all of them -- a rank 2 passer with a rook behind it collected
+    /// passed_pawn_rook_support, which is 30, against a rank bonus of 5.
+    ///
+    /// Rather than give each of them its own ladder, they are scaled together
+    /// by distance to promotion, indexed [6 - row_dist] like the two tables
+    /// above. The last three entries are 100 on purpose: those are the ranks
+    /// the old code evaluated, and this change must leave them untouched and
+    /// only add to the ranks that were previously scored at 2 centipawns and
+    /// skipped.
+    std::array<int, 6> passed_pawn_support_scale = {10, 25, 50, 100, 100, 100};
     int passed_pawn_unblocked = 1;      ///< square in front is empty
     int passed_pawn_control = 3;        ///< per attacker of the square in front, each side
     int passed_pawn_rook_behind = 1;    ///< own rook anywhere behind on the file

--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -314,12 +314,18 @@ struct parameters {
     int wrong_rook_pawn_scale = 0;
 
     // Passed pawn rank bonuses
-    /// Passed-pawn bonus by distance to promotion, indexed [4 - row_dist],
-    /// so entry 0 is a passer still four or more ranks away and entry 3 is one
-    /// step from queening. These values were hard-coded inside
-    /// eval_passed_pawns while this array sat registered with the tuner and
-    /// read by nothing.
-    std::array<int, 4> passed_pawn_rank_bonus = {2, 45, 90, 180};
+    /// Passed-pawn bonus by distance to promotion, indexed [6 - row_dist], so
+    /// entry 0 is a passer on its starting rank and entry 5 is one step from
+    /// queening.
+    ///
+    /// This used to be four entries covering only the last three ranks, with
+    /// everything further out collapsed into entry 0 at 2 centipawns -- and
+    /// eval_passed_pawns took an early exit at that point, so a passer on
+    /// rank 4 was not merely worth two centipawns, it was also not credited
+    /// with a rook behind it, a connected neighbour, or control of the square
+    /// in front. The bottom three entries continue the existing ladder's
+    /// roughly doubling shape downward rather than inventing a new scale.
+    std::array<int, 6> passed_pawn_rank_bonus = {5, 11, 22, 45, 90, 180};
 
     /// The rest of eval_passed_pawns, which carried these as bare literals.
     /// A passed pawn is the single most decisive structural feature on the

--- a/src/eval/hce.cpp
+++ b/src/eval/hce.cpp
@@ -1252,11 +1252,8 @@ template <Color c> int HCEEvaluator::eval_passed_pawns(const position& p, einfo&
         // 5. Closer to promotion
         score += params_.passed_pawn_rank_bonus[6 - row_dist];
 
-        // The blocked penalty only ever had entries for the last three ranks.
-        // A passer further out that loses the square in front is charged the
-        // furthest-out rate rather than reading off the end of the table.
         if (crudeControl < 0)
-            score -= params_.passed_pawn_blocked_penalty[std::max(0, 3 - row_dist)];
+            score -= params_.passed_pawn_blocked_penalty[6 - row_dist];
     }
     return score;
 }

--- a/src/eval/hce.cpp
+++ b/src/eval/hce.cpp
@@ -1201,9 +1201,16 @@ template <Color c> int HCEEvaluator::eval_passed_pawns(const position& p, einfo&
 
         Square front = (c == white ? Square(f + 8) : Square(f - 8));
 
+        // Everything from here to the rank ladder is flat -- it says the same
+        // thing about a passer on rank 2 as about one on rank 7 -- so it is
+        // accumulated separately and scaled by distance to promotion at the
+        // end. The scale is 100 for the last three ranks, which are the only
+        // ones this function used to reach at all.
+        int support = 0;
+
         // 1. Is next square blocked?
         if (p.piece_on(front) == no_piece)
-            score += params_.passed_pawn_unblocked;
+            support += params_.passed_pawn_unblocked;
 
         // 2. Control of front square
         U64 our_attackers = 0ULL;
@@ -1217,11 +1224,11 @@ template <Color c> int HCEEvaluator::eval_passed_pawns(const position& p, einfo&
 
         if (our_attackers != 0ULL) {
             crudeControl += bits::count(our_attackers);
-            score += params_.passed_pawn_control * bits::count(our_attackers);
+            support += params_.passed_pawn_control * bits::count(our_attackers);
         }
         if (their_attackers != 0ULL) {
             crudeControl -= bits::count(their_attackers);
-            score -= params_.passed_pawn_control * bits::count(their_attackers);
+            support -= params_.passed_pawn_control * bits::count(their_attackers);
         }
 
         // 3. Rooks behind passed pawns
@@ -1235,10 +1242,10 @@ template <Color c> int HCEEvaluator::eval_passed_pawns(const position& p, einfo&
                     auto supports = ((bitboards::between[rf][f] & p.all_pieces()) ^
                                      (bitboards::squares[rf] | bitboards::squares[f])) == 0ULL;
                     if (isBehind)
-                        score += params_.passed_pawn_rook_behind;
+                        support += params_.passed_pawn_rook_behind;
                     if (isBehind && supports) {
                         crudeControl += 1;
-                        score += params_.passed_pawn_rook_support;
+                        support += params_.passed_pawn_rook_support;
                     }
                 }
             }
@@ -1247,9 +1254,12 @@ template <Color c> int HCEEvaluator::eval_passed_pawns(const position& p, einfo&
         // 4. Connected passers
         auto connectedPassed = (bitboards::neighbor_cols[util::col(f)] & ei.pe->passed[c]) != 0ULL;
         if (connectedPassed)
-            score += params_.passed_pawn_connected;
+            support += params_.passed_pawn_connected;
 
-        // 5. Closer to promotion
+        score += (support * params_.passed_pawn_support_scale[6 - row_dist]) / 100;
+
+        // 5. Closer to promotion. The ladder and the blocked penalty are graded
+        // by rank in their own right, so they are not scaled again.
         score += params_.passed_pawn_rank_bonus[6 - row_dist];
 
         if (crudeControl < 0)

--- a/src/eval/hce.cpp
+++ b/src/eval/hce.cpp
@@ -1194,10 +1194,10 @@ template <Color c> int HCEEvaluator::eval_passed_pawns(const position& p, einfo&
         Square f = Square(bits::pop_lsb(passers));
         int row_dist = (c == white ? 7 - util::row(f) : util::row(f));
 
-        if (row_dist > 3 || row_dist <= 0) {
-            score += params_.passed_pawn_rank_bonus[0];
+        // A pawn cannot be passed on the rank it promotes on, so row_dist is
+        // always 1..6 and every entry of the ladder below is reachable.
+        if (row_dist <= 0)
             continue;
-        }
 
         Square front = (c == white ? Square(f + 8) : Square(f - 8));
 
@@ -1250,10 +1250,13 @@ template <Color c> int HCEEvaluator::eval_passed_pawns(const position& p, einfo&
             score += params_.passed_pawn_connected;
 
         // 5. Closer to promotion
-        score += params_.passed_pawn_rank_bonus[4 - row_dist];
+        score += params_.passed_pawn_rank_bonus[6 - row_dist];
 
+        // The blocked penalty only ever had entries for the last three ranks.
+        // A passer further out that loses the square in front is charged the
+        // furthest-out rate rather than reading off the end of the table.
         if (crudeControl < 0)
-            score -= params_.passed_pawn_blocked_penalty[3 - row_dist];
+            score -= params_.passed_pawn_blocked_penalty[std::max(0, 3 - row_dist)];
     }
     return score;
 }

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -161,6 +161,9 @@ std::vector<std::pair<std::string, int*>> parameters::all_params(TuneStage stage
         result.emplace_back("passed_pawn_rook_behind", &passed_pawn_rook_behind);
         result.emplace_back("passed_pawn_rook_support", &passed_pawn_rook_support);
         result.emplace_back("passed_pawn_connected", &passed_pawn_connected);
+        for (size_t i = 0; i < passed_pawn_support_scale.size(); ++i)
+            result.emplace_back("passed_pawn_support_scale_" + std::to_string(i),
+                                &passed_pawn_support_scale[i]);
         for (size_t i = 0; i < passed_pawn_blocked_penalty.size(); ++i)
             result.emplace_back("passed_pawn_blocked_penalty_" + std::to_string(i),
                                 &passed_pawn_blocked_penalty[i]);

--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -1346,6 +1346,14 @@ TEST_F(EvalTest, EveryTunableParameterReachesTheEvaluation) {
         // 0.34% of the minors evaluated over a depth-15 bench -- so no
         // ordinary position in this corpus reaches it.
         "r2qkb1r/pp1p3p/2n5/3NpB2/2P1P3/8/PP3PPP/RNBQK2R w KQkq - 0 1",
+        // Passed pawns far from promotion whose square in front is controlled
+        // by the enemy. eval_passed_pawns used to stop looking at a passer more
+        // than three ranks out, so the blocked penalty only ever needed three
+        // entries; now that it has six, the bottom three need a passer on
+        // ranks 2, 3 and 4 with a knight covering the square ahead of it.
+        "4k2r/4pp2/8/n7/8/8/1P6/R2K4 w k - 0 1",
+        "4k2r/4pp2/n7/8/8/1P6/8/R2K4 w k - 0 1",
+        "4k2r/n3pp2/8/8/1P6/8/8/R2K4 w k - 0 1",
     };
 
     // The pawn and material caches are keyed on structure, not on parameter


### PR DESCRIPTION
`eval_passed_pawns` opened with an early exit at `row_dist > 3`. A passer four
or more ranks from promotion collected `passed_pawn_rank_bonus[0]`, which was
**2 centipawns**, and then `continue`d -- so it was not merely worth almost
nothing, it was never credited with a rook behind it, a connected passer beside
it, or control of the square in front, and never charged for losing that square.
All of that machinery existed and simply did not run for a passer on rank 4,
which is where most of them are when it starts to matter.

Three commits, because the first version of this was wrong twice and the
reasons are worth keeping:

1. **Widen the rank ladder** to six entries covering every rank a passer can
   stand on, `{5, 11, 22, 45, 90, 180}`, continuing the existing roughly
   doubling shape downward rather than inventing a scale.

2. **Widen the blocked penalty to match.** Widening only the bonus left
   `passed_pawn_blocked_penalty` at three entries with a clamped index, so a
   passer six ranks out paid the same 30 that one three ranks out pays --
   against a bonus of 5. That measured **-30 Elo over 127 games**.

3. **Grade the flat terms by rank.** The five remaining terms --
   `unblocked`, `control`, `rook_behind`, `rook_support`, `connected` -- say the
   same thing about a passer on rank 2 as about one on rank 7. Harmless while
   the function only reached the last three ranks; wrong the moment it reached
   all of them, since a rank 2 passer with a rook behind it collected
   `passed_pawn_rook_support` at 30. The batch measured **-20.3 +/- 29 over 427
   games**. They are now accumulated into one total and scaled by
   `passed_pawn_support_scale`, whose last three entries are **100 on purpose**:
   those are the ranks the old code evaluated, so this leaves them bit-identical
   and only adds to the ranks that were previously skipped.

The lesson, recorded in `docs/revisit-after-tuning.md`: extending a term's
*scope* is as much a weight change as editing its value, because every constant
that term touches now applies to positions it never applied to before.

**Measured:** 0.0 +/- 32 Elo over 341 self-play games at 10+0.1, non-regression
bounds, against `main` -- against -20.3 for the version before the rank grading.
128/128 tests, bench 1011459.
