### PR TITLE
eval: count king attackers in a zone two ranks deep, not just the ring

### DIFF
--- a/docs/revisit-after-tuning.md
+++ b/docs/revisit-after-tuning.md
@@ -237,3 +237,23 @@ a defended outpost is worth about as much again as the outpost itself.
   real even with few pieces, because the pieces that remain still give check".
   100 reproduces the old behaviour exactly, so the tuner can undo this
   completely if the measurement says so.
+
+- **The king zone, and every weight that reads through it.** The attacker
+  counting sites now use a band two ranks deep in front of the king instead of
+  the eight squares touching it. The shape is not in doubt -- a knight on g5
+  aimed at a castled king on g1 was previously worth exactly nothing to the
+  danger sum -- but the weights underneath it were all chosen against the old,
+  narrower mask.
+
+  Two of them are affected in a way tuning has to sort out. `attacker_weight`
+  feeds a term that is squared, so a wider zone that raises the attacker count
+  does not raise the penalty proportionally, it raises it quadratically;
+  `king_danger_divisor` is the obvious counterweight and was never moved.
+  `attack_combos` fires on squares attacked twice, and there are simply more of
+  those in a zone half again as large.
+
+  Measured `+3.5 +/- 19.1` over 794 games, i.e. neutral, which is consistent
+  with a better-shaped term carrying weights calibrated for the old shape.
+  These four -- `attacker_weight`, `king_danger_divisor`, `attack_combos` and
+  the `pawn_king` / piece-king count tables -- should be refit together rather
+  than one at a time.

