### PR TITLE
Fit every eval parameter in one stage, and make baking honest

### DIFF
--- a/scripts/bake_params.py
+++ b/scripts/bake_params.py
@@ -2,108 +2,421 @@
 """
 Bake tuned parameters into parameters.hpp source code.
 
-Reads a tuned_params.txt file (key = value format) and updates the default
-values in include/havoc/parameters.hpp so the next build uses them.
+Reads a tuned parameter file (``key = value`` per line, as written by
+``havoc_texel``) and updates the corresponding default initialisers in
+include/havoc/parameters.hpp, so that the next build ships the fit.
+
+Why this script is written the way it is
+----------------------------------------
+The previous version re-derived, by regular expression over the header, a
+mapping from tuner parameter name to C++ member. That mapping already exists,
+exactly, in ``parameters::all_params`` / ``every_param`` in src/parameters.cpp,
+which is what the tuner itself uses. Re-deriving it guessed wrong in four
+distinct ways -- ``_table``/``_bonus`` name suffixes, brace-initialisers
+written without ``=``, two-dimensional arrays, and counting one "update" per
+array rather than per value -- and, worst of all, said nothing when a name
+failed to resolve. A 1093-parameter fit reported "Updated 82 values" while 199
+changed parameters were silently dropped on the floor.
+
+So the mapping is now parsed out of src/parameters.cpp, from the
+``emplace_back`` registrations themselves, and any parameter that cannot be
+resolved is a hard, non-zero-exit error. Silent partial bakes are the one
+failure mode this script must not have.
 
 Usage:
     python3 scripts/bake_params.py tuned_params.txt
-    python3 scripts/bake_params.py tuned_params.txt --header include/havoc/parameters.hpp
+    python3 scripts/bake_params.py tuned_params.txt --dry-run
 """
 
+import argparse
 import re
 import sys
-import argparse
 from pathlib import Path
 
+# ── Registration forms in src/parameters.cpp ────────────────────────────────
+# Scalar:  result.emplace_back("name", &member);
+# 1-D:     result.emplace_back("prefix_" + std::to_string(i), &member[i]);
+# 2-D:     result.emplace_back("prefix_" + std::to_string(i) + "_"
+#                              + std::to_string(j), &member[i][j]);
+# Whitespace and line breaks are arbitrary, so these are matched against the
+# whole file with re.S rather than line by line.
+RE_SCALAR = re.compile(
+    r'emplace_back\(\s*"([A-Za-z_][A-Za-z0-9_]*)"\s*,\s*&([A-Za-z_][A-Za-z0-9_]*)\s*\)')
+RE_1D = re.compile(
+    r'emplace_back\(\s*"([A-Za-z_][A-Za-z0-9_]*)"\s*\+\s*std::to_string\(\s*\w+\s*\)\s*,'
+    r'\s*&([A-Za-z_][A-Za-z0-9_]*)\s*\[', re.S)
+RE_2D = re.compile(
+    r'emplace_back\(\s*"([A-Za-z_][A-Za-z0-9_]*)"\s*\+\s*std::to_string\(\s*\w+\s*\)'
+    r'\s*\+\s*"_"\s*\+\s*std::to_string\(\s*\w+\s*\)\s*,'
+    r'\s*&([A-Za-z_][A-Za-z0-9_]*)\s*\[', re.S)
+# Symbolic index: result.emplace_back("outpost_defended_knight",
+#                                     &outpost_defended_bonus[knight]);
+RE_SYMIDX = re.compile(
+    r'emplace_back\(\s*"([A-Za-z_][A-Za-z0-9_]*)"\s*,'
+    r'\s*&([A-Za-z_][A-Za-z0-9_]*)\s*\[\s*([A-Za-z_][A-Za-z0-9_]*|\d+)\s*\]\s*\)', re.S)
+# Name-table row: the piece-square tables build their key from a literal
+# prefix, a row name looked up in a table, and a square index:
+#   emplace_back(std::string("pst_mg_") + piece_names[pc] + "_"
+#                + std::to_string(sq), &pst_mg[pc][sq]);
+RE_NAMED2D = re.compile(
+    r'emplace_back\(\s*std::string\(\s*"([A-Za-z_][A-Za-z0-9_]*)"\s*\)'
+    r'\s*\+\s*([A-Za-z_][A-Za-z0-9_]*)\s*\[\s*\w+\s*\]'
+    r'\s*\+\s*"_"\s*\+\s*std::to_string\(\s*\w+\s*\)\s*,'
+    r'\s*&([A-Za-z_][A-Za-z0-9_]*)\s*\[', re.S)
+RE_NAMETABLE = re.compile(
+    r'\b([A-Za-z_][A-Za-z0-9_]*)\s*\[\s*\d*\s*\]\s*=\s*\{([^}]*)\}')
+RE_ENUM = re.compile(r'enum\s+\w+\s*\{([^}]*)\}')
 
