### PR TITLE
ci: fix the test invocation, and stop the sanitizer job hanging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
       # Test
       - name: Test
         working-directory: build
-        run: ctest --config Release --output-on-failure --parallel
+        run: ctest -C Release --output-on-failure --parallel 4
 
       # Debug build with sanitizers (Linux GCC only, to keep CI fast)
       - name: Configure Debug + Sanitizers
@@ -97,7 +97,13 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && matrix.compiler == 'gcc'
         run: cmake --build build-debug --config Debug --parallel
 
+      # EverySearchParameterReachesTheSearch runs a full search per tunable
+      # parameter. It costs ~53s in Release and over 20x that instrumented,
+      # which would dominate this job. It is a coverage test, not a
+      # memory-safety one, and the Release job above still runs it.
       - name: Test Debug (ASan + UBSan)
         if: matrix.os == 'ubuntu-latest' && matrix.compiler == 'gcc'
         working-directory: build-debug
-        run: ctest --config Debug --output-on-failure --parallel
+        run: >
+          ctest -C Debug --output-on-failure --parallel 4
+          -E 'EverySearchParameterReachesTheSearch'


### PR DESCRIPTION
The first CI run this repository has ever had went red on all four platforms. This fixes the two things that broke it on Linux and macOS. The Windows failure is a real code bug and is fixed separately in the `fix/msvc-constexpr-abs` branch.

### `ctest --config` is not an option

Every job died before running a single test:

```
CMake Error: Unknown argument: --config
```

`--config` belongs to `cmake --build`. `ctest` spells it `-C <cfg>` / `--build-config <cfg>`. The two had been conflated. Older ctest tolerated the unknown argument; the version on current runners does not.

### `--parallel` had no job count

The job count only became optional in CMake 3.29. Passing `--parallel` bare risks it swallowing whichever token follows — which now matters, because `-E` follows it. Both invocations now pass an explicit `4`.

### One test dominated the sanitizer job

`SearchTest.EverySearchParameterReachesTheSearch` runs a full search per tunable parameter: **53s in Release**, and it had *not finished after 22 minutes* under ASan+UBSan. It is a coverage test, not a memory-safety one, and the Release job still runs it, so it is excluded from the instrumented run only.

| sanitizer suite | before | after |
| --- | --- | --- |
| result | unfinished at 22 min | 132/132 in **77s** |
| ASan/UBSan diagnostics | — | none |

Workflow-only change; no engine code touched.