### PR TITLE
eval: make the category scales mean what they say, and measure what actually chooses moves

### DIFF
--- a/include/havoc/eval/hce.hpp
+++ b/include/havoc/eval/hce.hpp
@@ -34,6 +34,32 @@ struct einfo {
     U64 light_sq_pawns[2]{};
     U64 dark_sq_pawns[2]{};
     unsigned kattackers[2][5]{};
+    /// Three running totals that are collected inside the piece, king and pawn
+    /// terms but must not be scaled by the category factor those terms sit
+    /// under. Each category scale is supposed to control one coherent idea,
+    /// and without these it does not:
+    ///
+    ///   mobility already carries mobility_category_scale, applied inside each
+    ///   piece function. Leaving it inside the piece total multiplied it by
+    ///   sq_score_category_scale as well, so the two scales compounded and the
+    ///   tuner could trade one against the other along a flat direction
+    ///   instead of fitting either.
+    ///
+    ///   king_placement is the king piece-square score, which is positional
+    ///   king activity, not danger. Inside the king total it was scaled by
+    ///   king_safety_category_scale, so raising king safety silently pulled
+    ///   the king towards or away from the centre.
+    ///
+    ///   king_pressure is a pawn attacking the enemy king ring. It is
+    ///   collected in the pawn term and so was scaled by
+    ///   pawn_structure_category_scale, which is a scale for weak pawns.
+    ///
+    /// All three are exact no-ops at the default scales of 100, since integer
+    /// (x * 100) / 100 is x. They change what the scales mean, not what the
+    /// evaluation currently returns.
+    int mobility[2]{};
+    int king_placement[2]{};
+    int king_pressure[2]{};
 };
 
 /// Hand-Crafted Evaluation function.

--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -216,7 +216,6 @@ struct parameters {
     int king_open_file_penalty = 9;
     int king_open_file_heavy_penalty = 4;
 
-    int uncastled_penalty = 5;
     /// eval_threats weights. Every one of these was a bare literal in the
     /// evaluation, so none of them could be tuned. The defaults reproduce the
     /// values that were hardcoded. The three tables are indexed

--- a/src/eval/hce.cpp
+++ b/src/eval/hce.cpp
@@ -361,6 +361,21 @@ int HCEEvaluator::evaluate(const position& p, int /*lazy_margin*/) {
                                           params_.passed_pawn_endgame_scale)) /
              100;
 
+    // The three totals the piece, king and pawn terms deliberately kept out of
+    // their own running score, each folded in under the category scale that
+    // actually describes it. King placement is positional, so it joins the
+    // piece-square bucket; a pawn attacking the enemy king ring is king
+    // pressure, so it joins king safety; mobility already carries its own
+    // scale and its own endgame taper, so it is added unscaled rather than
+    // being multiplied a second time by the piece-square scale.
+    const int king_placement = ei.king_placement[white] - ei.king_placement[black];
+    const int king_pressure = ei.king_pressure[white] - ei.king_pressure[black];
+    const int mobility_score = ei.mobility[white] - ei.mobility[black];
+
+    score += (king_placement * params_.sq_score_category_scale) / 100;
+    score += (king_pressure * params_.king_safety_category_scale) / 100;
+    score += mobility_score;
+
     int threat_score = eval_threats<white>(p, ei) - eval_threats<black>(p, ei);
     int space_score = eval_space<white>(p, ei) - eval_space<black>(p, ei);
 
@@ -429,7 +444,7 @@ template <Color c> int HCEEvaluator::eval_pawns(const position& p, einfo& ei) {
     if (kAttkCount) {
         ei.kattackers[c][pawn]++;
         ei.kattk_points[c][pawn] |= kattks;
-        score += params_.pawn_king[std::min(2, kAttkCount)];
+        ei.king_pressure[c] += params_.pawn_king[std::min(2, kAttkCount)];
     }
 
     // Pawn chain bases / undefended enemy pawns
@@ -462,9 +477,12 @@ template <Color c> int HCEEvaluator::eval_knights(const position& p, einfo& ei) 
             int mob = (cnt < params_.knight_mobility_table.size())
                           ? params_.knight_mobility_table[cnt]
                           : params_.knight_mobility_table.back();
-            score += ((params_.knight_mobility_scale * params_.mobility_scaling[knight] * mob) /
-                      100) *
-                     ei.me->taper(params_.mobility_category_scale, params_.mobility_endgame_scale) / 100;
+            ei.mobility[c] += ((params_.knight_mobility_scale *
+                                params_.mobility_scaling[knight] * mob) /
+                               100) *
+                              ei.me->taper(params_.mobility_category_scale,
+                                           params_.mobility_endgame_scale) /
+                              100;
         }
 
         // Outpost. A knight on a hole is good; one a friendly pawn also