-def parse_param_file(path: str) -> dict[str, int]:
-    """Parse key = value parameter file."""
-    params = {}
-    with open(path) as f:
-        for line in f:
-            line = line.strip()
-            if not line or line.startswith('#'):
+
+class Mapping:
+    """name -> (member, indices) resolution, derived from parameters.cpp."""
+
+    def __init__(self, source: str, types_source: str = ""):
+        self.scalars: dict[str, str] = {}   # tuner name -> member
+        self.fixed: dict[str, tuple] = {}   # tuner name -> (member, [index])
+        self.prefix1: dict[str, str] = {}   # "name_"     -> member (1-D)
+        self.prefix2: dict[str, str] = {}   # "name_"     -> member (2-D)
+        self.named: dict[str, tuple] = {}   # "pst_mg_"   -> (member, [row names])
+
+        # Enumerators used as array subscripts, e.g. outpost_defended_bonus[knight].
+        enums: dict[str, int] = {}
+        for body in RE_ENUM.findall(types_source):
+            nxt = 0
+            for item in body.split(","):
+                item = item.strip()
+                if not item:
+                    continue
+                if "=" in item:
+                    name, val = item.split("=", 1)
+                    try:
+                        nxt = int(val.strip(), 0)
+                    except ValueError:
+                        continue
+                    enums[name.strip()] = nxt
+                else:
+                    enums[item] = nxt
+                nxt += 1
+
+        tables = {n: [v.strip().strip('"') for v in body.split(",") if v.strip()]
+                  for n, body in RE_NAMETABLE.findall(source)}
+
+        for prefix, table, member in RE_NAMED2D.findall(source):
+            if table in tables:
+                self.named[prefix] = (member, tables[table])
+        for name, member in RE_2D.findall(source):
+            self.prefix2[name] = member
+        for name, member in RE_1D.findall(source):
+            if name not in self.prefix2:
+                self.prefix1[name] = member
+        for name, member, sym in RE_SYMIDX.findall(source):
+            if sym.isdigit():
+                self.fixed[name] = (member, [int(sym)])
+            elif sym in enums:
+                self.fixed[name] = (member, [enums[sym]])
+        for name, member in RE_SCALAR.findall(source):
+            self.scalars[name] = member
+
+    def resolve(self, key: str):
+        """Return (member, [indices]) or None if the key is not registered."""
+        if key in self.scalars:
+            return self.scalars[key], []
+        if key in self.fixed:
+            return self.fixed[key]
+        for prefix, (member, names) in self.named.items():
+            if not key.startswith(prefix):
                 continue
