### PR TITLE
eval: give the king shelter term enough resolution to be worth having

### DIFF
--- a/docs/revisit-after-tuning.md
+++ b/docs/revisit-after-tuning.md
@@ -658,3 +658,44 @@ Note also what the corpus rules are for. The first draft of the half-open file
 pair deleted the f2 pawn to open the file, leaving the sides a pawn apart and
 producing a 138cp margin that was entirely material. Equal material is checked
 mechanically by the regression test for exactly this reason.
+
+### King shelter: shape fixed, magnitude unresolved
+
+`king_shelter` indexed a four-entry table with a *count* of friendly pawns on
+the eight squares touching the king. It could express four states, the whole
+gap between a perfect shield and a broken one was one step of that table, and
+h3 and h4 were identical because neither touches the king. It is now indexed by
+the distance of the nearest friendly pawn in front of the king, per file,
+summed over three files.
+
+| | count model | distance model |
+|---|---|---|
+| pawn shield pair margin | 4cp | 9cp |
+| carried by | pawn structure | `king_shelter`, 11cp / 122% |
+| pairs decisive | 15/16 | 16/16 |
+| bench nodes | 953544 | 697583 |
+| SPRT vs previous | - | -11.9 +/- 31.8 over 334 games |
+
+The node result is the interesting one and was not predicted: a shelter that
+moves by 11cp between adjacent king positions gives the search something stable
+to prune against, where four discrete 6cp steps did not. It returns 27%, more
+than the coherent reset spent.
+
+The magnitude is unresolved and should not be hand-tuned further. Summing over
+three files triples the range as a side effect of changing the shape: +21/-45
+against the count model's +6/-22. Halving to {-8,4,1,-2} was tried and puts the
+pawn shield pair back to a 4cp margin that `king_shelter` no longer carries,
+with bench back up to 790209. Discrimination and nodes both track the range, so
+the two effects cannot be separated by halving, and the wider range is the one
+the SPRT actually measured. This is an SPSA problem.
+
+### A correction to earlier attribution figures
+
+`eval_bench` originally ranked individual parameters. A table like
+`king_shelter` is one idea spread over several entries, and a pair can move two
+of them in opposite directions -- +7 on the near slot, -4 on the far one -- so
+no element beats an unrelated scalar even when the family plainly decided the
+pair. It now aggregates by family before ranking, which took corpus-wide
+correct attribution from 7/14 to 9/14. Attribution claims made before this
+change understate table-valued families, including the claim above that king
+safety did not carry its own pairs.

