### PR TITLE
tune: fix the pipeline script and stop it baking unmeasured results

### DIFF
--- a/scripts/tune.sh
+++ b/scripts/tune.sh
@@ -4,7 +4,9 @@ set -euo pipefail
 # ── Configuration ─────────────────────────────────────────────────────────────
 GAMES=${1:-500}
 DEPTH=${2:-6}
-ITERATIONS=${3:-3}
+# Sweeps, not gradient steps. The optimiser is coordinate descent: one sweep
+# tries both directions on every parameter and keeps what lowers the error.
+ITERATIONS=${3:-20}
 THREADS=${4:-$(sysctl -n hw.ncpu 2>/dev/null || nproc 2>/dev/null || echo 4)}
 BUILD_DIR="./build"
 DATAGEN="$BUILD_DIR/havoc_datagen"
@@ -29,29 +31,42 @@ echo "--- Generating training data ($GAMES games at depth $DEPTH) ---"
 echo ""
 
 # ── Step 3: Run staged Texel tuning ──────────────────────────────────────────
-echo "--- Stage 1: Category normalization (coarse) ---"
-"$TUNER" --data "$DATA_FILE" --output "$PARAMS_FILE" --stage 1 --iterations 3
+# The category scales and the individual weights they multiply are fitted in
+# separate stages on purpose: fitting them together leaves an exact flat
+# direction in the loss. That means stage 2 changes the shapes underneath the
+# scales chosen in stage 1, so stage 1 is refitted afterwards.
+echo "--- Stage 1: category scales (coarse) ---"
+"$TUNER" --data "$DATA_FILE" --output "$PARAMS_FILE" --stage 1 \
+         --iterations "$ITERATIONS" --threads "$THREADS" --max-step 32
 echo ""
 
-echo "--- Stage 2: Shape tuning (medium) ---"
-"$TUNER" --data "$DATA_FILE" --params "$PARAMS_FILE" --output "$PARAMS_FILE" --stage 2 --iterations "$ITERATIONS"
+echo "--- Stage 2: individual weights and curve shapes ---"
+"$TUNER" --data "$DATA_FILE" --params "$PARAMS_FILE" --output "$PARAMS_FILE" --stage 2 \
+         --iterations "$ITERATIONS" --threads "$THREADS" --max-step 24
 echo ""
 
-# ── Step 4: Bake into source ─────────────────────────────────────────────────
-echo "--- Baking tuned params into source ---"
-python3 scripts/bake_params.py "$PARAMS_FILE"
+echo "--- Stage 1 refit: category scales against the new shapes ---"
+"$TUNER" --data "$DATA_FILE" --params "$PARAMS_FILE" --output "$PARAMS_FILE" --stage 1 \
+         --iterations "$ITERATIONS" --threads "$THREADS" --max-step 24
 echo ""
 
-# ── Step 5: Rebuild with tuned defaults ──────────────────────────────────────
-echo "--- Rebuilding with new defaults ---"
-cmake --build "$BUILD_DIR" --parallel
+# ── Step 4: Stop ─────────────────────────────────────────────────────────────
+# This script deliberately does NOT bake the result into the source tree.
+#
+# A lower fitting error is not evidence of a stronger engine. The fit is made
+# against static evaluations of quiet positions drawn from one distribution,
+# while strength is decided by games; the two come apart whenever the training
+# set does not look like the positions the engine actually reaches. Baking
+# first and measuring later also destroys the baseline needed to measure
+# against.
+echo "=== Fit complete ==="
+echo "Tuned parameters written to: $PARAMS_FILE"
 echo ""
-
-# ── Step 6: Verify with bench ────────────────────────────────────────────────
-echo "--- Running bench with baked-in params ---"
-printf "bench 8\nquit\n" | "$ENGINE"
+echo "This has NOT been baked into the source tree, and should not be until it"
+echo "has won a match. To evaluate it:"
 echo ""
-
-echo "=== Done ==="
-echo "Tuned params baked into include/havoc/parameters.hpp"
-echo "Rebuild complete — new defaults are active."
+echo "  1. python3 scripts/bake_params.py $PARAMS_FILE"
+echo "  2. cmake --build $BUILD_DIR --parallel"
+echo "  3. SPRT the resulting binary against the current one"
+echo ""
+echo "Revert the bake if the match does not support it."


### PR DESCRIPTION
Follow-up to #63, #64 and #66, now that the tuner underneath `scripts/tune.sh` works.

**Stage 1 was hardcoded to three iterations** regardless of the `ITERATIONS` argument. Under the old optimiser this made no difference, since it reverted every iteration anyway. Under coordinate descent an iteration is a full sweep over every parameter, so three left most weights untouched.

**Stage 1 was never refitted.** The category scales and the individual weights they multiply are fitted in separate stages (see #64) because fitting them together leaves an exact flat direction in the loss. But that means stage 2 moves the shapes out from under the scales stage 1 chose. The script now refits stage 1 afterwards.

**Most importantly, it baked the fit into `parameters.hpp` and rebuilt, with no measurement anywhere.** A lower fitting error is not evidence of a stronger engine — the fit is made against static evaluations of quiet positions from one distribution, while strength is decided by games, and the two come apart exactly when the training set does not resemble the positions the engine reaches. Baking before measuring also destroys the baseline you would measure against. The script now stops at the fit and prints the bake / rebuild / SPRT steps to run deliberately.

Also passes `--threads` through to the tuner, which it never did.