@@ -572,7 +590,7 @@ template <Color c> int HCEEvaluator::eval_bishops(const position& p, einfo& ei) 
         if ((sq_bb & p.pinned<c>()) && mobility_score > 0)
             mobility_score /= params_.pinned_scaling[bishop];
 
-        score += mobility_score;
+        ei.mobility[c] += mobility_score;
 
         // King distance
         score -= std::max(util::row_dist(s, ks), util::col_dist(s, ks)) *
@@ -693,7 +711,7 @@ template <Color c> int HCEEvaluator::eval_rooks(const position& p, einfo& ei) {
         if (sq_bb & p.pinned<c>())
             mobility_score /= params_.pinned_scaling[rook];
 
-        score += mobility_score;
+        ei.mobility[c] += mobility_score;
 
         // Trapped rook. Blended by phase for the same reason as the bishop
         // penalty above: index 1 of trapped_rook_penalty was reachable only in
@@ -817,7 +835,7 @@ template <Color c> int HCEEvaluator::eval_queens(const position& p, einfo& ei) {
             if (bitboards::squares[s] & p.pinned<c>())
                 mobility_score /= params_.pinned_scaling[queen];
 
-            score += mobility_score;
+            ei.mobility[c] += mobility_score;
         }
 
         // Weak queen penalty
@@ -866,8 +884,8 @@ template <Color c> int HCEEvaluator::eval_king(const position& p, einfo& ei) {
         // king logic -- KPK through the bitbase, KRK, KBNK -- do so by adding
         // to this score, and the endgame king table already wants the king
         // centralised, so there is nothing here to double count.
-        score += params_.sq_score_scaling[king] *
-                 square_score<c>(params_, king, s, ei.me->phase_interpolant);
+        ei.king_placement[c] += params_.sq_score_scaling[king] *
+                                square_score<c>(params_, king, s, ei.me->phase_interpolant);
 
         // Mobility
         U64 mvs = ei.kmask[c] & ei.empty;

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -190,8 +190,13 @@ std::vector<std::pair<std::string, int*>> parameters::all_params(TuneStage stage
             result.emplace_back("passed_pawn_blocked_penalty_" + std::to_string(i),
                                 &passed_pawn_blocked_penalty[i]);
 
-        // Attacker weights
-        for (size_t i = 0; i < attacker_weight.size(); ++i)
+        // Attacker weights. Index 0 is the pawn slot and is deliberately not
+        // registered: the king-danger sum in eval_king runs from knight to
+        // queen, so the entry is read by nothing and a tuner given it would
+        // spend two passes over the training set per iteration computing a
+        // gradient that is identically zero. The element itself stays so the
+        // array remains indexable by piece type.
+        for (size_t i = 1; i < attacker_weight.size(); ++i)
             result.emplace_back("attacker_weight_" + std::to_string(i), &attacker_weight[i]);
 
         // King shelter
@@ -240,8 +245,6 @@ std::vector<std::pair<std::string, int*>> parameters::all_params(TuneStage stage
 
         result.emplace_back("bishop_own_pawn_penalty_mg", &bishop_own_pawn_penalty_mg);
         result.emplace_back("bishop_own_pawn_penalty_eg", &bishop_own_pawn_penalty_eg);
-
-        result.emplace_back("uncastled_penalty", &uncastled_penalty);
 
         // King harassment tables, the threat tables and the piece-pair combo
         // matrix. All of these were static constexpr until now, which put the

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ set(HAVOC_TEST_SOURCES
     test_perft.cpp
     test_position.cpp
     test_eval.cpp
+    test_eval_discrimination.cpp
     test_search.cpp
 )
 

--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -1611,3 +1611,131 @@ TEST_F(EvalTest, EvaluationDoesNotDependOnWhatWasEvaluatedBefore) {
             << "evaluation of " << b_fen << " changed after evaluating " << a_fen;
     }
 }
+
+// ─── Category scales control one thing each ────────────────────────────────
+
+// The category scales exist so that a tuner, or a human, can ask "how much is
+// mobility worth relative to everything else" and get an answer. That only
+// works if each scale multiplies one coherent group of terms and no term is
+// multiplied by two of them.
+//
+// Three terms used to sit in the wrong group. Mobility was scaled by
+// mobility_category_scale inside each piece function and then by
+// sq_score_category_scale again with the rest of the piece total, so the two
+// scales compounded: their product was determined but neither factor was, and
+// coordinate descent could slide along that flat direction forever without the
+// error moving. The king piece-square table sat inside the king total and was
+// therefore scaled by king_safety_category_scale, so tuning king *safety*
+// silently retuned king *activity*. And a pawn attacking the enemy king ring
+// was collected in the pawn term, so king pressure was scaled by the weak-pawn
+// factor.
+//
+// All three were exact no-ops at the default scales of 100, which is why
+// nothing caught them: integer (x * 100) / 100 is x. They only showed up once
+// a scale moved off 100 -- which is precisely what tuning does.
+
+namespace {
+/// Evaluates `fen` with two category scales set to the given percentages.
+int eval_with_scales(const char* fen, int sq_scale, int mobility_scale) {
+    havoc::parameters params;
+    params.sq_score_category_scale = sq_scale;
+    params.mobility_category_scale = mobility_scale;
+    params.mobility_endgame_scale = mobility_scale;
+    havoc::pawn_table pt(params);
+    havoc::material_table mt(params);
+    havoc::HCEEvaluator eval(pt, mt, params);
+    auto pos = make_pos(fen);
+    return eval.evaluate(pos);
+}
+} // namespace
+
+TEST_F(EvalTest, MobilityAndPieceSquareScalesAreIndependent) {
+    // An open middlegame, so both buckets are large enough that a compounded
+    // product would be obvious rather than lost in integer rounding.
+    const char* fen = "r2q1rk1/pp2bppp/2n1bn2/2pp4/3P4/2P1PN2/PP1NBPPP/R1BQ1RK1 w - - 0 1";
+
+    const int base = eval_with_scales(fen, 100, 100);
+    const int sq_up = eval_with_scales(fen, 200, 100);
+    const int mob_up = eval_with_scales(fen, 100, 200);
+    const int both_up = eval_with_scales(fen, 200, 200);
+
+    // Additive separability. If mobility were multiplied by both scales, the
+    // effect of raising the mobility scale would itself depend on the
+    // piece-square scale and these two differences would diverge.
+    EXPECT_EQ(both_up - sq_up, mob_up - base)
+        << "raising sq_score_category_scale changed what mobility_category_scale "
+           "is worth, so the two scales are multiplying the same term";
+
+    // Guard against the degenerate way to pass the above: if either scale had
+    // no effect at all the equality would hold trivially.
+    EXPECT_NE(sq_up, base) << "sq_score_category_scale does nothing";
+    EXPECT_NE(mob_up, base) << "mobility_category_scale does nothing";
+}
+
+TEST_F(EvalTest, KingPlacementIsNotScaledByKingSafety) {
+    // King safety switched off entirely. King *activity* is a different idea
+    // and must still be evaluated: otherwise a tuner that decides king safety
+    // is overrated takes king centralisation down with it, in exactly the
+    // endings where centralisation is most of what matters.
+    //
+    // The probe scales the king piece-square table itself rather than reading
+    // a score directly. Two positions differ only in where white's king
+    // stands; black's king is on the same square in both, so its share of the
+    // table cancels in the difference and what is left is white's king
+    // placement alone. Multiplying the table must therefore move that
+    // difference. If the table is being multiplied by king_safety_category_scale
+    // -- which is zero here -- the difference cannot move at all.
+    auto placement_gap = [](int pst_multiplier) {
+        havoc::parameters params;
+        params.king_safety_category_scale = 0;
+        for (auto& v : params.pst_mg[havoc::king])
+            v *= pst_multiplier;
+        for (auto& v : params.pst_eg[havoc::king])
+            v *= pst_multiplier;
+
+        havoc::pawn_table pt(params);
+        havoc::material_table mt(params);
+        havoc::HCEEvaluator eval(pt, mt, params);
+
+        auto central = make_pos("6k1/5ppp/8/3K4/8/8/5PPP/7R w - - 0 1");
+        auto corner = make_pos("6k1/5ppp/8/8/8/8/5PPP/K6R w - - 0 1");
+        return eval.evaluate(central) - eval.evaluate(corner);
+    };
+
+    const int single = placement_gap(1);
+    const int tripled = placement_gap(3);
+
+    EXPECT_NE(tripled, single)
+        << "with king_safety_category_scale at 0 the king piece-square table "
+           "stopped being read, so king safety and king activity are still the "
+           "same knob";
+    EXPECT_GT(single, 0) << "a centralised king in an ending must beat a cornered one";
+    EXPECT_GT(tripled, single) << "scaling up the king table must widen the gap, not shrink it";
+}
+
+TEST_F(EvalTest, PawnKingPressureIsNotScaledByPawnStructure) {
+    // A pawn bearing on the enemy king ring is king pressure, not a statement
+    // about pawn structure, but it is collected inside the pawn term and so
+    // used to be multiplied by pawn_structure_category_scale -- the weak-pawn
+    // knob. Turning that knob to zero, which a tuner is free to do, deleted
+    // part of the king attack.
+    auto pressure = [](int pawn_scale, int king_ring_weight) {
+        havoc::parameters params;
+        params.pawn_structure_category_scale = pawn_scale;
+        for (auto& v : params.pawn_king)
+            v = king_ring_weight;
+
+        havoc::pawn_table pt(params);
+        havoc::material_table mt(params);
+        havoc::HCEEvaluator eval(pt, mt, params);
+
+        // White pawns on f6 and g7 both cover squares of black's king ring.
+        auto pos = make_pos("r5k1/pp4P1/5P2/7Q/8/8/PP6/R5K1 w - - 0 1");
+        return eval.evaluate(pos);
+    };
+
+    EXPECT_NE(pressure(0, 40), pressure(0, 0))
+        << "with pawn_structure_category_scale at 0 the pawn king-ring weight "
+           "stopped being read, so attacking the king is still priced by the "
+           "weak-pawn scale";
+}

--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -777,13 +777,13 @@ TEST_F(EvalTest, OppositeColorBishops_NotScaledWithPiecesOnBoard) {
 
 TEST_F(EvalTest, ParameterSaveLoad) {
     havoc::parameters p;
-    p.uncastled_penalty = 42;
+    p.king_open_file_penalty = 42;
     p.opposite_bishop_scale = 77;
     p.save("/tmp/havoc_test_params.txt");
 
     havoc::parameters p2;
     p2.load("/tmp/havoc_test_params.txt");
-    EXPECT_EQ(p2.uncastled_penalty, 42);
+    EXPECT_EQ(p2.king_open_file_penalty, 42);
     EXPECT_EQ(p2.opposite_bishop_scale, 77);
 
     std::remove("/tmp/havoc_test_params.txt");
@@ -1462,12 +1462,6 @@ TEST_F(EvalTest, EveryTunableParameterReachesTheEvaluation) {
         // (b) inert by design: pawns are valued by the pawn hash, and a king
         // is never exchanged, so neither value can move an evaluation
         "material_value_0", "material_value_5",
-        // (b) genuinely dead: declared, tuned and saved, but read by nothing.
-        // attacker_weight_0 is the pawn entry of the king-danger sum, whose
-        // loop starts at knight. uncastled_penalty is a feature that was never
-        // implemented -- eval_king has a hard-coded castling bonus with no
-        // matching penalty.
-        "attacker_weight_0", "uncastled_penalty",
     };
 
     std::vector<std::string> unexpected;

--- a/tests/test_eval_discrimination.cpp
+++ b/tests/test_eval_discrimination.cpp
@@ -1,0 +1,201 @@
+/// @file test_eval_discrimination.cpp
+/// @brief Paired quiet positions of equal material that the evaluation must
+///        rank correctly.
+///
+/// Why this file exists
+/// --------------------
+/// The evaluation already has two measurements pointed at it, and neither one
+/// measures the thing that actually chooses moves.
+///
+/// Texel tuning measures *global* calibration: given a static position, how
+/// well does the evaluation predict the eventual game result? That quantity is
+/// dominated by material, and a fit can improve it substantially by doing
+/// nothing more than repricing the pieces. A recent refit cut held-out error
+/// by 7.6% relative, and the single largest change it made was the queen, from
+/// 910 to 1078.
+///
+/// An SPRT measures strength, which is the truth, but it costs tens of
+/// thousands of games to resolve a few Elo and says nothing about *which* term
+/// is wrong when it comes back negative.
+///
+/// Between those sits the property that decides moves: the ability to rank two
+/// positions that are one ply apart and therefore almost always have identical
+/// material. Repricing a queen contributes exactly nothing there. Nothing in
+/// the test suite covered it, so an evaluation could lose that ability
+/// entirely -- to a mis-signed term, a term scaled to irrelevance, or a term
+/// that was never written -- while every existing test stayed green.
+///
+/// Each case below is a pair of legal, quiet positions with the *same material
+/// on both sides*, differing in one positional feature that chess theory has a
+/// settled opinion about. Material cancels by construction, so the assertion is
+/// a direct statement about positional understanding.
+///
+/// A failure here is not a tuning problem. It means the feature is either
+/// absent from the evaluation, mis-signed, or outweighed by something that
+/// should not dominate it -- none of which a weight tuner can discover, since
+/// several of these features barely occur in a quiet-filtered training set.
+///
+/// One trap when adding cases: sparse material draws the position into a
+/// specialised endgame evaluator (KRK, KPK, KBNK and friends, hce.cpp), which
+/// returns a mate-driving score and ignores the general term under test. The
+/// first draft of the rook-on-the-seventh pair was bare KRK and both sides
+/// evaluated to exactly the same number for that reason. Keep enough pawns on
+/// the board that the ordinary evaluation actually runs.
+
+#include "havoc/bitboard.hpp"
+#include "havoc/eval/hce.hpp"
+#include "havoc/kpk.hpp"
+#include "havoc/magics.hpp"
+#include "havoc/material_table.hpp"
+#include "havoc/parameters.hpp"
+#include "havoc/pawn_table.hpp"
+#include "havoc/position.hpp"
+#include "havoc/zobrist.hpp"
+
+#include <gtest/gtest.h>
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+havoc::position make_pos(const std::string& fen) {
+    std::istringstream iss(fen);
+    return havoc::position(iss);
+}
+
+/// One discrimination case.
+///
+/// `better` and `worse` must have identical material for both colours and the
+/// same side to move, so that the difference in score is attributable to the
+/// named feature alone.
+struct Pair {
+    const char* feature;
+    const char* better;
+    const char* worse;
+    const char* rationale;
+};
+
+const std::vector<Pair> kPairs = {
+    {"connected pawns beat isolated pawns",
+     "4k3/8/8/8/8/8/PP6/4K3 w - - 0 1",
+     "4k3/8/8/8/8/8/P1P5/4K3 w - - 0 1",
+     "a2+b2 defend each other; a2+c2 are both isolated and need pieces to hold them"},
+
+    {"healthy pawns beat doubled pawns",
+     "4k3/8/8/8/8/8/PP6/4K3 w - - 0 1",
+     "4k3/8/8/8/P7/8/P7/4K3 w - - 0 1",
+     "doubled a-pawns cover fewer files and cannot defend one another"},
+
+    {"a passed pawn beats a blocked pawn",
+     "4k3/p7/8/4P3/8/8/8/4K3 w - - 0 1",
+     "4k3/8/4p3/4P3/8/8/8/4K3 w - - 0 1",
+     "e5 with no black pawn ahead is passed; e5 facing e6 is permanently blocked"},
+
+    {"a rook prefers an open file",
+     "4k3/8/8/8/8/8/PP6/3RK3 w - - 0 1",
+     "4k3/8/8/8/8/8/3PP3/3RK3 w - - 0 1",
+     "the d-rook is unobstructed in the first, staring at its own d2 pawn in the second"},
+
+    {"a castled king beats a king in the centre",
+     "4k2r/5ppp/8/8/8/8/5PPP/5RK1 w k - 0 1",
+     "4k2r/5ppp/8/8/8/8/5PPP/4KR2 w k - 0 1",
+     "same pieces; g1 sits behind an intact f2-g2-h2 shelter, e1 does not"},
+
+    {"a knight prefers an advanced supported outpost",
+     "4k3/pp6/8/3N4/4P3/8/8/4K3 w - - 0 1",
+     "4k3/pp6/8/8/4P3/3N4/8/4K3 w - - 0 1",
+     "d5 is supported by e4 and cannot be driven off by a pawn; d3 is passive"},
+
+    {"a rook prefers the seventh rank",
+     "4k3/3R1ppp/8/8/8/8/5PPP/4K3 w - - 0 1",
+     "4k3/5ppp/8/8/8/8/3R1PPP/4K3 w - - 0 1",
+     "d7 rakes the seventh rank and ties black to f7; d2 is passive"},
+
+    {"an endgame king prefers the centre",
+     "7k/8/8/3K4/8/8/8/R6r w - - 0 1",
+     "7k/8/8/8/8/8/K7/R6r w - - 0 1",
+     "with queens off, a centralised king is worth roughly a third of a pawn"},
+
+    {"an intact shelter beats an advanced one",
+     "6k1/5ppp/8/8/8/8/5PPP/6K1 w - - 0 1",
+     "6k1/5ppp/8/8/5P1P/8/6P1/6K1 w - - 0 1",
+     "f4/h4 have left holes on g3 and the third rank in front of the king"},
+
+    {"a bishop prefers pawns on the opposite colour",
+     "4k3/pp6/8/8/3P4/4P3/8/4KB2 w - - 0 1",
+     "4k3/pp6/8/8/4P3/3P4/8/4KB2 w - - 0 1",
+     "the f1 bishop is light-squared; d4/e3 are dark, while e4/d3 block it"},
+
+    {"a rook belongs behind its own passed pawn",
+     "5k2/8/8/4P3/8/8/8/4RK2 w - - 0 1",
+     "5k2/8/4R3/4P3/8/8/8/5K2 w - - 0 1",
+     "the rook supports the advance from behind instead of blocking it"},
+
+    {"a protected passer beats a lone passer",
+     "4k3/8/8/3PP3/8/8/8/4K3 w - - 0 1",
+     "4k3/8/8/4P3/8/3P4/8/4K3 w - - 0 1",
+     "d5 and e5 defend each other as they advance; d3 and e5 are split"},
+};
+
+class EvalDiscriminationTest : public ::testing::Test {
+  protected:
+    static void SetUpTestSuite() {
+        havoc::bitboards::init();
+        havoc::magics::init();
+        havoc::zobrist::init();
+        havoc::kpk::init();
+    }
+
+    /// Assert that both sides really do have identical material, so that a
+    /// score difference cannot be explained by the piece values. A case that
+    /// fails this check is a broken test, not a broken evaluation.
+    static void require_equal_material(const havoc::position& a,
+                                       const havoc::position& b,
+                                       const std::string& feature) {
+        for (int c = 0; c < 2; ++c)
+            for (int pc = 0; pc < havoc::pieces; ++pc)
+                ASSERT_EQ(a.number_of(havoc::Color(c), havoc::Piece(pc)),
+                          b.number_of(havoc::Color(c), havoc::Piece(pc)))
+                    << feature << ": the two positions do not have the same material, "
+                    << "so this case cannot isolate the feature";
+    }
+};
+
+TEST_F(EvalDiscriminationTest, RanksEqualMaterialPositionsByPositionalMerit) {
+    havoc::parameters params;
+    havoc::pawn_table pt(params);
+    havoc::material_table mt(params);
+    havoc::HCEEvaluator eval(pt, mt, params);
+
+    std::vector<std::string> failures;
+
+    for (const auto& c : kPairs) {
+        auto better = make_pos(c.better);
+        auto worse = make_pos(c.worse);
+        require_equal_material(better, worse, c.feature);
+
+        const int sb = eval.evaluate(better);
+        const int sw = eval.evaluate(worse);
+
+        if (sb <= sw) {
+            failures.push_back(std::string(c.feature) + "\n      better " + c.better +
+                               " -> " + std::to_string(sb) + "\n      worse  " + c.worse +
+                               " -> " + std::to_string(sw) +
+                               "\n      margin " + std::to_string(sb - sw) +
+                               "\n      why: " + c.rationale);
+        }
+    }
+
+    if (!failures.empty()) {
+        std::string msg = std::to_string(failures.size()) + " of " +
+                          std::to_string(kPairs.size()) +
+                          " equal-material pairs are ranked wrongly:\n";
+        for (const auto& f : failures)
+            msg += "\n  - " + f + "\n";
+        FAIL() << msg;
+    }
+}
+
+} // namespace


### PR DESCRIPTION
Three commits, in increasing order of consequence. None of them changes what the engine plays today: bench is 754857 nodes at every step, identical to `main`.

## 1. Rank equal-material quiet positions by positional merit

Neither instrument pointed at the evaluation measures the property that actually chooses moves.

Texel tuning measures global calibration against game results, which is dominated by material. The most recent refit cut held-out error by 7.6% relative and its single largest change was repricing the queen from 910 to 1078. An SPRT measures strength but costs tens of thousands of games and names no term when it comes back negative.

The property that decides a move is the ability to rank two positions one ply apart, which almost always have identical material. Repricing a queen contributes nothing there, so an evaluation could lose that ability entirely -- to a mis-signed term, a term scaled into irrelevance, or a term never written -- with every existing test still green.

Twelve pairs of legal quiet positions, identical material on both sides, differing in one feature chess theory has a settled opinion about: connected against isolated pawns, doubled pawns, a blockaded passer, a rook on an open file, a castled against a centralised king, a knight outpost, a rook on the seventh, endgame king centralisation, an intact shelter, a good against a bad bishop, a rook behind its own passer, a protected passer. Material is asserted equal per pair, so a construction mistake fails loudly rather than passing for the wrong reason.

All twelve pass, so this is a guard rather than a bug report. It exists to make the coming evaluation restructuring falsifiable.

Building it surfaced one methodological trap worth recording. The rook-on-the-seventh pair was originally bare KRK and both sides evaluated to exactly the same number -- not because the term is missing, but because sparse material diverts the position into the specialised KRK evaluator, which returns a mate-driving score and never consults the general term.

## 2. Stop tuning two parameters the evaluation never reads

`EveryTunableParameterReachesTheEvaluation` had been naming both in its exemption list under "genuinely dead: declared, tuned and saved, but read by nothing". The list documented them rather than fixing them.

`uncastled_penalty` appears in no evaluation expression anywhere in `src/`. The state it needs -- whether a king reached its square by castling -- was removed deliberately, because it made the score depend on how a position was arrived at rather than on the position. King placement is already priced by the king piece-square table, which charges a centre king without needing any history.

`attacker_weight[0]` is the pawn slot of the king-danger sum, and that loop runs from knight to queen. The array element stays, because the table is indexed by piece type and shifting it would silently reassign every other weight; only the registration starts at 1, matching the convention already used for the king harassment tables below it.

The cost was not hypothetical: coordinate descent evaluates every registered parameter in both directions on every sweep, so each dead entry buys two full passes over the training set per sweep for a difference that is identically zero, then writes a number into the fitted file that reads as a tuned value.

## 3. Give each category scale one thing to control

The most consequential of the three. Three terms were being scaled by a factor that does not describe them.

**Mobility was multiplied twice.** Once by `mobility_category_scale` inside every piece function, then again by `sq_score_category_scale` as part of the piece total. Only the product was determined; the individual factors were not. Coordinate descent can slide along that flat direction indefinitely, trading one scale against the other while the error never moves.

**The king piece-square table was scaled by `king_safety_category_scale`.** King placement is activity, not danger, so deciding king safety was overrated took king centralisation down with it -- in endings, where centralisation is most of what matters.

**A pawn attacking the enemy king ring was scaled by `pawn_structure_category_scale`,** the weak-pawn knob. Turning that to zero deleted part of the king attack.

Each now accumulates separately and is folded in under the scale that describes it. Mobility is added unscaled, since it already carries its own scale and endgame taper.

All three were exact no-ops at the shipped defaults -- every category scale defaults to 100, and integer `(x * 100) / 100` is `x` -- which is why nothing caught them. They bite once a scale leaves 100, which is what tuning does: the last fit moved `sq_score_category_scale` to 108 and an earlier one to 66.

### Verification

Three tests added, each confirmed to fail against the previous code and pass against this one. The mobility test asserts additive separability: raising `sq_score_category_scale` must not change what `mobility_category_scale` is worth. Before, the two differences were -94 and -47 -- a factor of two, the compounding stated exactly. It also asserts neither scale is inert, so it cannot pass by the terms having been deleted.

133 tests pass. Bench unchanged at 754857 nodes.
