### PR TITLE
eval: grade the king pawn storm by how far advanced it is

### DIFF
--- a/docs/revisit-after-tuning.md
+++ b/docs/revisit-after-tuning.md
@@ -30,15 +30,20 @@ course.
 
 ## Evaluation defaults introduced with no evidence behind them
 
-- **`open_file_bonus` (1 -> 12) and `semiopen_file_bonus` (new, 6).** A rook's
+- **`open_file_bonus` (1 -> 8) and `semiopen_file_bonus` (new, 4).** A rook's
   half-open file was not scored at all, and the fully open case was worth one
   centipawn. Both numbers are now guesses in the right ballpark rather than one
   guess in the wrong one. They are strongly collinear with the rook mobility
   table -- an open file is mostly why a rook has moves -- so expect a fit to
   move all three together, and do not read either in isolation.
-- **`king_storm_rank_penalty` {32, 20, 8, 2, 0, 0}.** A new six-entry table
+- **`king_storm_rank_penalty` {12, 8, 4, 1, 0, 0}.** A new six-entry table
   replacing an ungraded count. The shape (steeply decaying with distance) is
-  the confident part; the magnitudes are not. It overlaps `king_storm_penalty`,
+  the confident part; the magnitudes are not. The first attempt peaked at 32,
+  three times the largest king safety weight beside it, and measured -22 Elo
+  over 141 games as part of a two-change batch. Introducing a term far out of
+  scale with its neighbours is a large untested weight change wearing a
+  structural fix as a disguise; both tables here are now in family with what
+  surrounds them. It overlaps `king_storm_penalty`,
   which still charges for the number of storming pawns, and both overlap the
   shelter and king-zone open-file terms.
 - **`cont_hist1_pct` and `cont_hist2_pct`, both 100.** The two continuation

--- a/docs/revisit-after-tuning.md
+++ b/docs/revisit-after-tuning.md
@@ -36,16 +36,29 @@ course.
   guess in the wrong one. They are strongly collinear with the rook mobility
   table -- an open file is mostly why a rook has moves -- so expect a fit to
   move all three together, and do not read either in isolation.
-- **`king_storm_rank_penalty` {12, 8, 4, 1, 0, 0}.** A new six-entry table
+- **`king_storm_rank_penalty` {6, 4, 2, 1, 0, 0}.** A new six-entry table
   replacing an ungraded count. The shape (steeply decaying with distance) is
-  the confident part; the magnitudes are not. The first attempt peaked at 32,
-  three times the largest king safety weight beside it, and measured -22 Elo
-  over 141 games as part of a two-change batch. Introducing a term far out of
-  scale with its neighbours is a large untested weight change wearing a
-  structural fix as a disguise; both tables here are now in family with what
-  surrounds them. It overlaps `king_storm_penalty`,
-  which still charges for the number of storming pawns, and both overlap the
-  shelter and king-zone open-file terms.
+  the confident part; the magnitudes are not. Three scales were measured, and
+  the sequence is the clearest illustration in this repository of why a new
+  weight has to be scaled against the *total* a term contributes rather than
+  against its own entries: the table is summed over up to three pawns, and the
+  count table it augments tops out at 4 centipawns for a full storm.
+
+  | Peak entry | Full storm | Result |
+  | --- | --- | --- |
+  | 32 | 96 | -22 Elo over 141 games (in a two-change batch) |
+  | 12 | 36 | -37 Elo over 228 games |
+  | 6 | 18 | +4.9 +/- 14 over 484 games -- merged |
+
+  At 6 the term is still four times the old value, but it reads as an
+  adjustment to the count table rather than a replacement of it, and that is
+  the difference between -37 and neutral. It is merged on the neutral-plus-
+  structural rule: an ungraded count genuinely cannot tell a pawn on the third
+  rank from one on the sixth, so the axis is worth having in the parameter set
+  even though its present weights bought nothing. It overlaps
+  `king_storm_penalty`, which still charges for the number of storming pawns,
+  and both overlap the shelter and king-zone open-file terms -- move all three
+  together under the tuner.
 - **`cont_hist1_pct` and `cont_hist2_pct`, both 100.** The two continuation
   history planes are added to the plain history score at full weight because
   that is what other engines do, not because it was measured here. Zero