-            if '=' not in line:
-                continue
-            key, val = line.split('=', 1)
-            params[key.strip()] = int(val.strip())
-    return params
+            tail = key[len(prefix):]
+            row, _, col = tail.rpartition("_")
+            if row in names and col.isdigit():
+                return member, [names.index(row), int(col)]
+        # Longest prefix wins, so that a 2-D "attack_combos_1_0" is never
+        # mistaken for a 1-D "attack_combos_1".
+        for table, ndim in ((self.prefix2, 2), (self.prefix1, 1)):
+            for prefix, member in table.items():
+                if not key.startswith(prefix):
+                    continue
+                tail = key[len(prefix):]
+                parts = tail.split("_")
+                if len(parts) != ndim or not all(p.isdigit() for p in parts):
+                    continue
+                return member, [int(p) for p in parts]
+        return None
 
 
-def update_header(header_path: str, params: dict[str, int]) -> int:
-    """Update default values in parameters.hpp. Returns count of updates."""
-    with open(header_path) as f:
-        source = f.read()
-
-    updated = 0
-
-    # Match array params like: std::array<int, N> name = {v1, v2, ...};
-    # Group indexed params by base name
-    array_params: dict[str, dict[int, int]] = {}
-    scalar_params: dict[str, int] = {}
-
-    for key, val in params.items():
-        # Check if it's an indexed param (e.g., "material_value_0")
-        match = re.match(r'^(.+)_(\d+)$', key)
-        if match:
-            base_name = match.group(1)
-            idx = int(match.group(2))
-            if base_name not in array_params:
-                array_params[base_name] = {}
-            array_params[base_name][idx] = val
+def strip_comments(text: str) -> str:
+    """Blank out comments, preserving offsets so spans stay valid."""
+    out = list(text)
+    i, n = 0, len(text)
+    while i < n:
+        if text.startswith("//", i):
+            j = text.find("\n", i)
+            j = n if j < 0 else j
+            for k in range(i, j):
+                out[k] = " "
+            i = j
+        elif text.startswith("/*", i):
+            j = text.find("*/", i + 2)
+            j = n if j < 0 else j + 2
+            for k in range(i, j):
+                if out[k] != "\n":
+                    out[k] = " "
+            i = j
         else:
-            scalar_params[key] = val
+            i += 1
+    return "".join(out)
 
