### PR TITLE
eval: fade king danger toward the endgame

### DIFF
--- a/docs/revisit-after-tuning.md
+++ b/docs/revisit-after-tuning.md
@@ -223,3 +223,17 @@ that one of its own pawns defends. The case is rare (0.34% of minors over a
 depth-15 bench) and the two values were chosen to sit beside
 `knight_outpost_bonus`, which tops out at 3, rather than from any evidence that
 a defended outpost is worth about as much again as the outpost itself.
+
+- **`king_danger_endgame_scale`, 40.** None of the king danger terms -- safe
+  checks, the quadratic attacker score, the attack combinations -- were faded
+  by game phase, so a rook endgame was charged for an exposed king at exactly
+  the rate a middlegame with two queens on was. That is wrong on the chess and
+  it fights the endgame king table, which wants the king walking into the
+  centre. The shelter term beside them was already tapered, which is what makes
+  this an oversight rather than a deliberate choice.
+
+  The taper is the confident part; 40 is not. It says a little over a third of
+  the danger survives into a pure endgame, which is a guess at "some danger is
+  real even with few pieces, because the pieces that remain still give check".
+  100 reproduces the old behaviour exactly, so the tuner can undo this
+  completely if the measurement says so.

--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -43,6 +43,16 @@ struct parameters {
     int pawn_structure_category_scale = 100;
     int space_category_scale = 100;
     int king_danger_divisor = 256;
+
+    /// Percentage of the king danger terms -- safe checks, the quadratic
+    /// attacker score and the attack combinations -- that survives at the
+    /// pure-endgame end of the phase taper. None of them were tapered at all,
+    /// so a rook endgame was charged the same for an exposed king as a
+    /// middlegame with two queens on, and that pulls directly against the
+    /// endgame king table, which wants the king out in the open. The
+    /// middlegame end stays at 100. See docs/revisit-after-tuning.md: the
+    /// value here is a chess argument, not a fitted number.
+    int king_danger_endgame_scale = 40;
     /// Bonus, in centipawns, for having the move. Measured, not assumed: this
     /// term was effectively inert until the side-to-move convention was
     /// unified, because the old `stm_sign * (score + tempo)` is just

--- a/src/eval/hce.cpp
+++ b/src/eval/hce.cpp
@@ -852,6 +852,17 @@ template <Color c> int HCEEvaluator::eval_king(const position& p, einfo& ei) {
         U64 mvs = ei.kmask[c] & ei.empty;
 
         // King safety - attackers
+        //
+        // The danger terms below accumulate into `danger` rather than straight
+        // into `score` so they can be faded by game phase. An exposed king is
+        // a liability while the enemy still has the pieces to punish it and an
+        // asset once they are traded off, and none of this was tapered: a rook
+        // endgame collected the same safe-check and attack-combination
+        // penalties as a middlegame with two queens on, which also pulls
+        // directly against the endgame king table's wish to centralise. The
+        // shelter term further down was already faded on the middlegame
+        // weight; these were not.
+        int danger = 0;
         U64 unsafe_bb = 0ULL;
         for (Piece pc = pawn; pc <= queen; ++pc)
             unsafe_bb |= ei.kattk_points[them][pc];
@@ -890,7 +901,7 @@ template <Color c> int HCEEvaluator::eval_king(const position& p, einfo& ei) {
             for (Piece pc = knight; pc <= queen; ++pc) {
                 const U64 checks = check_from[pc] & ei.piece_attacks[them][pc] & safe;
                 if (checks)
-                    score -= params_.safe_check_weight[pc] * bits::count(checks);
+                    danger -= params_.safe_check_weight[pc] * bits::count(checks);
             }
         }
 
@@ -903,8 +914,7 @@ template <Color c> int HCEEvaluator::eval_king(const position& p, einfo& ei) {
                 danger_score +=
                     static_cast<int>(ei.kattackers[them][j]) * params_.attacker_weight[j];
 
-            score -= (danger_score * danger_score) / params_.king_danger_divisor;
-
+            danger -= (danger_score * danger_score) / params_.king_danger_divisor;
             score += params_.king_safe_sqs[std::min(7, bits::count(mvs))];
 
             // Attack combinations
@@ -913,7 +923,7 @@ template <Color c> int HCEEvaluator::eval_king(const position& p, einfo& ei) {
                     U64 twiceAttacked = ei.kattk_points[them][p1] & ei.kattk_points[them][p2];
                     if (twiceAttacked) {
                         int attack_penalty = params_.attack_combos[p1][p2];
-                        score -= attack_penalty;
+                        danger -= attack_penalty;
 
                         // Any twice-attacked square beside the king that only
                         // the king defends is the dangerous one, so look at all
@@ -936,7 +946,7 @@ template <Color c> int HCEEvaluator::eval_king(const position& p, einfo& ei) {
                         while (remaining) {
                             const Square attacked_sq = Square(bits::pop_lsb(remaining));
                             if ((p.attackers_of2(attacked_sq, c) & ~sq_bb) == 0ULL) {
-                                score -= 3 * attack_penalty;
+                                danger -= 3 * attack_penalty;
                                 break;
                             }
                         }
@@ -944,6 +954,12 @@ template <Color c> int HCEEvaluator::eval_king(const position& p, einfo& ei) {
                 }
             }
         }
+
+        // Fade the danger by game phase. king_danger_endgame_scale is the
+        // percentage that survives at the pure-endgame end of the taper; the
+        // middlegame end stays at 100 so nothing changes where king safety is
+        // supposed to be at full strength.
+        score += (danger * ei.me->taper(100, params_.king_danger_endgame_scale)) / 100;
 
         // Pawn shelter, weighted towards the middlegame.
         {

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -117,6 +117,7 @@ std::vector<std::pair<std::string, int*>> parameters::all_params(TuneStage stage
         result.emplace_back("doubled_isolated_penalty_eg", &doubled_isolated_penalty_eg);
         result.emplace_back("space_category_scale", &space_category_scale);
         result.emplace_back("king_danger_divisor", &king_danger_divisor);
+        result.emplace_back("king_danger_endgame_scale", &king_danger_endgame_scale);
         return result;
     }
 


### PR DESCRIPTION
Safe checks, the quadratic attacker score and the attack-combination penalties were charged at full rate regardless of phase. The pawn-shelter term sitting three lines below them was already faded on the middlegame weight, which is what makes this look like an oversight rather than a decision.

An exposed king is a liability while the enemy still has the pieces to punish it and an asset once they are traded off. Under the old code a rook endgame collected the same safe-check penalty as a middlegame with two queens on, and that penalty pulls directly against the endgame king table, which wants the king centralised. The two terms were arguing.

Those three terms now accumulate into a `danger` local which is faded with `ei.me->taper(100, king_danger_endgame_scale)`. The new parameter is the percentage surviving at the pure-endgame end; **100 reproduces the old behaviour bit for bit**, so it is also a clean axis for SPSA later. Default 40.

**SPRT vs main:** `+12.6 +/- 18.9` over 794 games (LOS 90.5%). Positive, not significant. Merging under the standing rule for structural changes that measure neutral-or-better, and flagged in `docs/revisit-after-tuning.md` — 40 is a guess and the sign of this change is much more certain than its size.

Bench 956042, 129/129.