### PR TITLE
tune: stop fitting the pawn weights against their own multiplier

### DIFF
--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -91,6 +91,22 @@ std::vector<std::pair<std::string, int*>> parameters::all_params(TuneStage stage
     if (stage == TuneStage::category) {
         // Stage 1: Category-level scale factors only. Tempo is FROZEN here
         // to prevent the bias term from absorbing scale changes.
+        //
+        // The individual pawn-structure weights deliberately do NOT appear
+        // here even though they used to. pawn_table.cpp sums them into
+        // pe->score_mg/eg and hce.cpp then multiplies that whole sum by
+        // pawn_structure_category_scale, so the contribution is
+        //
+        //     taper(sum_i w_i) * scale / 100
+        //
+        // Scaling every w_i by c and the scale by 1/c leaves the evaluation
+        // bit-identical. Fitting the scale and the weights it multiplies in
+        // the same stage therefore leaves an exact flat direction in the
+        // loss, and the optimiser wanders along it: two runs on different
+        // data converged to pawn_structure_category_scale 36 and 27 with
+        // doubled_pawn_penalty_mg 39 and -15 respectively, a sign flip on a
+        // penalty. The weights now live in stage 2, where the scale is held
+        // fixed and they are identified.
         result.emplace_back("sq_score_category_scale", &sq_score_category_scale);
         result.emplace_back("mobility_category_scale", &mobility_category_scale);
         result.emplace_back("mobility_endgame_scale", &mobility_endgame_scale);
@@ -99,6 +115,21 @@ std::vector<std::pair<std::string, int*>> parameters::all_params(TuneStage stage
         result.emplace_back("passed_pawn_category_scale", &passed_pawn_category_scale);
         result.emplace_back("passed_pawn_endgame_scale", &passed_pawn_endgame_scale);
         result.emplace_back("pawn_structure_category_scale", &pawn_structure_category_scale);
+        result.emplace_back("space_category_scale", &space_category_scale);
+        result.emplace_back("king_danger_divisor", &king_danger_divisor);
+        result.emplace_back("king_danger_endgame_scale", &king_danger_endgame_scale);
+        return result;
+    }
+
+    if (stage == TuneStage::shape) {
+        // Stage 2: Individual weights and curve shapes (~50-100 params)
+        // NOTE: tempo is excluded — it's a bias term that interferes with
+        // weight tuning. Set it manually to a small value (5-15cp).
+
+        // Pawn-structure weights. These are summed in pawn_table.cpp and the
+        // sum is then multiplied by pawn_structure_category_scale, which is
+        // fitted in stage 1 and held fixed here so that the weights are
+        // identified rather than free to slide against their own multiplier.
         result.emplace_back("doubled_pawn_penalty_mg", &doubled_pawn_penalty_mg);
         result.emplace_back("doubled_pawn_penalty_eg", &doubled_pawn_penalty_eg);
         result.emplace_back("backward_pawn_penalty_mg", &backward_pawn_penalty_mg);
@@ -115,16 +146,6 @@ std::vector<std::pair<std::string, int*>> parameters::all_params(TuneStage stage
         result.emplace_back("doubled_pawn_semiopen_eg", &doubled_pawn_semiopen_eg);
         result.emplace_back("doubled_isolated_penalty_mg", &doubled_isolated_penalty_mg);
         result.emplace_back("doubled_isolated_penalty_eg", &doubled_isolated_penalty_eg);
-        result.emplace_back("space_category_scale", &space_category_scale);
-        result.emplace_back("king_danger_divisor", &king_danger_divisor);
-        result.emplace_back("king_danger_endgame_scale", &king_danger_endgame_scale);
-        return result;
-    }
-
-    if (stage == TuneStage::shape) {
-        // Stage 2: Individual weights and curve shapes (~50-100 params)
-        // NOTE: tempo is excluded — it's a bias term that interferes with
-        // weight tuning. Set it manually to a small value (5-15cp).
 
         // Per-piece mobility scale factors
         result.emplace_back("knight_mobility_scale", &knight_mobility_scale);


### PR DESCRIPTION
Stage 1 is documented as "category-level scale factors only", but it also contained the sixteen individual pawn-structure weights. Those are summed in `pawn_table.cpp` into `pe->score_mg/eg`, and `hce.cpp` then multiplies the tapered sum by `pawn_structure_category_scale`:

```
contribution = taper(sum_i w_i) * pawn_structure_category_scale / 100
```

Multiplying every `w_i` by *c* and the scale by *1/c* leaves the evaluation **bit-identical**. Fitting the scale together with the weights it multiplies therefore leaves an exact flat direction in the loss. The optimiser has no reason to prefer any point along it and simply drifts.

The insidious part is that this does not look like a failure. Both runs below decreased monotonically and reported success:

| parameter | 287k self-play | 985k CCRL |
|---|---|---|
| `pawn_structure_category_scale` | 36 | 27 |
| `doubled_pawn_penalty_mg` | **39** | **-15** |
| `isolated_pawn_penalty_mg` | 31 | 13 |
| `backward_pawn_penalty_eg` | -93 | -16 |

A penalty changing sign between datasets is the signature — `-15` means a doubled pawn is a *bonus*. So is a fit that drives `passed_pawn_category_scale` onto its lower bound.

The weights move to stage 2, where `pawn_structure_category_scale` is held fixed and they are identified.

**Verification:** stage 1 goes 27 -> 11 parameters, stage 2 goes 257 -> 273, and `every_param` is unchanged at 1093 entries, so `save`/`load` still round-trip exactly the same set. 129/129 tests pass.

After this fix plus #63, the two datasets agree exactly on `sq_score_category_scale` (73 and 73) and near-exactly that pawn structure is worthless as shaped (6 and 11). The remaining disagreements are all phase-dependent parameters, which is expected given one dataset barely reaches endgames.