### PR TITLE
search: scale the futility margin by the reduced depth, not the raw depth

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -844,16 +844,31 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
         // every quiet with neutral history in the first few slots.
         //
         // skipQuiets is set rather than just skipping this move: the margin
-        // does not depend on the move, so if it rejects one quiet it rejects
-        // all of them, and telling the picker stops it generating and scoring
-        // the rest. Excluded are moves that are not really quiet in the sense
-        // this rule assumes -- checks, advanced pawn pushes -- along with the
-        // hash move and killers, and the whole rule is off while in check,
+        // tightens monotonically as the move index rises -- a later quiet is
+        // reduced further, so its reduced depth is smaller and the condition
+        // only gets easier to satisfy -- so once the rule rejects one quiet it
+        // rejects every quiet after it, and telling the picker stops it
+        // generating and scoring the rest. Excluded are moves that are not
+        // really quiet in the sense this rule assumes -- checks, advanced pawn
+        // pushes -- along with the hash move and killers, and the whole rule
+        // is off while in check,
         // where every legal move is an evasion.
+        //
+        // The margin scales with the *reduced* depth, not the raw one. This
+        // move, if searched, is very likely to be reduced -- that is what LMR
+        // does to a late quiet -- so the raw depth overstates how much work it
+        // is about to cost and therefore how large a margin is justified for
+        // skipping it. Charging the raw depth was measured: it puts a 640cp
+        // margin at depth 6 on a subtree that may really be searched at depth
+        // 2, and loosening the margins from there to prune a comparable share
+        // of the tree measured -15.6 +/- 19.1 over 794 games.
+        const int lmr_depth =
+            std::max(0, static_cast<int>(depth) -
+                            static_cast<int>(reduction(pvNode, improving, depth, moves_searched)));
         if (!pvNode && !in_check && hasStaticValue && isQuiet && !hashOrKiller &&
-            !dangerousQuietCheck && !advancedPawnPush && depth <= params_.fp_max_depth &&
+            !dangerousQuietCheck && !advancedPawnPush && lmr_depth <= params_.fp_max_depth &&
             bestScore > score::kMatedMaxPly &&
-            static_eval_val + params_.fp_base + params_.fp_margin * depth <= alpha) {
+            static_eval_val + params_.fp_base + params_.fp_margin * lmr_depth <= alpha) {
             skipQuiets = true;
             continue;
         }


### PR DESCRIPTION
Follow-up to #58 and #59, and the fix the failed experiment in #59 pointed at.

The rule was borrowed from engines that apply it to the **LMR-reduced** depth and was written here against the raw one. That matters more than it looks: a late quiet is about to be reduced, which is the entire point of LMR, so the raw depth overstates both what searching the move costs and how large a margin is justified for skipping it. At depth 6 the old form applied a 640cp margin to a subtree that may really be searched at depth 2.

The evidence that this — and not the margin values — was the defect is the attempt to fix it the other way. Loosening the margins to 0/60 removes a comparable ~12% of the tree and measured `-15.6 +/- 19.1` over 794 games. Same share of nodes removed, opposite sign.

**SPRT vs main:** `+8.3 +/- 18.8` over 794 games, LOS 80.5%. Bench 754857 against 855540, so ~12% of the tree gone, this time without paying for it.

`skipQuiets` stays correct: the reduced depth only falls as the move index rises, so the condition is monotone and a rule that rejects one quiet rejects every quiet after it. The comment at the call site says so, since that is not obvious.

129/129.