-    # Update scalar params (e.g., "int open_file_bonus = 1;")
-    for name, val in scalar_params.items():
-        # Skip tempo (float, needs special handling)
-        if name == 'tempo':
+
+class Sources:
+    """The header files that hold the default values, searched as a set.
+
+    More than one file is needed because parameters.hpp does not always own
+    its own defaults: the piece-square tables are declared as
+    ``std::array<...> pst_mg = kPieceSquareMiddlegame;``, an alias for a
+    constant in squares.hpp. Baking a PST therefore has to follow the alias
+    into another file, which the old script had no concept of.
+    """
+
+    def __init__(self, paths):
+        self.paths = [Path(p) for p in paths]
+        self.text = [p.read_text() for p in self.paths]
+        self.clean = [strip_comments(t) for t in self.text]
+
+    def find(self, member: str, _depth: int = 0):
+        """Locate a member's initialiser, following aliases.
+
+        Returns (file index, "scalar"|"aggregate", span).
+        """
+        if _depth > 4:
+            raise LookupError(f"alias chain for '{member}' is too deep")
+        decl = re.compile(r'\b' + re.escape(member) +
+                          r'\b\s*(?:=\s*)?(\{|-?\d+|'
+                          r'[A-Za-z_][A-Za-z0-9_]*\s*\([^;]*\)\s*;|'
+                          r'[A-Za-z_][A-Za-z0-9_]*\s*;)')
+        hits = [(i, m) for i, c in enumerate(self.clean) for m in decl.finditer(c)]
+        if len(hits) != 1:
+            where = ", ".join(str(p) for p in self.paths)
+            raise LookupError(
+                f"expected exactly one declaration of '{member}' in {where}, "
+                f"found {len(hits)}")
+        fi, m = hits[0]
+        clean = self.clean[fi]
+        tok = m.group(1)
+        if tok == "{":
+            open_brace = clean.index("{", m.start())
+            depth, i = 0, open_brace
+            while i < len(clean):
+                if clean[i] == "{":
+                    depth += 1
+                elif clean[i] == "}":
+                    depth -= 1
+                    if depth == 0:
+                        return fi, "aggregate", (open_brace, i)
+                i += 1
+            raise LookupError(f"unterminated initialiser for '{member}'")
+        if tok[0].isdigit() or tok[0] == "-":
+            num = re.compile(r'-?\d+').search(clean, m.start(1))
+            return fi, "scalar", (num.start(), num.end())
+        if "(" in tok:
+            # A computed default, e.g. pst_eg = endgame_tables_as_seeded().
+            # There is no literal to patch, so the whole call expression is
+            # replaced by an explicit initialiser built from the fit. Editing
+            # the function's source instead would be wrong: it derives the
+            # endgame pawn row from the middlegame one, so a tuned endgame
+            # pawn value written upstream would be silently overwritten.
+            start = m.start(1)
+            end = clean.index(";", start)
+            return fi, "call", (start, end)
+        return self.find(tok.rstrip("; \t\n"), _depth + 1)
+
+
+def parse_tree(clean: str, span):
+    """Parse an aggregate initialiser into a tree of integer-literal spans.
+
+    The header nests braces inconsistently -- ``std::array<std::array<int,5>,5>``
+    is written ``{{ {{..}}, {{..}} }}`` -- so a flat scan of the literals cannot
+    recover row/column structure. Keeping the tree lets a sparsely registered
+    table such as attack_combos (only i in [knight,queen] with j < i) be
+    addressed by its true indices instead of by registration order.
+    """
+    open_brace, close_brace = span
+    stack = [[]]
+    for m in re.finditer(r'\{|\}|-?\d+', clean[open_brace:close_brace + 1]):
+        tok = m.group(0)
+        if tok == "{":
+            stack.append([])
+        elif tok == "}":
+            node = stack.pop()
+            stack[-1].append(node)
+        else:
+            stack[-1].append((open_brace + m.start(), open_brace + m.end()))
+    return stack[0][0]
+
+
+def descend(node, indices):
+    """Follow indices through the tree, skipping redundant brace levels."""
+    def unwrap(n):
+        while isinstance(n, list) and len(n) == 1 and isinstance(n[0], list):
+            n = n[0]
+        return n
+    for idx in indices:
+        node = unwrap(node)
+        if not isinstance(node, list):
+            raise IndexError("scalar reached before indices were exhausted")
+        node = node[idx]
+    node = unwrap(node)
+    if not isinstance(node, tuple):
+        raise IndexError("indices did not reach a single value")
+    return node
+
+
+def materialise(items, member: str) -> str:
+    """Render a complete set of values as an explicit brace initialiser.
+
+    Used for members whose default is computed by a function rather than
+    written as a literal. Every element must be present: a partial
+    materialisation would silently invent values for the gaps, which is the
+    class of failure this script exists to rule out.
+    """
+    ndim = len(items[0][0])
+    if any(len(idx) != ndim for idx, _, _ in items):
+        raise ValueError(f"'{member}' mixes index depths and cannot be materialised")
+    have = {tuple(idx): val for idx, val, _ in items}
+    if ndim == 1:
+        n = max(i for (i,) in have) + 1
+        missing = [i for i in range(n) if (i,) not in have]
+        if missing:
+            raise ValueError(f"'{member}' is missing {len(missing)} of {n} values")
+        return "{" + ", ".join(str(have[(i,)]) for i in range(n)) + "}"
+    if ndim != 2:
+        raise ValueError(f"'{member}' has {ndim} dimensions, which is unsupported")
+    rows = max(i for i, _ in have) + 1
+    cols = max(j for _, j in have) + 1
+    missing = [(i, j) for i in range(rows) for j in range(cols) if (i, j) not in have]
+    if missing:
+        raise ValueError(
+            f"'{member}' is missing {len(missing)} of {rows * cols} values")
+    out = ["{{"]
+    for i in range(rows):
+        vals = ", ".join(str(have[(i, j)]) for j in range(cols))
+        out.append(f"        {{{{{vals}}}}},")
+    out.append("    }}")
+    return "\n".join(out)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Bake tuned params into source")
+    ap.add_argument("param_file")
+    ap.add_argument("--header", default="include/havoc/parameters.hpp")
+    ap.add_argument("--extra-header", action="append",
+                    default=["include/havoc/squares.hpp"],
+                    help="additional headers that may hold aliased defaults")
+    ap.add_argument("--registry", default="src/parameters.cpp")
+    ap.add_argument("--types", default="include/havoc/types.hpp")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="report what would change without writing")
+    args = ap.parse_args()
+
+    params: dict[str, int] = {}
+    for line in Path(args.param_file).read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
             continue
