### PR TITLE
search: prune quiet moves that hang material

### DIFF
--- a/docs/revisit-after-tuning.md
+++ b/docs/revisit-after-tuning.md
@@ -272,3 +272,15 @@ a defended outpost is worth about as much again as the outpost itself.
   read the LMR-reduced depth. That makes 90 per ply mean something different
   here than it does in the engines the number was borrowed from, and is worth
   changing before the margins are fit.
+
+- **Rejected: futility margins at `fp_base` 0 / `fp_margin` 60.** Recorded
+  because the negative result is the useful part. The shipped 100/90 fires on
+  about 1.4% of bench nodes; 0/60 removes about 12% of the tree, and measured
+  `-15.6 +/- 19.1` over 794 games.
+
+  So the answer is not "prune more of the same thing". The likely cause is that
+  the condition reads raw `depth` where every engine this rule was borrowed
+  from reads the LMR-reduced depth: at raw depth 6 the margin is being applied
+  to a subtree that may really be searched at depth 2, and the rule throws away
+  moves the reduced search would have looked at cheaply anyway. Switch to a
+  reduced depth before touching the margins again.

--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -420,6 +420,8 @@ struct parameters {
     int history_prune_depth = 3;    // history pruning only below this depth
     int history_prune_margin = 4096; // ...and only below -margin*depth
     int see_prune_depth = 1;        // negative-SEE capture pruning depth
+    int see_quiet_prune_depth = 5; // quiet moves losing material pruned below this depth
+    int see_quiet_margin = 50;      // ...when see < -margin * depth
     int qs_delta_margin = 910;      // quiescence delta pruning margin
     int qs_delta_pawn7th = 775;     // ...widened by this with a pawn near promotion
     int singular_min_depth = 8;     // singular extension minimum depth

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -384,6 +384,8 @@ std::vector<std::pair<std::string, int*>> parameters::all_params(TuneStage stage
         result.emplace_back("history_prune_depth", &history_prune_depth);
         result.emplace_back("history_prune_margin", &history_prune_margin);
         result.emplace_back("see_prune_depth", &see_prune_depth);
+        result.emplace_back("see_quiet_prune_depth", &see_quiet_prune_depth);
+        result.emplace_back("see_quiet_margin", &see_quiet_margin);
     result.emplace_back("qs_delta_margin", &qs_delta_margin);
     result.emplace_back("qs_delta_pawn7th", &qs_delta_pawn7th);
         result.emplace_back("singular_min_depth", &singular_min_depth);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -873,6 +873,24 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
             (SEE = pos.see(move)) < 0)
             continue;
 
+        // Skip quiet moves that hang material. The rule above covers captures
+        // only, so a quiet move stepping a knight onto a square defended by a
+        // pawn was searched at full width no matter how obviously it loses a
+        // piece -- history pruning would only catch it once the same move had
+        // already failed often enough to sink its history score, which is a
+        // slow way to learn something SEE answers immediately.
+        //
+        // see() handles quiet moves correctly: with no victim the sequence
+        // starts at zero and plays out the recaptures on the destination
+        // square, so the return is exactly what the mover loses by going
+        // there. The threshold scales with depth because the deeper the node
+        // the more likely the search would have found the refutation anyway.
+        if (!pvNode && !in_check && isQuiet && !hashOrKiller && !dangerousQuietCheck &&
+            !advancedPawnPush && moves_searched > 1 &&
+            depth <= params_.see_quiet_prune_depth && bestScore > score::kMatedMaxPly &&
+            pos.see(move) < -params_.see_quiet_margin * depth)
+            continue;
+
         // Singular extension: if the hash move is significantly better than
         // all alternatives, extend it by 1 ply. The alternatives are measured
         // by re-searching this node with the hash move excluded.


### PR DESCRIPTION
The SEE rule in the move loop covered **captures only**, so a quiet move stepping a knight onto a square defended by a pawn was searched at full width no matter how plainly it loses a piece. History pruning would eventually catch it, but only after the same move had failed often enough to sink its history score — a slow way to learn something SEE answers immediately.

`see()` already handles quiet moves correctly: with no victim the exchange sequence starts at zero and plays out the recaptures on the destination square, so the return value is exactly what the mover loses by going there. No new evaluation machinery was needed.

Guarded like the other shallow-depth quiet rules — non-PV, not in check, not the hash move or a killer, not a dangerous check or an advanced pawn push, and never the first move searched. The threshold scales with depth because the deeper the node, the more likely the search finds the refutation unaided.

**SPRT vs main:** `+17.8 +/- 18.8` over 794 games, LOS 96.8%.

Bench 855540 against main's 947421 — 10% of the tree, and unlike the futility margin experiment below, this is 10% the engine genuinely did not need.

Also records a **negative** result in `docs/revisit-after-tuning.md`. Loosening the new futility margins from 100/90 to 0/60, which removes a comparable ~12% of nodes, measured `-15.6 +/- 19.1` over 794 games and was dropped. The two together say something specific: the tree has slack, but which 10% you remove decides whether it is worth Elo or costs it. The suspected cause of the futility failure is that it reads raw `depth` where the convention is the LMR-reduced depth, so at depth 6 it applies a 640cp margin to a subtree that may really be searched at depth 2.

`see_quiet_prune_depth` 5 and `see_quiet_margin` 50 registered for SPSA. 129/129.