### PR TITLE
search: futility-prune quiet moves at shallow depth

### DIFF
--- a/docs/revisit-after-tuning.md
+++ b/docs/revisit-after-tuning.md
@@ -257,3 +257,18 @@ a defended outpost is worth about as much again as the outpost itself.
   These four -- `attacker_weight`, `king_danger_divisor`, `attack_combos` and
   the `pawn_king` / piece-king count tables -- should be refit together rather
   than one at a time.
+
+- **`fp_base` 100 / `fp_margin` 90 / `fp_max_depth` 6.** Forward futility
+  pruning of quiet moves. The rule is standard and was simply missing; these
+  three numbers are conventional starting points and nothing more.
+
+  At these values it barely fires -- roughly 1.4% of bench nodes -- and it
+  measured `+2.2 +/- 19.2` over 794 games, which is what a nearly inert change
+  should measure. Dropping the base to 0 and the margin to 60 cuts about 12% of
+  nodes, so the whole useful range of this rule sits below the default it
+  shipped with.
+
+  Note also that the condition reads raw `depth`, where the convention is to
+  read the LMR-reduced depth. That makes 90 per ply mean something different
+  here than it does in the engines the number was borrowed from, and is worth
+  changing before the margins are fit.

--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -414,6 +414,9 @@ struct parameters {
     int nmp_eval_div = 200;         // extra reduction of (eval-beta)/this
     int nmp_eval_max = 3;           // ...capped here
     int futility_base = 6;          // (base + depth^2) / (2 - improving)
+    int fp_max_depth = 6;           // forward futility pruning of quiets below this depth
+    int fp_base = 100;              // ...prune when eval + base + margin*depth <= alpha
+    int fp_margin = 90;
     int history_prune_depth = 3;    // history pruning only below this depth
     int history_prune_margin = 4096; // ...and only below -margin*depth
     int see_prune_depth = 1;        // negative-SEE capture pruning depth

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -378,6 +378,9 @@ std::vector<std::pair<std::string, int*>> parameters::all_params(TuneStage stage
         result.emplace_back("nmp_eval_div", &nmp_eval_div);
         result.emplace_back("nmp_eval_max", &nmp_eval_max);
         result.emplace_back("futility_base", &futility_base);
+        result.emplace_back("fp_max_depth", &fp_max_depth);
+        result.emplace_back("fp_base", &fp_base);
+        result.emplace_back("fp_margin", &fp_margin);
         result.emplace_back("history_prune_depth", &history_prune_depth);
         result.emplace_back("history_prune_margin", &history_prune_margin);
         result.emplace_back("see_prune_depth", &see_prune_depth);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -832,6 +832,32 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
             (to_mv == white ? util::row(move.f) >= Row::r6 : util::row(move.f) <= Row::r3);
         auto dangerousQuietCheck = isQuiet && pos.quiet_gives_dangerous_check(move);
 
+        // Futility pruning of quiet moves. If the static eval is so far below
+        // alpha that even a generous allowance for what a quiet move can be
+        // worth leaves it short, searching the rest of the quiets is unlikely
+        // to raise alpha.
+        //
+        // The engine had the two *conditional* forms of this rule -- history
+        // pruning, which needs a move with bad history, and move-count
+        // pruning, which needs a high move index -- but not the plain
+        // eval-based one, so a node 400cp behind at depth 2 still searched
+        // every quiet with neutral history in the first few slots.
+        //
+        // skipQuiets is set rather than just skipping this move: the margin
+        // does not depend on the move, so if it rejects one quiet it rejects
+        // all of them, and telling the picker stops it generating and scoring
+        // the rest. Excluded are moves that are not really quiet in the sense
+        // this rule assumes -- checks, advanced pawn pushes -- along with the
+        // hash move and killers, and the whole rule is off while in check,
+        // where every legal move is an evasion.
+        if (!pvNode && !in_check && hasStaticValue && isQuiet && !hashOrKiller &&
+            !dangerousQuietCheck && !advancedPawnPush && depth <= params_.fp_max_depth &&
+            bestScore > score::kMatedMaxPly &&
+            static_eval_val + params_.fp_base + params_.fp_margin * depth <= alpha) {
+            skipQuiets = true;
+            continue;
+        }
+
         // History pruning: skip quiet moves with terrible history at shallow depths
         if (!pvNode && !in_check && depth <= params_.history_prune_depth && !hashOrKiller &&
             isQuiet && bestScore > score::kMatedMaxPly) {


### PR DESCRIPTION
The move loop had the two *conditional* forms of shallow-depth quiet pruning — history pruning, which needs a move with bad history, and move-count pruning, which needs a high move index — but not the plain eval-based one. A node 400cp behind at depth 2 still searched every quiet move with neutral history sitting in the first few slots.

Now, at a non-PV node not in check, if `eval + fp_base + fp_margin * depth` is still at or below alpha, quiets are dropped. `skipQuiets` is set rather than the move merely skipped: the margin does not depend on the move, so a rule that rejects one quiet rejects all of them, and telling the picker stops it generating and scoring the rest.

Excluded are the moves that are not quiet in the sense the rule assumes — ones giving a dangerous check, advanced pawn pushes — plus the hash move and killers. The rule is off entirely while in check, where every legal move is an evasion and dropping quiets can discard the only escape.

**SPRT vs main:** `+2.2 +/- 19.2` over 794 games. Neutral — and that is explained rather than excused: at the shipped margins the rule fires on about **1.4%** of bench nodes. Dropping the base to 0 and the margin to 60 cuts ~12% of nodes, so the entire useful range of this rule lies *below* its default. A follow-up will measure a live setting; this PR is the mechanism and three registered SPSA axes.

Two notes for the tuner, both recorded in `docs/revisit-after-tuning.md`:

- The condition reads raw `depth` where the convention is the LMR-reduced depth, so 90-per-ply does not mean here what it means in the engines the number came from.
- Bench node count turned out to be a **useless** proxy for this change: over a five-point margin grid it moved non-monotonically (base 50 / margin 60 gave 943k, base 100 / margin 60 gave 924k). One prune changes move ordering downstream and the tree reorganises. Only game results were trusted.

129/129.