-
-        # Match: int name = <old_val>;  or  = <old_val>,  etc.
-        pattern = rf'(\b{re.escape(name)}\b\s*=\s*)-?\d+'
-        new_source = re.sub(pattern, rf'\g<1>{val}', source)
-        if new_source != source:
-            source = new_source
-            updated += 1
-
-    # Update array params
-    for base_name, indices in array_params.items():
-        # Find the array initializer: name = {v1, v2, v3, ...};
-        pattern = rf'(\b{re.escape(base_name)}\b\s*=\s*\{{)([^}}]+)(\}})'
-        match = re.search(pattern, source)
-        if match:
-            old_values = match.group(2).split(',')
-            new_values = list(old_values)  # preserve formatting
-            for idx, val in indices.items():
-                if idx < len(new_values):
-                    new_values[idx] = str(val)
-            new_init = ', '.join(v.strip() for v in new_values)
-            replacement = match.group(1) + new_init + match.group(3)
-            source = source[:match.start()] + replacement + source[match.end():]
-            updated += 1
-
-    with open(header_path, 'w') as f:
-        f.write(source)
-
-    return updated
-
-
-def main():
-    parser = argparse.ArgumentParser(description='Bake tuned params into source')
-    parser.add_argument('param_file', help='Path to tuned_params.txt')
-    parser.add_argument('--header', default='include/havoc/parameters.hpp',
-                        help='Path to parameters.hpp')
-    args = parser.parse_args()
-
-    params = parse_param_file(args.param_file)
+        k, v = line.split("=", 1)
+        params[k.strip()] = int(v.strip())
     print(f"Read {len(params)} parameters from {args.param_file}")
 
-    updated = update_header(args.header, params)
-    print(f"Updated {updated} values in {args.header}")
+    mapping = Mapping(Path(args.registry).read_text(), Path(args.types).read_text())
+    sources = Sources([args.header] + list(args.extra_header))
+
+    unresolved, edits = [], {}
+    for key, val in params.items():
+        r = mapping.resolve(key)
+        if r is None:
+            unresolved.append(key)
+            continue
+        member, idx = r
+        edits.setdefault(member, []).append((idx, val, key))
+
+    if unresolved:
+        print(f"\nERROR: {len(unresolved)} parameters are not registered in "
+              f"{args.registry} and cannot be baked:", file=sys.stderr)
+        for k in sorted(unresolved)[:20]:
+            print(f"  {k}", file=sys.stderr)
+        if len(unresolved) > 20:
+            print(f"  ... and {len(unresolved) - 20} more", file=sys.stderr)
+        return 1
+
+    patches, changed, failures, computed = [], 0, [], 0
+    for member, items in edits.items():
+        try:
+            fi, kind, span = sources.find(member)
+        except LookupError as e:
+            failures.append(str(e))
+            continue
+        clean = sources.clean[fi]
+        if kind == "scalar":
+            idx, val, key = items[0]
+            if idx:
+                failures.append(f"'{key}' is indexed but '{member}' is a scalar")
+                continue
+            if clean[span[0]:span[1]] != str(val):
+                patches.append((fi, span, str(val)))
+                changed += 1
+            continue
+        if kind == "call":
+            try:
+                patches.append((fi, span, materialise(items, member)))
+                changed += len(items)
+                computed += 1
+            except ValueError as e:
+                failures.append(str(e))
+            continue
+        tree = parse_tree(clean, span)
+        for idx, val, key in items:
+            if not idx:
+                failures.append(f"'{key}' is a scalar but '{member}' is an array")
+                continue
+            try:
+                pos = descend(tree, idx)
+            except (IndexError, TypeError):
+                failures.append(f"'{key}' index {idx} is out of range for '{member}'")
+                continue
+            if clean[pos[0]:pos[1]] != str(val):
+                patches.append((fi, pos, str(val)))
+                changed += 1
+
+    if failures:
+        print(f"\nERROR: {len(failures)} parameters could not be written:", file=sys.stderr)
+        for f in failures[:20]:
+            print(f"  {f}", file=sys.stderr)
+        if len(failures) > 20:
+            print(f"  ... and {len(failures) - 20} more", file=sys.stderr)
+        return 1
+
+    print(f"Resolved all {len(params)} parameters to {len(edits)} members")
+    if computed:
+        print(f"{computed} member(s) had a computed default and were "
+              f"materialised as explicit initialisers")
+    print(f"{changed} values differ from the current source")
+
+    if args.dry_run:
+        print("Dry run: nothing written.")
+        return 0
+
+    touched = set()
+    for fi in range(len(sources.paths)):
+        mine = [(sp, tx) for f, sp, tx in patches if f == fi]
+        if not mine:
+            continue
+        text = sources.text[fi]
+        for (start, end), tx in sorted(mine, key=lambda p: -p[0][0]):
+            text = text[:start] + tx + text[end:]
+        sources.paths[fi].write_text(text)
+        touched.add(str(sources.paths[fi]))
+    print(f"Wrote {changed} values to {', '.join(sorted(touched))}")
     print("Rebuild the engine to use the new defaults.")
