### PR TITLE
eval: test every rook pair for the connected bonus, not the first two

### DIFF
--- a/src/eval/hce.cpp
+++ b/src/eval/hce.cpp
@@ -724,20 +724,36 @@ template <Color c> int HCEEvaluator::eval_rooks(const position& p, einfo& ei) {
         score += bits::count(p.attackers_of2(s, c)) * params_.rook_protection_bonus;
     }
 
-    // Connected rook bonus
-    if (rookIdx >= 2) {
-        int row0 = util::row(rookSquares[0]);
-        int row1 = util::row(rookSquares[1]);
-        int col0 = util::col(rookSquares[0]);
-        int col1 = util::col(rookSquares[1]);
-
-        if ((row0 == row1) || (col0 == col1)) {
-            U64 between_bb = bitboards::between[rookSquares[0]][rookSquares[1]];
-            U64 sq_bb = bitboards::squares[rookSquares[0]] | bitboards::squares[rookSquares[1]];
-            U64 blockers = (between_bb ^ sq_bb) & ei.all_pieces;
-
-            if (blockers == 0ULL)
-                score += params_.connected_rook_bonus;
+    // Connected rook bonus.
+    //
+    // This used to look only at rookSquares[0] and rookSquares[1] -- the first
+    // two rooks the piece list happened to yield -- and ignore any others. With
+    // a promoted third rook that silently tests the wrong pair, and because the
+    // piece list is not enumerated in a mirror-symmetric order, the same
+    // position and its reflection disagreed: black rooks on a8, b8 and h3 were
+    // enumerated a8, b8, h3 and scored the bonus, while the mirrored white
+    // rooks on a1, b1 and h6 came out h6, a1, b1 and did not. That is a real
+    // one-centipawn evaluation asymmetry, and a depth-1 search magnified it to
+    // thirteen by flipping which of two near-tied moves it chose.
+    //
+    // Every pair is now tested, and the bonus is still paid at most once, so
+    // for the two-rook case that covers virtually every real position this is
+    // bit-identical to the old code.
+    for (int i = 0; i < rookIdx; ++i) {
+        bool connected = false;
+        for (int j = i + 1; j < rookIdx && !connected; ++j) {
+            const Square a = rookSquares[i], b = rookSquares[j];
+            if (util::row(a) != util::row(b) && util::col(a) != util::col(b))
+                continue;
+            // `between` is inclusive of both endpoints, so the two rook squares
+            // have to be taken back out before asking what stands in the way.
+            const U64 sq_bb = bitboards::squares[a] | bitboards::squares[b];
+            if (((bitboards::between[a][b] ^ sq_bb) & ei.all_pieces) == 0ULL)
+                connected = true;
+        }
+        if (connected) {
+            score += params_.connected_rook_bonus;
+            break;
         }
     }
 

--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -68,6 +68,12 @@ const std::vector<std::string>& mirror_test_positions() {
         "r1bqkb1r/pppppppp/2n2n2/8/3PP3/8/PPP2PPP/RNBQKBNR w KQkq - 2 3",
         "r2q1rk1/ppp2ppp/2n1bn2/2b1p3/3pP3/3P1N1P/PPP1BPP1/RNBQR1K1 w - - 0 8",
         "2rr2k1/pp3ppp/2n1bn2/2q1p3/8/1NP2N1P/PP3PP1/R1BQR1K1 w - - 5 14",
+        // Three rooks a side (one promoted), which is what exposed the
+        // connected-rook bonus testing only the first two entries of the piece
+        // list. The list is not enumerated in a mirror-symmetric order, so
+        // black's a8/b8 pair was found first and scored the bonus while the
+        // mirrored white a1/b1 pair came after h6 and did not.
+        "rr6/3nk3/3pP1p1/p1NP4/P1N3P1/4P1pr/8/2R2K1Q w - - 1 81",
         // Opposite-colored bishops, pieces still on
         "r2q1rk1/1p2bppp/2n2n2/3p4/3P4/2N2N2/PP2BPPP/R2Q1RK1 w - - 0 1",
         // Pure opposite-colored bishop ending


### PR DESCRIPTION
The connected-rook bonus read `rookSquares[0]` and `rookSquares[1]` and ignored anything after them. The piece list is not enumerated in a mirror-symmetric order, so with three rooks a position and its reflection disagree.

In `rr6/3nk3/3pP1p1/p1NP4/P1N3P1/4P1pr/8/2R2K1Q w - - 1 81`, black's rooks come out a8, b8, h3 — the first two share a rank and collect the bonus. Mirrored, white's come out h6, a1, b1 and collect nothing. Eval: **459 one way, 460 the other**.

One centipawn is ignorable on its own. What makes it worth fixing is the amplification: a depth-1 search of that pair returned scores **13 apart**, because 1cp flips which of two near-tied moves wins and the two run into different quiescence lines. It was surfacing as an intermittent `QuiescenceIsMirrorSymmetricOverRandomPlay` failure.

- Every pair tested; bonus still paid at most once → bit-identical for the two-rook case.
- **Bench identical to main at 973688** — the fix touches only positions the bench never reaches, so no SPRT is needed.
- Fuzz over 4731 random-play positions: 1 asymmetric before, **0 after**.
- Offending FEN added to the mirror corpus. 128/128.