--- a/include/havoc/bitboard.hpp
+++ b/include/havoc/bitboard.hpp
@@ -83,7 +83,6 @@ extern U64 neighbor_cols[8];
 /// King flank masks for pawn shelter.
 extern U64 kflanks[8];
 /// Pawn storm detection masks [color][side].
-extern U64 kpawnstorm[2][2];
 /// King zone masks (extended king area for eval).
 /// Check masks for each piece type from king square.
 /// Passed pawn detection masks [color][square].

--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -175,11 +175,15 @@ struct parameters {
     /// next rank and entry 5 is one still on its starting square. The count
     /// table above says how many pawns are coming; this says how close they
     /// have got.
-    /// Kept in family with the other king safety weights on purpose. The
-    /// largest of those is king_open_file_penalty at 9, and a first attempt at
-    /// this table peaked at 32 -- three times anything beside it -- which is a
-    /// large untested weight change wearing a structural fix as a disguise.
-    std::vector<int> king_storm_rank_penalty{12, 8, 4, 1, 0, 0};
+    /// Kept in family with the term it replaces, which is what matters here:
+    /// the entries are summed over up to three pawns, so what has to stay in
+    /// scale is the total, not the entry. The count table above tops out at 4
+    /// centipawns for a full storm. A first attempt peaked at 32 per pawn --
+    /// 96 for three, a twenty-fourfold change -- and measured -22 Elo; a second
+    /// at 12 per pawn, 36 for three, measured -37 over 228 games. At 6 a full
+    /// storm is worth 18 plus the count term, which is still four times the old
+    /// value but is an adjustment to it rather than a replacement of it.
+    std::vector<int> king_storm_rank_penalty{6, 4, 2, 1, 0, 0};
     std::vector<int> king_safe_sqs{-4, -2, -1, 0, 0, 1, 2, 4};
 
     /// Danger per square from which an enemy piece could give check without

--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -175,7 +175,11 @@ struct parameters {
     /// next rank and entry 5 is one still on its starting square. The count
     /// table above says how many pawns are coming; this says how close they
     /// have got.
-    std::vector<int> king_storm_rank_penalty{32, 20, 8, 2, 0, 0};
+    /// Kept in family with the other king safety weights on purpose. The
+    /// largest of those is king_open_file_penalty at 9, and a first attempt at
+    /// this table peaked at 32 -- three times anything beside it -- which is a
+    /// large untested weight change wearing a structural fix as a disguise.
+    std::vector<int> king_storm_rank_penalty{12, 8, 4, 1, 0, 0};
     std::vector<int> king_safe_sqs{-4, -2, -1, 0, 0, 1, 2, 4};
 
     /// Danger per square from which an enemy piece could give check without

--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -169,6 +169,13 @@ struct parameters {
     /// Charged by the number of enemy pawns bearing down on the king's side of
     /// the board, capped at three.
     std::vector<int> king_storm_penalty{0, 0, 2, 4};
+
+    /// Per-pawn storm penalty, indexed by how many ranks in front of the king
+    /// the storming pawn stands, minus one -- so entry 0 is a pawn on the very
+    /// next rank and entry 5 is one still on its starting square. The count
+    /// table above says how many pawns are coming; this says how close they
+    /// have got.
+    std::vector<int> king_storm_rank_penalty{32, 20, 8, 2, 0, 0};
     std::vector<int> king_safe_sqs{-4, -2, -1, 0, 0, 1, 2, 4};
 
     /// Danger per square from which an enemy piece could give check without

--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -24,7 +24,6 @@ U64 nmask[64];
 U64 kmask[64];
 U64 kflanks[8];
 U64 rmask[64];
-U64 kpawnstorm[2][2];
 U64 battks[64];
 U64 rattks[64];
 U64 small_center_mask;
@@ -304,16 +303,6 @@ void bitboards::init() {
         rmask[s] = bm;
     }
 
-    // King pawn storm detection
-    kpawnstorm[white][0] = between[Square::F2][Square::F5] | between[Square::G2][Square::G5] |
-                           between[Square::H2][Square::H5];
-    kpawnstorm[white][1] = between[Square::A2][Square::A5] | between[Square::B2][Square::B5] |
-                           between[Square::C2][Square::C5];
-
-    kpawnstorm[black][0] = between[Square::F7][Square::F4] | between[Square::G7][Square::G4] |
-                           between[Square::H7][Square::H4];
-    kpawnstorm[black][1] = between[Square::A7][Square::A4] | between[Square::B7][Square::B4] |
-                           between[Square::C7][Square::C4];
 }
 
 } // namespace havoc

--- a/src/eval/hce.cpp
+++ b/src/eval/hce.cpp
@@ -979,12 +979,43 @@ template <Color c> int HCEEvaluator::eval_king(const position& p, einfo& ei) {
 
 
 
-        // Enemy pawn storm
+        // Enemy pawn storm.
+        //
+        // Two defects here. The mask was one of two fixed bitboards -- files
+        // f/g/h or files a/b/c, chosen by which half the king stood on -- so a
+        // king on e1 had its own file ignored and looked at the h file
+        // instead, and a king on d1 was scored on the queenside while the storm
+        // came down the d file. It is now built from the king's own file and
+        // its neighbours, exactly like the open-file term above it.
+        //
+        // Worse, the penalty counted storming pawns and nothing else. A pawn
+        // one square from the king's rank and one four ranks away scored
+        // identically, and the count penalty is {0, 0, 2, 4}: two storming
+        // pawns, however far advanced, cost nothing at all. Grade each pawn by
+        // how close it has come. The count term is kept -- pawns arriving
+        // together are worth more than the sum of their parts -- but it is no
+        // longer the only thing being said.
         {
-            auto pawnStormMask = bitboards::kpawnstorm[c][!(util::col(s) >= Col::E)];
-            auto pawnStorm = pawnStormMask & enemyPawns;
-            auto numAttackers = bits::count(pawnStorm);
-            int storm = -params_.king_storm_penalty[std::min(3, numAttackers)];
+            const int kcol = util::col(s);
+            const int krow = util::row(s);
+            int numAttackers = 0;
+            int storm = 0;
+            for (int f = std::max(0, kcol - 1); f <= std::min(7, kcol + 1); ++f) {
+                U64 stormers = bitboards::col[f] & enemyPawns;
+                while (stormers) {
+                    const int sq = bits::pop_lsb(stormers);
+                    // A pawn is only storming if it is in front of the king.
+                    // One that has already gone past is not an attacker, it is
+                    // a passed pawn, and another term has that.
+                    const int dist = (c == white) ? util::row(sq) - krow : krow - util::row(sq);
+                    if (dist <= 0)
+                        continue;
+                    ++numAttackers;
+                    storm -= params_.king_storm_rank_penalty[std::min<int>(
+                        dist - 1, static_cast<int>(params_.king_storm_rank_penalty.size()) - 1)];
+                }
+            }
+            storm -= params_.king_storm_penalty[std::min(3, numAttackers)];
             score += (storm * mg) / material_entry::kPhaseMax;
         }
     }

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -177,6 +177,9 @@ std::vector<std::pair<std::string, int*>> parameters::all_params(TuneStage stage
             result.emplace_back("king_shelter_" + std::to_string(i), &king_shelter[i]);
         result.emplace_back("pawnless_flank_penalty", &pawnless_flank_penalty);        for (size_t i = 0; i < king_storm_penalty.size(); ++i)
             result.emplace_back("king_storm_penalty_" + std::to_string(i), &king_storm_penalty[i]);
+        for (size_t i = 0; i < king_storm_rank_penalty.size(); ++i)
+            result.emplace_back("king_storm_rank_penalty_" + std::to_string(i),
+                                &king_storm_rank_penalty[i]);
 
         // eval_threats weights, all of which used to be bare literals.
         result.emplace_back("threat_by_pawn", &threat_by_pawn);


### PR DESCRIPTION
The storm penalty charged by the *number* of enemy pawns bearing down on the king and ignored how far they had got, so a pawn still on its starting square counted the same as one a rank from the king.

This adds `king_storm_rank_penalty`, a six-entry table indexed by distance, summed per storming pawn on top of the existing count.

**Scaling is the whole story here.** The table is summed over up to three pawns and the count table it augments tops out at 4cp for a full storm:

| Peak entry | Full storm | Result |
| --- | --- | --- |
| 32 | 96 | −22 Elo / 141 games |
| 12 | 36 | −37 Elo / 228 games |
| **6** | **18** | **+4.9 ± 14 / 484 games** |

Merged on the neutral-plus-structural rule: an ungraded count genuinely cannot distinguish a pawn on the 3rd rank from one on the 6th, so the axis belongs in the parameter set even though these weights bought nothing on their own. Flagged in `docs/revisit-after-tuning.md`.

Bench 973688. 128/128.