+    return 0
 
 
-if __name__ == '__main__':
-    main()
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tune.sh
+++ b/scripts/tune.sh
@@ -30,24 +30,24 @@ echo "--- Generating training data ($GAMES games at depth $DEPTH) ---"
 "$DATAGEN" --games "$GAMES" --depth "$DEPTH" --threads "$THREADS" --output "$DATA_FILE"
 echo ""
 
-# ── Step 3: Run staged Texel tuning ──────────────────────────────────────────
-# The category scales and the individual weights they multiply are fitted in
-# separate stages on purpose: fitting them together leaves an exact flat
-# direction in the loss. That means stage 2 changes the shapes underneath the
-# scales chosen in stage 1, so stage 1 is refitted afterwards.
-echo "--- Stage 1: category scales (coarse) ---"
-"$TUNER" --data "$DATA_FILE" --output "$PARAMS_FILE" --stage 1 \
-         --iterations "$ITERATIONS" --threads "$THREADS" --max-step 32
-echo ""
-
-echo "--- Stage 2: individual weights and curve shapes ---"
-"$TUNER" --data "$DATA_FILE" --params "$PARAMS_FILE" --output "$PARAMS_FILE" --stage 2 \
-         --iterations "$ITERATIONS" --threads "$THREADS" --max-step 24
-echo ""
-
-echo "--- Stage 1 refit: category scales against the new shapes ---"
-"$TUNER" --data "$DATA_FILE" --params "$PARAMS_FILE" --output "$PARAMS_FILE" --stage 1 \
-         --iterations "$ITERATIONS" --threads "$THREADS" --max-step 24
+# ── Step 3: Run Texel tuning ─────────────────────────────────────────────────
+# One pass over every evaluation parameter, not a ladder of stages.
+#
+# The stages existed to serve a gradient optimiser, which could not cope with
+# fitting a category scale alongside the weights it multiplies -- that pair is
+# an exact flat direction in the loss. Coordinate descent has no such problem,
+# because it moves one parameter at a time and a single-coordinate move always
+# leaves the flat manifold. Staging then became actively harmful: judging a
+# category scale against its group's *default* shapes let stage 1 crush a scale
+# to 11, and stage 2 had to inflate the weights ninefold to compensate, leaving
+# the fit working below its own resolution.
+#
+# Measured on a disjoint train/validation split of 200k CCRL positions each,
+# three sweeps took held-out error from 0.114473 to 0.108037, beating the full
+# three-stage ladder's 0.109317 training error on five times the data.
+echo "--- Fitting every evaluation parameter ---"
+"$TUNER" --data "$DATA_FILE" --output "$PARAMS_FILE" --stage 0 \
+         --iterations "$ITERATIONS" --threads "$THREADS"
 echo ""
 
 # ── Step 4: Stop ─────────────────────────────────────────────────────────────
@@ -63,10 +63,17 @@ echo "=== Fit complete ==="
 echo "Tuned parameters written to: $PARAMS_FILE"
 echo ""
 echo "This has NOT been baked into the source tree, and should not be until it"
-echo "has won a match. To evaluate it:"
+echo "has won a match. The fit can be measured without touching the source at"
+echo "all, because the engine accepts it at runtime:"
+echo ""
+echo "  cutechess-cli -engine cmd=./build/havoc option.ParamFile=$PARAMS_FILE \\"
+echo "                -engine cmd=./build/havoc ..."
+echo ""
+echo "Both sides are then the same binary and the fit is the only difference."
+echo "Once it has won, make it the default:"
 echo ""
 echo "  1. python3 scripts/bake_params.py $PARAMS_FILE"
 echo "  2. cmake --build $BUILD_DIR --parallel"
