### PR TITLE
search: correct the static evaluation with a pawn-structure history

### DIFF
--- a/include/havoc/move_order.hpp
+++ b/include/havoc/move_order.hpp
@@ -141,6 +141,35 @@ struct Movehistory {
     /// the weights set through `set_continuation_weights`.
     int continuation_score(const position& p, const Move& m, const SearchNode* stack) const;
 
+    /// ─── Correction history ─────────────────────────────────────────────
+    ///
+    /// The static evaluation is not a neutral estimator: it is wrong in ways
+    /// that repeat. A pawn structure the evaluation systematically overrates
+    /// will be overrated in every position that shares it, and the search
+    /// discovers that afresh at every node, paying for it in nodes each time.
+    /// Correction history remembers the gap between what the evaluation said
+    /// and what the search came back with, keyed on the pawn structure, and
+    /// applies it to the next static evaluation of a position with that same
+    /// structure.
+    ///
+    /// Values are held at `kCorrGrain` times their centipawn value so that a
+    /// running average can move by less than one centipawn per update, which
+    /// matters because most updates are small and integer division would
+    /// otherwise round them all to zero.
+    static constexpr int kCorrGrain = 256;
+    static constexpr int kCorrMax = kCorrGrain * 32;
+    static constexpr size_t kCorrSize = 16384;
+
+    /// Centipawn adjustment to add to a raw static evaluation.
+    [[nodiscard]] int correction(Color c, U64 pawnkey) const {
+        return corrections_[c][pawnkey & (kCorrSize - 1)] / kCorrGrain;
+    }
+
+    /// `diff` is the search result minus the corrected static evaluation, in
+    /// centipawns. Deeper searches carry more weight, capped so that no single
+    /// result can displace the accumulated average outright.
+    void update_correction(Color c, U64 pawnkey, int depth, int diff);
+
     /// The scoring functions are plain function pointers with a fixed
     /// signature and no route to the parameter block, so the search hands the
     /// tunable continuation weights to the table itself.
@@ -164,6 +193,9 @@ struct Movehistory {
                                  const Move& m) const;
 
     std::array<std::array<std::array<int, squares>, squares>, colors> history_;
+    /// Indexed by [side to move][pawn key]. Two colours because the same pawn
+    /// structure is a different proposition depending on whose move it is.
+    std::array<std::array<int, kCorrSize>, colors> corrections_{};
     // Countermove table: indexed by [color_of_previous_move][from][to] -> best response
     std::array<std::array<std::array<Move, 64>, 64>, 2> countermoves{};
     std::unique_ptr<ContinuationHistory> continuation_;

--- a/src/move_order.cpp
+++ b/src/move_order.cpp
@@ -139,6 +139,23 @@ void Movehistory::clear() {
     for (auto& color : countermoves)
         for (auto& from : color)
             std::fill(from.begin(), from.end(), empty);
+
+    for (auto& c : corrections_)
+        std::fill(c.begin(), c.end(), 0);
+}
+
+void Movehistory::update_correction(Color c, U64 pawnkey, int depth, int diff) {
+    int& e = corrections_[c][pawnkey & (kCorrSize - 1)];
+
+    // A single search result is one noisy sample of a systematic bias, so it
+    // is folded into a running average rather than written over it. The weight
+    // rises with depth because a deeper search is a better measurement, and is
+    // capped at 16/256 so that no one node can move the entry more than a
+    // sixteenth of the way to its own value.
+    const int w = std::min(depth + 1, 16);
+    const int sample = std::clamp(diff * kCorrGrain, -kCorrMax, kCorrMax);
+    e = (e * (256 - w) + sample * w) / 256;
+    e = std::clamp(e, -kCorrMax, kCorrMax);
 }
 
 int Movehistory::score(const Move& m, const Color& c) const {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -609,7 +609,17 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
     } else {
         auto* sthread = search_threads_[thread_id];
         static_eval_val = static_cast<int16_t>(std::lround(sthread->evaluator->evaluate(pos)));
+
+        // Correction history adjusts the raw evaluation, before the TT gets a
+        // say. The TT value has a real search behind it and needs no help; the
+        // point of the correction is to improve the estimate we fall back on
+        // when there is no such value, and to give the update below a corrected
+        // baseline so the table converges instead of chasing its own output.
+        static_eval_val = static_cast<int16_t>(std::clamp(
+            static_eval_val + history_.correction(pos.to_move(), pos.pawnkey()),
+            static_cast<int>(-score::kMate + 100), static_cast<int>(score::kMate - 100)));
     }
+    const int16_t corrected_static_eval = static_eval_val;
 
     // A TT score is a better estimate of the position than a static evaluation
     // -- it has a search behind it -- but only in the direction its bound
@@ -1082,6 +1092,27 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
     Bound bound = (bestScore >= beta            ? bound_low
                    : pvNode && bestScore > alpha_orig ? bound_exact
                                                      : bound_high);
+
+    // Feed the gap between what the evaluation guessed and what the search
+    // found back into correction history. Only when the search result is
+    // admissible evidence about the true score in the direction it differs:
+    // a fail-low bounds the score from above, so it may only teach the table
+    // that the evaluation was too high, and a fail-high only the reverse. A
+    // capture or a check makes the difference tactical rather than a property
+    // of the structure, which is what this table is keyed on.
+    const bool best_is_capture =
+        (best_move.type == static_cast<U8>(capture)) ||
+        (best_move.type == static_cast<U8>(ep)) ||
+        pos.is_cap_promotion(static_cast<Movetype>(best_move.type));
+
+    if (!in_check && !singular_search && corrected_static_eval != score::kNegInf &&
+        !best_is_capture && std::abs(bestScore) < score::kMate - 100 &&
+        (bound == bound_exact || (bound == bound_low && bestScore > corrected_static_eval) ||
+         (bound == bound_high && bestScore < corrected_static_eval))) {
+        history_.update_correction(to_mv, pos.pawnkey(), depth,
+                                   bestScore - corrected_static_eval);
+    }
+
     if (!singular_search)
         tt_.save(pos.key(), static_cast<U8>(depth), static_cast<U8>(bound), best_move,
                  score_to_tt(bestScore, stack->ply), pvNode);

--- a/tests/test_search.cpp
+++ b/tests/test_search.cpp
@@ -208,6 +208,49 @@ TEST_F(SearchTest, CheckEvasionsAreNeverPrunedAsLateQuiets) {
     EXPECT_NE(move_str(m), "0000");
 }
 
+// Correction history is a running average of the gap between the static
+// evaluation and the search result, keyed on pawn structure. Three properties
+// have to hold or it silently does nothing: a single update must move the
+// entry (integer division at grain 1 would round every small diff to zero), a
+// stream of consistent evidence must converge on that value rather than
+// overshoot it, and the entry must stay bounded no matter how much evidence
+// arrives.
+TEST_F(SearchTest, CorrectionHistoryConvergesAndStaysBounded) {
+    Movehistory hist;
+    const U64 key = 0x1234567890abcdefULL;
+
+    EXPECT_EQ(hist.correction(white, key), 0);
+
+    // One shallow update at a weight of 1/256 must still register internally,
+    // even though it is far too small to show up in centipawns yet.
+    hist.update_correction(white, key, 0, 50);
+    EXPECT_EQ(hist.correction(white, key), 0);
+
+    // Consistent evidence converges towards the observed gap without passing
+    // it -- a running average of a constant can never exceed that constant.
+    for (int i = 0; i < 400; ++i)
+        hist.update_correction(white, key, 8, 50);
+    const int converged = hist.correction(white, key);
+    EXPECT_GT(converged, 30);
+    EXPECT_LE(converged, 50);
+
+    // Unrelated structures are untouched, and so is the other side to move.
+    EXPECT_EQ(hist.correction(black, key), 0);
+    EXPECT_EQ(hist.correction(white, key ^ 0xffULL), 0);
+
+    // Absurd evidence cannot drive the entry past the clamp.
+    for (int i = 0; i < 2000; ++i)
+        hist.update_correction(white, key, 30, 5000);
+    EXPECT_LE(hist.correction(white, key), Movehistory::kCorrMax / Movehistory::kCorrGrain);
+
+    // Evidence in the other direction pulls it back, and clear() resets it.
+    for (int i = 0; i < 2000; ++i)
+        hist.update_correction(white, key, 30, -5000);
+    EXPECT_LT(hist.correction(white, key), 0);
+    hist.clear();
+    EXPECT_EQ(hist.correction(white, key), 0);
+}
+
 TEST_F(SearchTest, HistoryScoresStayBounded) {
     Movehistory hist;
     Move m(E2, E4, quiet);


### PR DESCRIPTION
The static evaluation is not a neutral estimator — it is wrong in ways that *repeat*. A pawn structure it overrates is overrated in every position sharing that structure, and the search rediscovers the same correction at every node, paying for it in nodes each time.

This keeps a running average of the gap between the evaluation and what the search actually returned, keyed on `[side to move][pawn key]`, and adds it to the next raw evaluation of a position with that structure.

Three details decide whether it works at all:

- **Applied to the raw eval, before the TT adjusts it.** A TT value already has a search behind it and needs no help. The point is to improve the number we fall back on when there is no such value — and to give the update a corrected baseline so the table converges instead of chasing its own output.
- **Entries held at 256× their centipawn value.** Most updates are small; at grain 1, integer division rounds every one of them to zero.
- **Only admissible evidence is recorded.** A fail-low bounds the true score from above, so it may only teach the table the eval was too high; a fail-high only the reverse. Captures and checks are excluded — the difference is then tactical, not a property of the structure the table is keyed on.

**SPRT: +30.6 ± 12 over 599 games** at 10+0.1. The largest single gain since the aspiration-window fix.

129/129 tests, including a new `CorrectionHistoryConvergesAndStaysBounded` covering the three failure modes (a single update must register, consistent evidence must converge without overshoot, and the entry must stay bounded).