--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -182,7 +182,15 @@ struct parameters {
     /// -3 and -2 both became -1, so two distinct parameter values produced an
     /// identical evaluation and the tuner had no gradient between them. The
     /// halving is gone and these are the values it produced.
-    std::vector<int> king_shelter{-22, -10, 0, 6}; // 0,1,2,3 pawns
+    // Indexed by the distance of the nearest friendly pawn in front of the
+    // king on a given file, summed over the king file and its two neighbours.
+    // Index 0 means no pawn in front at all, 1 means the pawn is unmoved
+    // beside the king, 3 means three ranks away or further.
+    //
+    // The previous model indexed by a *count* of pawns touching the king,
+    // which could express four states in total and could not tell h3 from h4.
+    // A perfect shield now scores 3*7 = 21 and a bare king -45.
+    std::vector<int> king_shelter{-15, 7, 1, -4}; // distance 0(none),1,2,3+
     /// Charged when the king's flank holds no friendly pawn at all.
     int pawnless_flank_penalty = 12;
     /// Charged by the number of enemy pawns bearing down on the king's side of

--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -189,7 +189,15 @@ struct parameters {
     //
     // The previous model indexed by a *count* of pawns touching the king,
     // which could express four states in total and could not tell h3 from h4.
-    // A perfect shield now scores 3*7 = 21 and a bare king -45.
+    // Summing over three files multiplies the range by three, which is easy to
+    // miss: these values give +21 for a perfect shield and -45 for a bare king,
+    // against the old count model's +6 and -22. Halving them to {-8,4,1,-2}
+    // restores the old range and was tried -- it puts the pawn shield pair back
+    // to a 4cp margin that king_shelter no longer carries, and bench back to
+    // 790209 from 697583. So the discrimination and the node win both come from
+    // the range, not from the shape alone, and the two cannot be separated by
+    // halving. Left at the wider range, which is the variant that was actually
+    // measured: -11.9 +/- 31.8 over 334 games. Needs SPSA, not more hand values.
     std::vector<int> king_shelter{-15, 7, 1, -4}; // distance 0(none),1,2,3+
     /// Charged when the king's flank holds no friendly pawn at all.
     int pawnless_flank_penalty = 12;

--- a/src/eval/hce.cpp
+++ b/src/eval/hce.cpp
@@ -1007,9 +1007,39 @@ template <Color c> int HCEEvaluator::eval_king(const position& p, einfo& ei) {
             // square does not belong in it: castling leaves the pawns
             // untouched, hits the same entry, and would score the shelter
             // against wherever the king stood when that entry was filled.
-            U64 pawn_shelter = p.get_pieces<c, pawn>() & ei.kmask[c];
-            int n = std::min(3, bits::count(pawn_shelter));
-            int shelter = params_.king_shelter[n];
+            // Measured per file by how far the nearest friendly pawn stands
+            // in front of the king, summed over the king's file and its two
+            // neighbours.
+            //
+            // The previous model counted how many pawns occupied the eight
+            // squares touching the king and indexed a four-entry table with
+            // that count. It could express only four states, and the whole
+            // difference between a perfect shield and a broken one was one
+            // step of that table. Pushing the h-pawn from h2 to h4 in front of
+            // a castled king moved the count from 3 to 2 and was worth 6cp
+            // before phase scaling -- and h3 and h4 were indistinguishable,
+            // since neither touches the king. eval_bench measured the whole
+            // pair at 4cp and attributed it to pawn structure rather than to
+            // king safety.
+            //
+            // Distance indexing gives the term the resolution to say that an
+            // unmoved pawn shields better than an advanced one, which is the
+            // distinction the shelter is there to make.
+            const U64 shelter_pawns = p.get_pieces<c, pawn>();
+            const int krow = util::row(s);
+            const int kcol0 = util::col(s);
+            int shelter = 0;
+            for (int f = std::max(0, kcol0 - 1); f <= std::min(7, kcol0 + 1); ++f) {
+                U64 bb = shelter_pawns & bitboards::col[f];
+                int nearest = 0; // 0 == no pawn in front of the king
+                while (bb) {
+                    const Square ps = Square(bits::pop_lsb(bb));
+                    const int d = (c == white) ? (util::row(ps) - krow) : (krow - util::row(ps));
+                    if (d > 0 && (nearest == 0 || d < nearest))
+                        nearest = d;
+                }
+                shelter += params_.king_shelter[std::min(3, nearest)];
+            }
 
             // Pawnless flank penalty
             U64 kflank = bitboards::kflanks[util::col(s)] & p.get_pieces<c, pawn>();

--- a/tools/eval_bench.cpp
+++ b/tools/eval_bench.cpp
@@ -361,10 +361,23 @@ int main(int argc, char** argv) {
                 contribs.push_back({name, d});
         }
 
-        std::sort(contribs.begin(), contribs.end(),
+        // Aggregate by family before ranking. A table like king_shelter is one
+        // idea spread over several entries, and a pair can move two of those
+        // entries in opposite directions -- +7 on the near slot, -4 on the far
+        // one -- so no single element beats an unrelated scalar even when the
+        // family as a whole is what decided the pair. Ranking parameters alone
+        // reports that as "king safety did not carry this", which is false.
+        std::map<std::string, double> by_family;
+        for (const auto& c2 : contribs)
+            by_family[family_of(c2.name)] += c2.delta;
+        std::vector<Contribution> fams;
+        for (auto& [k, v] : by_family)
+            fams.push_back({k, v});
+        std::sort(fams.begin(), fams.end(),
                   [](const Contribution& a, const Contribution& b) {
                       return std::abs(a.delta) > std::abs(b.delta);
                   });
+        contribs = fams;
 
         const double denom = r.margin != 0 ? std::abs(static_cast<double>(r.margin)) : 1.0;
         if (!contribs.empty())


### PR DESCRIPTION
king_shelter indexed a four-entry table with a *count* of pawns touching the king. It could express four states, the whole gap between a perfect shield and a broken one was one step, and h3/h4 were identical since neither touches the king. Now indexed by distance of the nearest friendly pawn in front of the king, per file, summed over three files.

| | count | distance |
|---|---|---|
| shield pair margin | 4cp | 9cp |
| carried by | pawn structure | king_shelter, 11cp/122% |
| decisive pairs | 15/16 | 16/16 |
| bench | 953544 | 697583 |
| SPRT | - | -11.9 +/- 31.8, 334 games |

The 27% node win was not predicted and is larger than the coherent reset spent. The SPRT is inconclusive and straddles zero; merged as a structural change under the standing policy and flagged for SPSA. Halving the values to restore the old range was tried and loses both the discrimination and the node win, so the two cannot be separated by hand.

Also fixes eval_bench to aggregate attribution by family before ranking -- it was ranking individual parameters, so a table moving +7 on one slot and -4 on another lost to an unrelated scalar and was reported as not carrying its own pair. Corpus-wide attribution 7/14 -> 9/14, and this corrects earlier claims in the docs.

133 tests pass.