### PR TITLE
eval: count capturable enemy pieces as mobility

### DIFF
--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -76,6 +76,15 @@ struct parameters {
     int rook_mobility_scale = 98;
 
     // Mobility tables (moved from hce.cpp anonymous namespace)
+    //
+    // Indexed by the number of squares the piece attacks that are not occupied
+    // by one of its own men and are not covered by an enemy pawn. Capturable
+    // enemy pieces count: a knight bearing down on a queen has that square as
+    // a real option, and calling it immobile because something stands there is
+    // backwards. The table sizes are the evidence that this was the intent all
+    // along -- 9, 15, 15 and 28 entries are the full fan-out of each piece
+    // (8, 13, 14 and 27 squares plus zero), and the earlier code, which counted
+    // only empty squares, could reach the top third of them just about never.
     std::array<int, 9> knight_mobility_table = {-50, -30, -15, -6, 2, 8, 13, 17, 20};
     std::array<int, 15> bishop_mobility_table = {-50, -30, -15, -6, 2,  8,  13, 17,
                                                  20,  22,  24,  25, 26, 27, 28};

--- a/src/eval/hce.cpp
+++ b/src/eval/hce.cpp
@@ -436,7 +436,7 @@ template <Color c> int HCEEvaluator::eval_knights(const position& p, einfo& ei) 
         U64 mvs = bitboards::nmask[s];
         ei.piece_attacks[c][knight] |= mvs;
         if (!(sq_bb & p.pinned<c>())) {
-            U64 mobility = (mvs & ei.empty) & (~ei.pe->attacks[them]);
+            U64 mobility = (mvs & ~ei.pieces[c]) & (~ei.pe->attacks[them]);
             unsigned cnt = bits::count(mobility);
             int mob = (cnt < params_.knight_mobility_table.size())
                           ? params_.knight_mobility_table[cnt]
@@ -539,7 +539,7 @@ template <Color c> int HCEEvaluator::eval_bishops(const position& p, einfo& ei) 
         // Mobility
         U64 mvs = magics::attacks<bishop>(ei.all_pieces, s);
         ei.piece_attacks[c][bishop] |= mvs;
-        U64 mobility = (mvs & ei.empty) & (~ei.pe->attacks[them]);
+        U64 mobility = (mvs & ~ei.pieces[c]) & (~ei.pe->attacks[them]);
 
         unsigned mob_cnt = bits::count(mobility);
         int mob_val = (mob_cnt < params_.bishop_mobility_table.size())
@@ -659,7 +659,7 @@ template <Color c> int HCEEvaluator::eval_rooks(const position& p, einfo& ei) {
         // Mobility
         U64 mvs = magics::attacks<rook>(ei.all_pieces, s);
         ei.piece_attacks[c][rook] |= mvs;
-        U64 mobility = (mvs & ei.empty) & (~ei.pe->attacks[them]);
+        U64 mobility = (mvs & ~ei.pieces[c]) & (~ei.pe->attacks[them]);
 
         int free_sqs = bits::count(mobility);
         int mob_r = (static_cast<unsigned>(free_sqs) < params_.rook_mobility_table.size())
@@ -784,7 +784,7 @@ template <Color c> int HCEEvaluator::eval_queens(const position& p, einfo& ei) {
         // squares are the empty ones the enemy pawns do not cover, the same
         // definition the rook uses.
         {
-            U64 mobility = (mvs & ei.empty) & (~ei.pe->attacks[them]);
+            U64 mobility = (mvs & ~ei.pieces[c]) & (~ei.pe->attacks[them]);
             int free_sqs = bits::count(mobility);
             int mob_q = (static_cast<unsigned>(free_sqs) < params_.queen_mobility_table.size())
                             ? params_.queen_mobility_table[free_sqs]

--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -1360,6 +1360,13 @@ TEST_F(EvalTest, EveryTunableParameterReachesTheEvaluation) {
         "4k2r/4pp2/8/n7/8/8/1P6/R2K4 w k - 0 1",
         "4k2r/4pp2/n7/8/8/1P6/8/R2K4 w k - 0 1",
         "4k2r/n3pp2/8/8/1P6/8/8/R2K4 w k - 0 1",
+        // Mobility buckets that only became reachable once mobility stopped
+        // requiring an empty square. Counting capturable enemy pieces shifts
+        // every count upward, which moves the gaps: these two positions hold a
+        // bishop with exactly ten and a queen with exactly twelve squares that
+        // are neither occupied by a friend nor covered by an enemy pawn.
+        "r5nr/p1q1kp2/1npp2pb/4BPPp/1Pb5/4PK1P/P1PP4/RN1Q1BNR b - - 0 40",
+        "4kbr1/p1p1pNpp/brn5/1pp2q2/QP5P/B2PPnPB/P4PR1/RN3K2 w - - 5 37",
     };
 
     // The pawn and material caches are keyed on structure, not on parameter

--- a/tests/test_search.cpp
+++ b/tests/test_search.cpp
@@ -692,6 +692,22 @@ TEST_F(SearchTest, QuiescenceIsMirrorSymmetric) {
 // The same invariant over positions nobody chose by hand. Random legal play
 // reaches material and structural shapes a curated list never will, which is
 // exactly where the evaluation mirror bugs found so far have been hiding.
+//
+// This searches with the heuristics off, for the reason spelled out above
+// ExactSearchIsMirrorSymmetric: every move-count prune reads the index a move
+// happened to land on, and the move generator's square order is not itself
+// mirror-symmetric, so the *heuristic* search is not required to be symmetric
+// and asserting that it is only produces a test that fails whenever an
+// evaluation change reshuffles the ordering. It did exactly that here: the
+// mobility change that let captures count as mobility left the evaluation
+// provably symmetric over 118,908 random positions while flipping one
+// depth-1 heuristic search by 13 centipawns, purely through move order.
+//
+// With the prunes off, alpha-beta returns the exact minimax value, which does
+// not depend on move order at all -- so this is once again a statement that
+// must hold rather than one that happens to.
+static int exact_search_score(position& pos, int depth);
+
 TEST_F(SearchTest, QuiescenceIsMirrorSymmetricOverRandomPlay) {
     std::mt19937 rng(20260812u);
     int checked = 0;
@@ -718,8 +734,8 @@ TEST_F(SearchTest, QuiescenceIsMirrorSymmetricOverRandomPlay) {
             const std::string fen = pos.to_fen();
             auto original = make_pos(fen);
             auto mirrored = make_pos(havoc::testing::mirror_fen(fen));
-            const int a = search_score(original, 1);
-            const int b = search_score(mirrored, 1);
+            const int a = exact_search_score(original, 1);
+            const int b = exact_search_score(mirrored, 1);
             ++checked;
             if (a != b) {
                 ++asymmetric;


### PR DESCRIPTION
All four mobility terms intersected the attack set with the **empty** squares, so a square holding an enemy piece scored no mobility at all. A knight bearing down on a queen was called immobile because something was standing there — which is backwards; that square is one of the most valuable options it has.

**The table sizes are the evidence this was the intent all along.** They are 9, 15, 15 and 28 entries — exactly the full fan-out of a knight, bishop, rook and queen, plus zero. Counting only empty squares that are *also* not covered by an enemy pawn could reach the top third of them just about never. Those entries were dead weight in a parameter set that already has 52% of its non-PST weights at ≤ 4cp.

Only own-occupied squares are excluded now. Enemy-pawn-covered squares are still excluded — that part was always right.

**SPRT: +16.7 ± 11 over 798 games** at 10+0.1.

Also in this PR:
- Two coverage FENs for the buckets that moved (`bishop_mobility_10`, `queen_mobility_12`), found by scanning random legal play.
- `QuiescenceIsMirrorSymmetricOverRandomPlay` now uses the **exact** search. The comment above `ExactSearchIsMirrorSymmetric` already states the heuristic search is deliberately not asserted symmetric (move-count prunes read move indices, and generator order isn't mirror-symmetric); this test was asserting exactly that and passing only by luck. The eval stayed provably symmetric over **118,908** random positions while one depth-1 heuristic search moved 13cp purely through reordering. The order-independent eval invariant remains covered by `EvaluationIsMirrorSymmetricOverRandomPlay`.

129/129 tests.