--- a/include/havoc/eval/hce.hpp
+++ b/include/havoc/eval/hce.hpp
@@ -19,6 +19,13 @@ struct einfo {
     U64 weak_pawns[2]{};
     U64 empty = 0;
     U64 kmask[2]{};
+    /// The squares an attack on which counts as an attack on the king.
+    /// Wider than kmask: the ring plus the three squares two ranks ahead of
+    /// the king, shifted back onto the board for kings on the edge files.
+    /// kmask stays the true ring and is what defends, shelters and gives the
+    /// king its flight squares; kzone is only ever read to decide whether an
+    /// enemy piece is pointed at the king.
+    U64 kzone[2]{};
     U64 kattk_points[2][5]{};
     U64 piece_attacks[2][5]{};
     U64 queen_sqs[2]{};

--- a/src/eval/hce.cpp
+++ b/src/eval/hce.cpp
@@ -208,6 +208,27 @@ int HCEEvaluator::evaluate(const position& p, int /*lazy_margin*/) {
                            ei.pe->undefended[black];
     ei.kmask[white] = bitboards::kmask[p.king_square(white)];
     ei.kmask[black] = bitboards::kmask[p.king_square(black)];
+    // King zone, used only for counting attackers. The eight squares touching
+    // the king are where an attack lands, but not where it is launched from:
+    // a knight on g5 or a rook lifted to h3 is aiming at a castled king on g1
+    // without touching its ring at all, and under the old mask contributed
+    // nothing to king danger until it had already arrived. Every other engine
+    // counts a band two ranks deep in front of the king for this reason.
+    //
+    // Built as the ring of the king square unioned with the ring of the square
+    // one rank in front of it, with that square's file pulled to the b--g
+    // range so a king on a1 or h1 still gets a three-file band instead of half
+    // of one falling off the board. The king square itself is removed so the
+    // zone stays a strict superset of the squares the old code counted.
+    for (Color kc : {white, black}) {
+        const int ks = p.king_square(kc);
+        const int fr = kc == white ? std::min(sq_row(ks) + 1, 7) : std::max(sq_row(ks) - 1, 0);
+        const int ff = std::clamp(sq_col(ks), 1, 6);
+        const int front = fr * 8 + ff;
+        ei.kzone[kc] = (bitboards::kmask[ks] | bitboards::squares[front] |
+                        bitboards::kmask[front]) &
+                       ~bitboards::squares[ks];
+    }
     // colored_sqs[white] is the light squares and colored_sqs[black] the dark
     // ones; see the initialiser in bitboard.cpp. These two lines are what makes
     // the bad-bishop penalty in eval_bishops do anything at all -- the masks it
@@ -403,7 +424,7 @@ template <Color c> int HCEEvaluator::eval_pawns(const position& p, einfo& ei) {
     U64 pawnAttacks = ei.pe->attacks[c];
 
     // Pawn harassment of enemy king
-    U64 kattks = pawnAttacks & ei.kmask[them];
+    U64 kattks = pawnAttacks & ei.kzone[them];
     int kAttkCount = bits::count(kattks);
     if (kAttkCount) {
         ei.kattackers[c][pawn]++;
@@ -486,7 +507,7 @@ template <Color c> int HCEEvaluator::eval_knights(const position& p, einfo& ei) 
         }
 
         // King harassment
-        U64 kattks = mvs & ei.kmask[them];
+        U64 kattks = mvs & ei.kzone[them];
         if (kattks) {
             ei.kattackers[c][knight]++;
             ei.kattk_points[c][knight] |= kattks;
@@ -613,7 +634,7 @@ template <Color c> int HCEEvaluator::eval_bishops(const position& p, einfo& ei) 
         score += bits::count(mvs & equeen_sq) * params_.attk_queen_bonus[bishop];
 
         // King harassment
-        U64 kattks = mvs & ei.kmask[them];
+        U64 kattks = mvs & ei.kzone[them];
         int king_attk_count = bits::count(kattks);
         if (king_attk_count) {
             ei.kattackers[c][bishop]++;
@@ -712,7 +733,7 @@ template <Color c> int HCEEvaluator::eval_rooks(const position& p, einfo& ei) {
             score += params_.rook_7th_bonus;
 
         // King harassment
-        U64 kattks = mvs & ei.kmask[them];
+        U64 kattks = mvs & ei.kzone[them];
         int king_attk_count = bits::count(kattks);
         if (king_attk_count) {
             ei.kattackers[c][rook]++;
@@ -808,7 +829,7 @@ template <Color c> int HCEEvaluator::eval_queens(const position& p, einfo& ei) {
             bits::count(mvs & bitboards::big_center_mask) * params_.center_influence_bonus[queen];
 
         // King harassment
-        U64 kattks = mvs & ei.kmask[them];
+        U64 kattks = mvs & ei.kzone[them];
         int king_attk_count = bits::count(kattks);
         if (king_attk_count) {
             ei.kattackers[c][queen]++;
@@ -938,10 +959,10 @@ template <Color c> int HCEEvaluator::eval_king(const position& p, einfo& ei) {
                         // color and not the other, worth 12cp with the rook and
                         // knight combination weight of 4.
                         //
-                        // twiceAttacked only ever holds squares in our own
-                        // king's mask, and attackers_of2 counts the king, so
-                        // masking the king out is what makes "undefended"
-                        // mean undefended by anything else.
+                        // twiceAttacked holds squares in our own king's zone,
+                        // and attackers_of2 counts the king, so masking the
+                        // king out is what makes "undefended" mean undefended
+                        // by anything else.
                         U64 remaining = twiceAttacked;
                         while (remaining) {
                             const Square attacked_sq = Square(bits::pop_lsb(remaining));


### PR DESCRIPTION
Every attacker-counting site masked with `bitboards::kmask`, the eight squares touching the king. That is where an attack *lands*, but not where it is *launched from*. A knight on g5, a rook lifted to h3, a bishop on the long diagonal — all pointed squarely at a castled king on g1, none of them touching a ring square, and so all worth exactly zero to the danger sum until they had already arrived. By then the attack is usually decided.

The zone is now the ring of the king square unioned with the ring of the square one rank in front of it, with that square's file pulled into the b–g range so a king on a1 or h1 gets a full three-file band instead of half of one falling off the edge. The king square itself is removed, so the new zone is a **strict superset** of what the old code counted.

This is a separate `einfo` field rather than a widened `kmask` on purpose. `kmask` is still read for three other things — the king's flight squares, the squares that count as defended when deciding whether a check is safe, and the pawns that count as shelter — and none of those mean anything outside the true ring.

**SPRT vs main:** `+3.5 +/- 19.1` over 794 games. Neutral.

That is the expected result and the reason it still merges. Every weight downstream of this mask was calibrated against the narrower one, and two of them react badly to a bigger zone: `attacker_weight` feeds a term that is **squared**, so more attackers is a quadratic increase and `king_danger_divisor` was never moved to compensate; `attack_combos` fires on twice-attacked squares, and a zone half again as large simply has more of them. A better-shaped term carrying weights fitted to the old shape measuring neutral is what you would predict.

`docs/revisit-after-tuning.md` now lists those four weight groups to be refit **together** rather than one at a time.

Bench 961317, 129/129.