### PR TITLE
docs: write down where this goes next, and what not to retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,9 +234,13 @@ Windows: [ci.yml](https://github.com/mjglatzmaier/haVoc/actions/workflows/ci.yml
 
 Being honest about where things stand:
 
-- The evaluation terms are largely hand-set. Texel tuning infrastructure exists
-  but has not produced a well-tuned parameter set yet. This is the weakest part
-  of the engine by a wide margin.
+- The evaluation terms are largely hand-set. Texel tuning infrastructure exists,
+  and has been shown *not* to be the answer: a parameter's gradient is
+  independent of its current value, so the fit is unmoved by better starting
+  points, and the error is dominated by material while the quiet filter discards
+  the positions where tactical terms fire. The fit it converges to measured
+  +1.4 ± 19.9 Elo over 781 games. Use it for material and piece-square tables
+  only — see [`docs/roadmap.md`](docs/roadmap.md).
 - The search is capped at 64 plies (`MAX_PLY`). Search and quiescence now stop
   cleanly at that bound rather than running past the end of the search stack,
   but the cap itself is low: a ten-second search already reaches ply 29, and a
@@ -251,13 +255,14 @@ Being honest about where things stand:
   different plies. This looks wrong and was measured: removing it costs about
   20% more nodes, so it stays until something better replaces it.
 - Syzygy tablebase probing and Polyglot opening books are stubs.
-- No rating against a rated opponent has been established. Strength has only
-  ever been measured as a self-play difference against previous versions of
-  haVoc, which says nothing about where the engine sits on any public list.
+- Search is not saturated: 29% of positions change their preferred move at depth
+  8 and 12% are still changing at depth 12, so nodes remain genuinely valuable
+  and the search margins are the most promising thing left to tune.
 
-Possible future work, in rough order of interest: retuning the depth-indexed
-search constants, finishing evaluation tuning, replacing the hand-written
-evaluation with a learned one, Syzygy probing, and Chess960 support.
+Possible future work, in rough order of interest: SPSA over the search margins,
+move ordering, replacing the hand-written evaluation with a learned one, Syzygy
+probing, and Chess960 support. [`docs/roadmap.md`](docs/roadmap.md) has the
+reasoning, the negative results, and the things not to retry.
 
 ## License
 

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,0 +1,104 @@
+# Picking this work up on another machine
+
+Everything needed to continue is in this repository. This page is the checklist.
+
+## Verify the handoff landed intact
+
+`bench` is deterministic and machine-independent: it fixes the search to a set
+of positions and counts nodes. The node count is therefore an exact checksum on
+"same code, same parameters, same build configuration". The *time* and *nps*
+will differ between machines; the node count must not.
+
+```sh
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DHAVOC_BUILD_TOOLS=ON
+cmake --build build -j
+printf 'bench\nquit\n' | ./build/havoc      # expect 697583 nodes
+./build/tests/havoc_tests                   # expect 133 passing
+```
+
+A different node count means a build difference, not a porting success. Track it
+down before measuring anything.
+
+## What does not travel
+
+- **cutechess-cli** — build or install it, then `export CUTECHESS=...`.
+- **Anchor engines** — see [`scripts/testing/README.md`](../scripts/testing/README.md).
+  They must be rebuilt; `gauntlet-anchors.sh` reports how many it found and
+  refuses to run with fewer than two.
+- **Baseline binaries** — the per-experiment snapshots used as SPRT baselines are
+  build artifacts. Rebuild any baseline you need from its commit, and confirm it
+  by bench node count.
+
+## Elo numbers are local to a machine, a time control and a book
+
+Ratings are not portable. The rows in the top-level README are comparable to
+each other because anchors, hardware, book and time control were held fixed; they
+are not comparable to a run on different hardware. On a new box, re-establish a
+baseline before comparing anything to a number measured elsewhere.
+
+Concurrency is the one setting worth tuning per machine. `common.sh` defaults to
+physical cores minus two. Oversubscribing does not bias a result when both
+engines are starved equally, but it inflates per-game variance, which costs
+games-to-decision.
+
+## Merge policy in force
+
+- **Structural** changes that measure neutral-to-slightly-negative may merge, and
+  are recorded in `revisit-after-tuning.md` for revisit after tuning. The
+  reasoning is that a correct-but-unoptimised structure is a prerequisite for
+  tuning to find anything.
+- **Pure parameter** changes must earn their keep with an SPRT. They have no
+  structural argument to fall back on.
+
+That policy has a failure mode, and it must be actively guarded. A change that
+measures −5 ± 25 is indistinguishable from neutral, so several can merge in a row
+while all being real, small regressions. Periodically SPRT current `main` against
+a snapshot 5–10 PRs back: the accumulated delta is larger than any individual
+one, so it resolves faster and in a single direction.
+
+## Where the effort should go
+
+Ordered by expected return. The reasoning behind each is in
+`revisit-after-tuning.md`; this is only the queue.
+
+1. **SPSA the search margins, using games as the objective.** The clearest
+   remaining headroom. Search is demonstrably not saturated (29% of positions
+   change their preferred move at depth 8, 12% still at depth 12), and bench node
+   count is proven unusable as a proxy — `rfp_margin` moves it non-monotonically
+   between 539k and 953k over a 50-point sweep. A screening gauntlet found no
+   margin candidate grossly wrong, with one weak but directionally consistent
+   hint that a larger `qs_delta_margin` helps.
+2. **SPSA the king shelter magnitude.** The shape was fixed by indexing on
+   distance per file rather than counting pawns near the king, which was worth
+   −27% bench nodes. But summing over three files tripled the dynamic range as a
+   side effect, and halving the values by hand loses both the discrimination and
+   the node win. It needs a search, not a guess.
+3. **Build a defensible dead-term list before trimming anything.** Use
+   `eval_bench --decisions` on **at least 10000 positions**. The fraction of
+   parameters that change no decision falls from 69% at 300 positions to 17% at
+   10000 and was still falling. Small samples manufacture dead parameters, and
+   they do it preferentially to rare-but-decisive knowledge.
+4. **Fix the mis-attributed discrimination pairs** — 5 of 14 are decided by
+   `sq_score_category_scale` or `pst_mg_king` rather than the term they were
+   written to test.
+
+## What not to spend time on
+
+Texel tuning cannot help this evaluation, and the reason is structural rather
+than a matter of setup. A parameter's gradient is independent of its current
+value, so resetting the defaults leaves the optimiser's landscape and its minimum
+exactly where they were: zeroing `bishop_king_distance_penalty` took its measured
+worth from 1.94 to 0.00 while its gradient moved 1.935 to 1.938. The fit it
+converges to measured +1.4 ± 19.9 Elo over 781 games. The error is dominated by
+material, and the quiet filter discards the positions where tactical terms fire.
+
+Use it for material and piece-square tables. Nothing else.
+
+## The larger question
+
+The coherent parameter reset — 59 values rewritten onto consistent scales, with
+double-counting removed — measured neutral, twice (+14.5 ± 26.9 at fixed time,
+−4.5 ± 25.8 at fixed depth). Sizeable, well-motivated changes to hand-crafted
+evaluation keep landing inside the noise. That is itself evidence about where the
+ceiling of this approach sits, and an argument for the NNUE work rather than
+against it.

--- a/docs/revisit-after-tuning.md
+++ b/docs/revisit-after-tuning.md
@@ -16,6 +16,11 @@ with real numbers instead of being forgotten.
 Each entry should say what to check and what would count as evidence to change
 course.
 
+> **New here?** Start with [`roadmap.md`](roadmap.md) for the state of play, what
+> has been tried, and where the remaining value is; and
+> [`handoff.md`](handoff.md) for setting up on a new machine. This file is the
+> underlying evidence log they both cite.
+
 ## Evaluation terms whose defaults are guesses
 
 | Term | Landed | What to check after tuning |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,245 @@
+# Roadmap
+
+Written for whoever — human or agent — picks this up next. It is a summary of
+the state of play, what has been tried, what to avoid, and where the remaining
+value is. The detailed evidence behind every claim is in
+[`revisit-after-tuning.md`](revisit-after-tuning.md); the practical setup steps
+are in [`handoff.md`](handoff.md).
+
+---
+
+## 1. Where the engine stands
+
+haVoc is a hand-crafted-evaluation (HCE) alpha-beta engine, currently around
+**2500 Elo** on the CCRL scale. `bench` is **697583 nodes** and there are **133
+passing tests**. Both are exact checksums — see `handoff.md`.
+
+The single most important finding of recent work:
+
+> Large, well-motivated changes to the hand-crafted evaluation keep measuring
+> inside the noise. The correctness work paid; the knowledge work has not.
+
+A coherent reset of 59 evaluation parameters onto consistent scales, removing
+double-counting and un-scaling knowledge that had been scaled away, measured
+**+14.5 ± 26.9** at fixed time and **−4.5 ± 25.8** at fixed depth. That is a
+genuinely neutral result for a change that should have been worth something if
+the evaluation were the binding constraint.
+
+Take this as evidence about where effort belongs, not as a counsel of despair.
+It argues for search work and for the NNUE/attention track, and against further
+rounds of HCE parameter polish.
+
+---
+
+## 2. Non-negotiables when measuring
+
+Most wasted effort in this project has come from trusting a measurement that
+could not support the conclusion drawn from it. In rough order of how much time
+each one cost:
+
+**Do not read the Elo column of cutechess's gauntlet ranking table.** It is
+normalised across the pool, and in a gauntlet the anchors never play each other,
+so its gaps are not pairwise-consistent. Subtracting them once turned a genuine
+203-point head-to-head gap into a reported 420 and made a ~2500 engine look like
+~2300. Use `scripts/testing/anchor_rating.py`, which works from raw results.
+
+**Do not use bench node count as an optimisation target.** It is deterministic,
+which makes it look like a clean objective, but it responds chaotically to search
+parameters: sweeping `rfp_margin` gives 539240 at 70, 953544 at 80 and 826577 at
+90. That is real search instability, not noise. Bench is a checksum, not a fitness
+function.
+
+**Do not declare an evaluation term dead on a small sample.** The fraction of
+parameters that change no move decision falls from **69% at 300 positions to 42%
+at 2000 and 17% at 10000**, and was still falling. Thin sampling manufactures
+dead parameters, and it does so preferentially for rare-but-decisive knowledge.
+Use at least 10000 positions.
+
+**Attribute by family, not by individual parameter.** A table that moves +7 on
+one entry and −4 on another nets out and loses to an unrelated scalar. Adding
+family aggregation to `eval_bench` moved corpus attribution from 7/14 to 9/14 and
+reversed a conclusion about king safety.
+
+**Self-play overstates field Elo.** A change measured against the engine's own
+previous revision routinely fails to appear against outside opponents. One batch
+measured +52 in self-play and did not show up in the gauntlet at all.
+
+**A single SPRT cannot catch accumulated drift.** Changes measuring −5 ± 25 merge
+as neutral under policy; several in a row can be real regressions. Periodically
+SPRT `main` against a snapshot 5–10 PRs back.
+
+---
+
+## 3. What has been tried
+
+### Worked
+
+- **Correctness fixes.** Zobrist and material key desync, phase interpolation,
+  aspiration window handling, TT bugs. This is where the measurable Elo came
+  from, and it is the reason the roadmap starts with correctness.
+- **King shelter re-indexing.** It was indexed by a *count* of pawns in the eight
+  squares around the king, giving four expressible states, one 6cp step between
+  perfect and broken, and no way to tell h3 from h4. Re-indexed by distance per
+  file over the king file and its neighbours. Worth **−27% bench nodes**, an
+  unpredicted and large win. The magnitude is still unresolved (see below).
+- **Building instruments instead of arguing.** `eval_sensitivity` (what is a term
+  worth), `eval_bench` (does the evaluation discriminate, and why), and
+  `--decisions` (what actually changes a move) each settled questions that had
+  been circular. When stuck, the fastest route has consistently been to build the
+  measurement rather than reason harder.
+
+### Did not work
+
+- **Texel tuning.** Covered in section 5 — do not retry it.
+- **Piecemeal margin raises.** Individually plausible, measured −85, −37, −22 and
+  −12.6 Elo. The margins are coupled; they must be moved together by a search.
+- **TT prefetch.** Node-identical and measurably faster, yet **−14 Elo**. Unexplained
+  and worth understanding before any similar micro-optimisation is trusted.
+- **Hand-halving the shelter values.** Restores the old dynamic range but loses
+  both the discrimination (9cp → 4cp) and the node win (697583 → 790209). The
+  effects cannot be separated by hand.
+- **Obscure engines as rating anchors.** GopherCheck and Rusty-Rival implied 2284
+  and 2507 for the same candidate. Sungorus 1.4 implied 2192 where Fruit and
+  Glaurung implied 2429 and 2397 in the same run, despite 1583 CCRL games behind
+  its rating.
+
+---
+
+## 4. Paths forward
+
+Ordered by expected return per unit of compute.
+
+### 4.1 SPSA the search margins, with games as the objective
+
+The clearest remaining headroom. Search is demonstrably **not saturated**: 29% of
+positions change their preferred move at depth 8, 22% at depths 10 and 11, 12%
+still at depth 12, and the median settle depth is 9. Nodes are therefore
+genuinely valuable, and the margins decide how they are spent.
+
+Bench is unusable as the objective (section 2), so this has to be games, which is
+why it wants a bigger machine. A screening gauntlet over `rfp_margin` 60/100,
+`fp_margin` 70/110 and `qs_delta_margin` 750/1050 found nothing grossly wrong,
+with one weak but directionally consistent hint: `qs_delta_margin` 1050 measured
++46 and 750 measured −26, both pointing at larger being better. That is well
+inside the error bars of a 40-game screen and needs a real SPRT.
+
+### 4.2 SPSA the king shelter magnitude
+
+Flagged when merged. The shape fix was right, but summing over three files
+tripled the dynamic range as a side effect (+21/−45 against the old +6/−22), and
+the merged variant measured −11.9 ± 31.8. Hand-tuning fails. This is a small,
+well-defined search space and a good first SPSA target.
+
+### 4.3 Move ordering
+
+Untouched by the recent work and historically the highest-leverage area in an
+alpha-beta engine. Measure the effective branching factor and the cutoff move
+index distribution before changing anything.
+
+### 4.4 Trim genuinely dead evaluation
+
+Only after a `--decisions` run on **≥10000 positions**. The prize is not Elo
+directly — it is nps and simplicity, which buy depth. Note that evaluation *code*
+cost is small here (nps was flat at 291k vs 297k across the reset), so the case
+for trimming rests on complexity, not speed.
+
+Related: the three overlapping king-safety models should be collapsed properly
+rather than by zeroing attacker tables, and `attackers_of2` is about **11% of
+runtime**.
+
+### 4.5 Fix the mis-attributed discrimination pairs
+
+Five of fourteen are decided by `sq_score_category_scale` or `pst_mg_king` rather
+than the term they were written to test. Each one is a small, concrete puzzle and
+they tend to surface real evaluation defects — that is how the shelter bug was
+found.
+
+### 4.6 NNUE / attention
+
+`feature/trainer` (27 commits, last touched March) is this line of work, developed
+on separate hardware. Given that the HCE reset measured neutral, this is the most
+plausible route to a substantial jump, and the target machine has the GPU and RAM
+for it. Treat the HCE as the thing that must be *correct and fast* to serve as a
+fallback and a datagen engine, not as the thing to squeeze for the next 100 Elo.
+
+Prerequisite: the `datagen` fixes in the backlog.
+
+---
+
+## 5. Do not retry Texel tuning
+
+It cannot help this evaluation, and the reason is structural rather than a matter
+of setup, so a better fit or more data will not change it.
+
+A parameter's gradient is **independent of its current value**. Zeroing
+`bishop_king_distance_penalty` moved its measured worth from 1.94 to 0.00 while
+its gradient moved only from 1.935 to 1.938. The optimiser therefore sees the same
+landscape after any reset of the defaults, and its minimum has not moved. A refit
+walks straight back to the fit that measured **+1.4 ± 19.9 Elo over 781 games**.
+
+Compounding this, the error is dominated by material, and the quiet-position
+filter discards the ~22% of positions where tactical terms fire — precisely the
+knowledge worth tuning.
+
+**Use it for material and piece-square tables. Nothing else.**
+
+For the same reason, "reset the parameters to natural values and refit" is not a
+plan. The reset was worth doing on its own merits — hygiene, no double-counting,
+knowledge not scaled away — and it was done. It did not make the tuner useful.
+
+### What to do instead
+
+Games are the only objective that has proven trustworthy. That points at SPSA and,
+if the compute is available, at population-based methods over self-play — which is
+what the user independently identified as the honest version of this problem.
+
+---
+
+## 6. Open questions
+
+- **Why is TT prefetch worth −14 Elo** while being node-identical and faster? Until
+  this is explained, no micro-optimisation in that area should be trusted.
+- **Why do two well-established anchors disagree by 70–90 points** about haVoc in
+  the same run, in opposite directions across runs? Bracketing anchors have been
+  added to find out; if the disagreement survives, it is real non-transitivity and
+  it limits how precisely this engine can be rated at all.
+- **What is the right shelter magnitude?** See 4.2.
+- **Is the HCE ceiling near?** Three separate lines of evidence — the neutral
+  reset, the material dominance of the argmax, and the flat response to
+  magnitude work — point the same way. Worth confirming deliberately rather than
+  concluding by accumulation.
+- Current `main` runs about **10% lower nps** than the state seven PRs earlier
+  while searching about 8% fewer nodes, so bench time is a wash. Whether that
+  trade is favourable in games is exactly what the drift check measures.
+
+---
+
+## 7. Branch inventory
+
+Merges are squashed, so most remote branches are delivered leftovers and can be
+deleted. These never went through a PR and should be checked before being assumed
+to contain undelivered work — most are probably superseded:
+
+`exp/threat-escape-ordering`, `feat/king-zone-shelter`, `fix/aspiration-window`,
+`fix/qsearch-fail-soft-delta`, `fix/see-material-sync`, `test/search-symmetry`.
+
+`feature/trainer` is the NNUE/attention line and is live work on other hardware —
+do not delete or rebase it.
+
+---
+
+## 8. Rules of engagement
+
+These were adopted during the recent work and are worth keeping.
+
+- **One commit per fix**, with a message that says what was wrong and how it was
+  proven, not what was typed.
+- **Structural** changes measuring neutral-to-slightly-negative may merge, and are
+  recorded in `revisit-after-tuning.md`. **Pure parameter** changes must earn their
+  keep with an SPRT.
+- **Prefer building a measurement over extending an argument.** Every genuine
+  advance recently came from a new instrument.
+- **Record negative results.** Half of this document is things that did not work,
+  and that half has saved more time than the other.
+- **Run one CPU-heavy job at a time**, and never build or run tests during a match
+  unless niced.


### PR DESCRIPTION
Adds an entry point to the project for whoever picks it up next, on other hardware or as a different agent.

`docs/revisit-after-tuning.md` had grown to 700 lines of evidence with no summary. Its most valuable content is the negative results, which are exactly the material that gets rediscovered expensively.

### `docs/roadmap.md`

States the position plainly: correctness work paid, evaluation knowledge work has not, and a coherent reset of 59 parameters measured neutral twice (+14.5 ± 26.9 fixed time, −4.5 ± 25.8 fixed depth).

- **Non-negotiables when measuring**, each with the number that proves it — the cutechess ranking-column trap (203-point gap reported as 420), bench as an unusable objective (`rfp_margin` 70/80/90 giving 539k/954k/827k nodes), the decision-sensitivity sample-size trap (69% dead at 300 positions, 17% at 10000), family-level attribution, self-play overstating field Elo, and accumulated drift.
- **What was tried and failed**: Texel tuning, piecemeal margin raises (−85, −37, −22, −12.6 Elo), TT prefetch (−14 Elo while node-identical and *faster*), hand-halving the shelter values, obscure rating anchors.
- **Paths forward** in priority order with reasoning: margin SPSA first, because search is measurably unsaturated (29% of positions change their preferred move at depth 8, 12% still at depth 12).
- **A section on why not to retry Texel.** It is the thing most likely to be attempted again in good faith. The obstacle is structural, not setup: a parameter's gradient is independent of its current value, so no reset of defaults moves the minimum, and the fit measured +1.4 ± 19.9 Elo over 781 games.
- Open questions, branch inventory, and the working rules adopted during this stretch.

### `docs/handoff.md`

The practical half. Bench node count is deterministic and machine-independent, so it is an exact checksum that a port succeeded — 697583 nodes, 133 tests. What has to be rebuilt, and why Elo numbers do not travel between machines.

### README corrections

Two claims had gone stale and contradicted the README's own strength table:

- "No rating against a rated opponent has been established" — the table above it lists three.
- "Texel tuning ... has not produced a well-tuned parameter set yet" — implies it merely needs another go, when the evidence says it cannot.

Documentation only; no engine code touched.