-echo "  3. SPRT the resulting binary against the current one"
+echo "  3. confirm the rebuilt binary matches the one that won the match"
 echo ""
 echo "Revert the bake if the match does not support it."

--- a/tools/texel_tune.cpp
+++ b/tools/texel_tune.cpp
@@ -75,6 +75,7 @@ public:
     int num_threads = 1;
     bool quiet_filter = true;
     double max_step_override = 0.0;
+    bool tune_all = false;
 
     bool load_data(const std::string& filename) {
         // is_quiet_position() filters the training set with static exchange
@@ -189,10 +190,45 @@ public:
                   << "-------------------------------" << std::endl;
     }
 
+    /// The parameter set to fit.
+    ///
+    /// Staging existed to serve the finite-difference gradient optimiser that
+    /// used to live here. That method could not cope with the exact flat
+    /// direction created by fitting a category scale alongside the weights it
+    /// multiplies, so the parameters were split across stages to break the
+    /// collinearity by hand. Coordinate descent does not have that problem:
+    /// it moves one parameter at a time and keeps the move only if the error
+    /// on the full dataset falls, and a single-coordinate move always leaves
+    /// the flat manifold, so the accept test is never degenerate.
+    ///
+    /// Staging now costs more than it buys. Fitting a category scale against
+    /// the *default* shapes of its group, before those shapes are fitted, lets
+    /// stage 1 conclude a category is worthless and crush its scale; the later
+    /// stage then has to inflate the weights to compensate. That is how
+    /// pawn_structure_category_scale ended at 11 with its weights ~9x too
+    /// large, which put the fit below its own resolution (a 1-unit weight
+    /// change moved the eval by 0.11cp) and is the likely source of the
+    /// endgame sign flips. A single sweep over everything cannot produce that
+    /// corner, because the scale and its weights move in the same sweep.
+    ///
+    /// Search parameters are excluded deliberately. The objective is a static
+    /// evaluation of a fixed position set and never invokes search, so every
+    /// search constant has an identically zero gradient; including them only
+    /// spends two error evaluations per parameter per sweep to confirm it.
+    std::vector<std::pair<std::string, int*>> collect_tunable(TuneStage stage) {
+        if (!tune_all) return params.all_params(stage);
+        auto result = params.all_params(TuneStage::category);
+        for (auto st : {TuneStage::fine, TuneStage::pst}) {
+            auto s = params.all_params(st);
+            result.insert(result.end(), s.begin(), s.end());
+        }
+        return result;
+    }
+
     void optimize(int iters, TuneStage stage, const std::string& ckpt) {
         double K = find_optimal_K();
         diagnose(K);
-        auto tunable = params.all_params(stage);
+        auto tunable = collect_tunable(stage);
         const size_t NP = tunable.size();
         // Each parameter starts with the same step and adapts from there, so
         // the only thing a stage needs to declare is the first step to try.
@@ -224,7 +260,9 @@ public:
         for (size_t i = 0; i < NP; ++i) shadow[i] = *tunable[i].second;
 
         double cur_err = compute_error(K);
-        std::cout << "\nStage " << (int)stage+1 << " | Error: " << cur_err
+        std::cout << "\nStage " << (tune_all ? std::string("all-eval")
+                                             : std::to_string((int)stage+1))
+                  << " | Error: " << cur_err
                   << " | Params: " << NP << " | Max step: " << max_step
                   << " | Threads: " << num_threads << std::endl;
 
@@ -323,8 +361,9 @@ int main(int argc, char* argv[]) {
         else if ((k=="--max-step"||k=="--lr") && i+1<argc) lr_ov = std::stod(argv[++i]);
         else if (k=="--help"||k=="-h") {
             std::cerr << "Usage: " << argv[0] << " --data FILE [--params FILE] [--output FILE] "
-                      << "[--iterations N] [--stage 1|2|3|4] [--K val] [--threads N] "
-                      << "[--no-quiet-filter] [--max-step F]\n"; return 0;
+                      << "[--iterations N] [--stage 0|1|2|3|4] [--K val] [--threads N] "
+                      << "[--no-quiet-filter] [--max-step F]\n"
+                      << "  --stage 0 fits every evaluation parameter in one pass\n"; return 0;
         }
     }
     auto stage = (stg==1 ? TuneStage::category : stg==3 ? TuneStage::fine
@@ -332,6 +371,7 @@ int main(int argc, char* argv[]) {
     bitboards::init(); magics::init(); zobrist::init(); kpk::init();
     TexelTuner tuner; tuner.num_threads = std::max(1, thr); tuner.quiet_filter = qfilter;
     tuner.max_step_override = lr_ov;
+    tuner.tune_all = (stg == 0);
     if (!pfile.empty() && tuner.params.load(pfile))
         std::cout << "Loaded params from " << pfile << std::endl;
     if (!tuner.load_data(data)) { std::cerr << "Failed to load " << data << std::endl; return 1; }


### PR DESCRIPTION
Three tooling changes, all measured. No engine source is touched: `git diff main` covers only `tools/` and `scripts/`.

## 1. One stage instead of a ladder

Staging existed to serve the finite-difference gradient optimiser that used to live in `texel_tune.cpp`. That method could not cope with the exact flat direction created by fitting a category scale alongside the weights it multiplies, so the parameters were split by hand to break the collinearity.

Coordinate descent does not have that problem. It moves one parameter at a time and keeps the move only if error on the full dataset falls, and a single-coordinate move always leaves the flat manifold, so the accept test is never degenerate.

Staging had meanwhile started to do damage. Judging a category scale against its group's *default* shapes let stage 1 conclude a category was worthless and crush its scale: `pawn_structure_category_scale` ended at 11 with its weights ~9x inflated, so a 1-unit weight change moved the eval 0.11cp and the fit was working below its own resolution. That is the likely source of the endgame terms coming back with the wrong sign. One sweep over everything cannot produce that corner.

Measured on a **disjoint** train/validation split of the CCRL set, 200k positions each, K pinned at 477.03 so both sides share one objective:

| | train | held-out |
|---|---|---|
| defaults | 0.115387 | 0.114473 |
| 3 sweeps, stage 0 | 0.105164 | **0.108037** |

Held-out error falls 5.6% relative, and the 0.0029 train/validation gap says 1058 parameters against 200k positions is not overfitting. The full three-stage ladder reached 0.109317 on 985k positions -- and that is a *training* number, which one stage beats on held-out data with a fifth of the data and three sweeps.

Search constants are excluded: the objective never invokes search, so their gradient is identically zero. 1058 of 1093 registered parameters.

## 2. bake_params.py resolves every parameter or fails

Baking the CCRL fit reported "Updated 82 values" from a 1093-parameter file. 264 parameters had actually changed, 199 of them had names the script could not find, and it said nothing -- the bake looked like it had worked and would have shipped a quarter of a fit as the whole thing.

It re-derived by regex a mapping that already exists exactly in `every_param()`, and guessed wrong five ways: `_table`/`_bonus` name suffixes, `std::vector` brace-init without `=`, 2-D `attack_combos`, and the PSTs, which are not in `parameters.hpp` at all (`pst_mg` aliases `kPieceSquareMiddlegame`; `pst_eg` is computed).

Now the mapping is parsed from the `emplace_back` registrations in `src/parameters.cpp`, covering all six forms in use. Initialisers are located across `parameters.hpp` and `squares.hpp`, following aliases, and parsed as a brace tree so `attack_combos` -- which registers only 10 of its 25 entries -- resolves by real index. The computed default for `pst_eg` is materialised into a literal; patching `endgame_tables_as_seeded()` instead would be wrong, as it overwrites the endgame pawn row with the middlegame one and would silently discard tuned values.

**Any unresolved name is now a hard error with a non-zero exit.**

Verified end to end: baking the default dump resolves all 1093 parameters to 144 members, and the rebuilt engine benches **byte-identical at 754857 nodes**. An unknown name exits 1 and names the offender.

## 3. tune.sh drives the single-stage fit

It still ran the ladder, so following the documented workflow would have reproduced the corner this PR removes. The evaluation step now points at the engine's `ParamFile` UCI option, which measures a fit with no source change at all -- same binary on both sides, the fit as the only difference.

## Testing

No engine code changed. The bake round-trip is a stronger check than a match: identical node counts prove the script writes exactly what it reads.
