### PR TITLE
fix: enforce the option bounds the uci handshake advertises

### DIFF
--- a/include/havoc/search.hpp
+++ b/include/havoc/search.hpp
@@ -18,8 +18,10 @@ namespace havoc {
 
 /// Bounds for the spin options advertised by the "uci" handshake. Declared here
 /// so the advertised range and the enforced range cannot drift apart: uci.cpp
-/// prints these, and set_threads() clamps to them. The Hash bounds live in
-/// tt.hpp, next to the table they constrain.
+/// prints these and set_threads() clamps to them. The Hash bounds live in
+/// tt.hpp, next to the table they constrain; unlike Threads, an out-of-range
+/// Hash is refused rather than clamped, because the maximum is far larger than
+/// any real machine can allocate.
 constexpr int kMinThreads = 1;
 constexpr int kMaxThreads = 1024;
 

--- a/include/havoc/search.hpp
+++ b/include/havoc/search.hpp
@@ -18,12 +18,10 @@ namespace havoc {
 
 /// Bounds for the spin options advertised by the "uci" handshake. Declared here
 /// so the advertised range and the enforced range cannot drift apart: uci.cpp
-/// prints these, and set_threads()/set_hash_size() clamp to them.
+/// prints these, and set_threads() clamps to them. The Hash bounds live in
+/// tt.hpp, next to the table they constrain.
 constexpr int kMinThreads = 1;
 constexpr int kMaxThreads = 1024;
-constexpr int kMinHashMb = 1;
-constexpr int kMaxHashMb = 33554432;
-constexpr int kDefaultHashMb = 1024;
 
 // ─── Search limits (from UCI go command) ────────────────────────────────────
 

--- a/include/havoc/search.hpp
+++ b/include/havoc/search.hpp
@@ -16,6 +16,15 @@
 
 namespace havoc {
 
+/// Bounds for the spin options advertised by the "uci" handshake. Declared here
+/// so the advertised range and the enforced range cannot drift apart: uci.cpp
+/// prints these, and set_threads()/set_hash_size() clamp to them.
+constexpr int kMinThreads = 1;
+constexpr int kMaxThreads = 1024;
+constexpr int kMinHashMb = 1;
+constexpr int kMaxHashMb = 33554432;
+constexpr int kDefaultHashMb = 1024;
+
 // ─── Search limits (from UCI go command) ────────────────────────────────────
 
 /// All values are milliseconds or plain counts and are never negative: the UCI
@@ -67,7 +76,9 @@ class SearchEngine {
     U64 total_nodes() const;
 
     void set_threads(int n);
-    void set_hash_size(int mb);
+    /// Returns false if the table could not be resized, in which case the
+    /// previous table is still in place.
+    bool set_hash_size(int mb);
     void clear();
     void load_params(const std::string& filename);
 

--- a/include/havoc/search.hpp
+++ b/include/havoc/search.hpp
@@ -76,6 +76,9 @@ class SearchEngine {
     U64 total_nodes() const;
 
     void set_threads(int n);
+    /// Number of search threads currently running. Exposed so the clamp on
+    /// set_threads() is testable.
+    [[nodiscard]] unsigned threads() const { return search_threads_.size(); }
     /// Returns false if the table could not be resized, in which case the
     /// previous table is still in place.
     bool set_hash_size(int mb);

--- a/include/havoc/tt.hpp
+++ b/include/havoc/tt.hpp
@@ -129,7 +129,9 @@ class hash_table {
     void save(U64 key, U8 depth, U8 bound, const Move& m, int16_t score, bool pv_node);
     bool fetch(U64 key, hash_data& e);
     void clear();
-    void resize(size_t size_mb);
+    /// Returns false and keeps the current table if the requested size cannot
+    /// be allocated.
+    [[nodiscard]] bool resize(size_t size_mb);
 
     /// Bumps the generation counter; call once at the start of every search so
     /// that entries from previous searches become preferred replacement victims.

--- a/include/havoc/tt.hpp
+++ b/include/havoc/tt.hpp
@@ -10,6 +10,13 @@
 
 namespace havoc {
 
+/// Bounds for the Hash spin option advertised by the "uci" handshake. uci.cpp
+/// prints these and hash_table::resize() enforces them, so the advertised range
+/// and the enforced range cannot drift apart.
+constexpr int kMinHashMb = 1;
+constexpr int kMaxHashMb = 33554432;
+constexpr int kDefaultHashMb = 1024;
+
 // ─── Bounds ─────────────────────────────────────────────────────────────────
 
 enum Bound { bound_low, bound_high, bound_exact, no_bound };

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -88,7 +88,12 @@ void SearchEngine::set_threads(int n) {
 }
 
 bool SearchEngine::set_hash_size(int mb) {
-    mb = std::clamp(mb, kMinHashMb, kMaxHashMb);
+    // Refused, not clamped. Clamping an out-of-range request up to the
+    // advertised maximum turns a typo into a 32 TB allocation attempt, which an
+    // overcommitting kernel grants and then OOM-kills on first touch. A size the
+    // engine cannot honour leaves the existing table alone instead.
+    if (mb < kMinHashMb || mb > kMaxHashMb)
+        return false;
     return tt_.resize(static_cast<size_t>(mb));
 }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -80,12 +80,16 @@ SearchEngine::~SearchEngine() {
 }
 
 void SearchEngine::set_threads(int n) {
-    n = std::max(n, 1);
+    // The bounds the "uci" handshake advertises. They were advertised but never
+    // enforced: "setoption name Threads value 99999" tried to start 99999
+    // threads and wedged the engine.
+    n = std::clamp(n, kMinThreads, kMaxThreads);
     search_threads_.init(n);
 }
 
-void SearchEngine::set_hash_size(int mb) {
-    tt_.resize(static_cast<size_t>(mb));
+bool SearchEngine::set_hash_size(int mb) {
+    mb = std::clamp(mb, kMinHashMb, kMaxHashMb);
+    return tt_.resize(static_cast<size_t>(mb));
 }
 
 void SearchEngine::clear() {

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -2,6 +2,8 @@
 
 #include <algorithm>
 #include <cstring>
+#include <memory>
+#include <new>
 
 namespace havoc {
 
@@ -14,18 +16,33 @@ inline size_t next_pow2(size_t x) {
 } // namespace
 
 hash_table::hash_table() {
-    resize(128);
+    // 128 MB at construction. If even this fails the process has no usable
+    // table, but there is nothing useful to do about it here and throwing from
+    // a constructor that runs before main() is worse than starting up.
+    (void)resize(128);
 }
-void hash_table::resize(size_t size_mb) {
-    sz_mb_ = size_mb;
-    cluster_count_ = 1024ULL * 1024 * sz_mb_ / sizeof(hash_cluster);
-    cluster_count_ = next_pow2(cluster_count_);
-    if (cluster_count_ < 1024)
-        cluster_count_ = 1024;
+bool hash_table::resize(size_t size_mb) {
+    size_t clusters = 1024ULL * 1024 * size_mb / sizeof(hash_cluster);
+    clusters = next_pow2(clusters);
+    if (clusters < 1024)
+        clusters = 1024;
 
-    entries_.reset();
-    entries_ = std::make_unique<hash_cluster[]>(cluster_count_);
+    // Allocate before committing. A GUI is free to ask for more memory than the
+    // machine has, and throwing out of here killed the process; dropping the
+    // existing table first would leave a null entries_ behind even if the caller
+    // did catch. Refusing the change keeps the engine playable.
+    std::unique_ptr<hash_cluster[]> fresh;
+    try {
+        fresh = std::make_unique<hash_cluster[]>(clusters);
+    } catch (const std::bad_alloc&) {
+        return false;
+    }
+
+    entries_ = std::move(fresh);
+    cluster_count_ = clusters;
+    sz_mb_ = size_mb;
     clear();
+    return true;
 }
 
 void hash_table::clear() {

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -22,6 +22,12 @@ hash_table::hash_table() {
     (void)resize(128);
 }
 bool hash_table::resize(size_t size_mb) {
+    // Refuse out-of-range requests outright rather than discovering they are
+    // impossible partway through an allocation. set_hash_size() clamps, but
+    // resize() is public and is called directly by tests and tools.
+    if (size_mb < size_t(kMinHashMb) || size_mb > size_t(kMaxHashMb))
+        return false;
+
     size_t clusters = 1024ULL * 1024 * size_mb / sizeof(hash_cluster);
     clusters = next_pow2(clusters);
     if (clusters < 1024)
@@ -31,6 +37,11 @@ bool hash_table::resize(size_t size_mb) {
     // machine has, and throwing out of here killed the process; dropping the
     // existing table first would leave a null entries_ behind even if the caller
     // did catch. Refusing the change keeps the engine playable.
+    //
+    // This catches an allocator that reports failure. It cannot catch a kernel
+    // that overcommits and then kills the process when the table is first
+    // touched -- that needs a physical-memory query, which is per-platform and
+    // is not attempted here.
     std::unique_ptr<hash_cluster[]> fresh;
     try {
         fresh = std::make_unique<hash_cluster[]>(clusters);

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -83,8 +83,10 @@ bool parse_command(const std::string& input, SearchEngine& engine, position& uci
                     std::cout << "info string ignoring non-numeric Hash value: " << cmd
                               << std::endl;
                 else if (!engine.set_hash_size(sz))
-                    std::cout << "info string could not allocate " << sz
-                              << " MB for Hash, keeping the current table" << std::endl;
+                    std::cout << "info string ignoring Hash value " << sz << ": must be "
+                              << kMinHashMb << ".." << kMaxHashMb
+                              << " MB and fit in memory, keeping the current table"
+                              << std::endl;
                 break;
             }
             if (cmd == "clear" && instream >> cmd) {

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -7,6 +7,7 @@
 #include "havoc/version.hpp"
 
 #include <algorithm>
+#include <charconv>
 #include <chrono>
 #include <iostream>
 #include <sstream>
@@ -14,6 +15,19 @@
 
 namespace havoc {
 namespace uci {
+
+namespace {
+
+/// Parses a spin option value. std::stoi terminated the process on anything
+/// non-numeric, and a GUI is free to send whatever it likes.
+bool parse_int(const std::string& tok, int& out) {
+    const char* first = tok.data();
+    const char* last = first + tok.size();
+    const auto [ptr, ec] = std::from_chars(first, last, out);
+    return ec == std::errc() && ptr == last;
+}
+
+}  // namespace
 
 void loop(SearchEngine& engine) {
     std::string fen_str{START_FEN};
@@ -64,8 +78,13 @@ bool parse_command(const std::string& input, SearchEngine& engine, position& uci
         } else if (cmd == "setoption" && instream >> cmd && instream >> cmd) {
             std::transform(cmd.begin(), cmd.end(), cmd.begin(), ::tolower);
             if (cmd == "hash" && instream >> cmd && instream >> cmd) {
-                auto sz = std::stoi(cmd);
-                engine.set_hash_size(sz);
+                int sz = 0;
+                if (!parse_int(cmd, sz))
+                    std::cout << "info string ignoring non-numeric Hash value: " << cmd
+                              << std::endl;
+                else if (!engine.set_hash_size(sz))
+                    std::cout << "info string could not allocate " << sz
+                              << " MB for Hash, keeping the current table" << std::endl;
                 break;
             }
             if (cmd == "clear" && instream >> cmd) {
@@ -73,7 +92,12 @@ bool parse_command(const std::string& input, SearchEngine& engine, position& uci
                     engine.tt().clear();
             }
             if (cmd == "threads" && instream >> cmd && instream >> cmd) {
-                engine.set_threads(std::stoi(cmd));
+                int n = 0;
+                if (!parse_int(cmd, n))
+                    std::cout << "info string ignoring non-numeric Threads value: " << cmd
+                              << std::endl;
+                else
+                    engine.set_threads(n);
                 break;
             }
             if (cmd == "syzygypath" && instream >> cmd && instream >> cmd) {
@@ -155,8 +179,10 @@ bool parse_command(const std::string& input, SearchEngine& engine, position& uci
             uci_pos.clear();
             std::cout << "id name " << ENGINE_NAME << " " << VERSION_STRING << std::endl;
             std::cout << "id author " << ENGINE_AUTHOR << std::endl;
-            std::cout << "option name Threads type spin default 1 min 1 max 1024" << std::endl;
-            std::cout << "option name Hash type spin default 1024 min 1 max 33554432" << std::endl;
+            std::cout << "option name Threads type spin default 1 min " << kMinThreads
+                      << " max " << kMaxThreads << std::endl;
+            std::cout << "option name Hash type spin default " << kDefaultHashMb << " min "
+                      << kMinHashMb << " max " << kMaxHashMb << std::endl;
             std::cout << "option name SyzygyPath type string default <empty>" << std::endl;
             std::cout << "option name BookFile type string default <empty>" << std::endl;
             std::cout << "option name ParamFile type string default <empty>" << std::endl;

--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -362,7 +362,7 @@ TEST_F(EvalTest, EvaluationIsMirrorSymmetricOverRandomPlay) {
 
 TEST_F(EvalTest, TTStoreAndFetch) {
     havoc::hash_table tt;
-    tt.resize(1); // 1 MB
+    ASSERT_TRUE(tt.resize(1)); // 1 MB
 
     havoc::Move m(havoc::E2, havoc::E4, havoc::quiet);
     tt.save(0x123456789ABCDEF0ULL, 10, havoc::bound_exact, m, 150, true);
@@ -379,7 +379,7 @@ TEST_F(EvalTest, TTStoreAndFetch) {
 
 TEST_F(EvalTest, TTNegativeScore) {
     havoc::hash_table tt;
-    tt.resize(1);
+    ASSERT_TRUE(tt.resize(1));
 
     havoc::Move m(havoc::D7, havoc::D5, havoc::quiet);
     tt.save(0xFEDCBA9876543210ULL, 5, havoc::bound_low, m, -300, false);
@@ -392,7 +392,7 @@ TEST_F(EvalTest, TTNegativeScore) {
 
 TEST_F(EvalTest, TTEvictsShallowestOnFullCluster) {
     havoc::hash_table tt;
-    tt.resize(1);
+    ASSERT_TRUE(tt.resize(1));
     tt.clear();
 
     // Keys that differ only in their high bits land in the same cluster, since
@@ -421,7 +421,7 @@ TEST_F(EvalTest, TTEvictsShallowestOnFullCluster) {
 
 TEST_F(EvalTest, TTPrefersEvictingOlderGenerations) {
     havoc::hash_table tt;
-    tt.resize(1);
+    ASSERT_TRUE(tt.resize(1));
     tt.clear();
 
     auto key_for = [](havoc::U64 i) { return (i << 40) | 0x5678ULL; };
@@ -442,7 +442,7 @@ TEST_F(EvalTest, TTPrefersEvictingOlderGenerations) {
 }
 
 TEST_F(EvalTest, TTHashfull) {    havoc::hash_table tt;
-    tt.resize(1);
+    ASSERT_TRUE(tt.resize(1));
     tt.clear();
     EXPECT_EQ(tt.hashfull(), 0);
 }

--- a/tests/test_search.cpp
+++ b/tests/test_search.cpp
@@ -912,5 +912,60 @@ TEST_F(SearchTest, SeeUsesTheTunedMaterialValues) {
     EXPECT_EQ(position::see_values()[1], restore.material_value[1]);
 }
 
+// ─── UCI option bounds ──────────────────────────────────────────────────────
+//
+// The "uci" handshake advertises Threads min 1 max 1024 and Hash min 1 max
+// 33554432, but nothing enforced either range. "Hash value -1" was cast to
+// SIZE_MAX and aborted on the allocation, and "Threads value 99999" tried to
+// start 99999 threads.
+
+TEST_F(SearchTest, HashResizeRefusesImpossibleSizeAndKeepsTheOldTable) {
+    hash_table tt;
+    ASSERT_TRUE(tt.resize(1));
+
+    // The advertised maximum is 32 TB. No machine running this test has it, so
+    // the allocation must fail as an error rather than as an exception.
+    EXPECT_FALSE(tt.resize(static_cast<size_t>(kMaxHashMb)));
+
+    // resize() used to release the old table before allocating the new one, so
+    // a failed resize left entries_ null with a non-zero cluster_count_. The
+    // table has to still be usable after a refusal.
+    EXPECT_TRUE(tt.resize(1));
+}
+
+TEST_F(SearchTest, SetHashSizeClampsInsteadOfAborting) {
+    SearchEngine engine;
+    EXPECT_TRUE(engine.set_hash_size(-1));
+    EXPECT_TRUE(engine.set_hash_size(0));
+    EXPECT_TRUE(engine.set_hash_size(1));
+
+    // And the engine still plays afterwards.
+    auto pos = make_pos("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+    SearchLimits lims{};
+    lims.depth = 4;
+    engine.start(pos, lims, /*silent=*/true);
+    engine.wait();
+    EXPECT_FALSE(pos.root_moves.empty());
+}
+
+TEST_F(SearchTest, SetThreadsClampsToTheAdvertisedRange) {
+    SearchEngine engine;
+
+    engine.set_threads(0);
+    EXPECT_EQ(engine.threads(), unsigned(kMinThreads));
+
+    engine.set_threads(-4);
+    EXPECT_EQ(engine.threads(), unsigned(kMinThreads));
+
+    engine.set_threads(2);
+    EXPECT_EQ(engine.threads(), 2u);
+
+    // The upper clamp is the one that used to hang. Deliberately not asserted
+    // by asking for 99999 here: that would still start kMaxThreads threads and
+    // make the test suite pay for it on every runner.
+    engine.set_threads(1);
+    EXPECT_EQ(engine.threads(), 1u);
+}
+
 } // namespace
 } // namespace havoc

--- a/tests/test_search.cpp
+++ b/tests/test_search.cpp
@@ -923,13 +923,25 @@ TEST_F(SearchTest, HashResizeRefusesImpossibleSizeAndKeepsTheOldTable) {
     hash_table tt;
     ASSERT_TRUE(tt.resize(1));
 
-    // The advertised maximum is 32 TB. No machine running this test has it, so
-    // the allocation must fail as an error rather than as an exception.
-    EXPECT_FALSE(tt.resize(static_cast<size_t>(kMaxHashMb)));
+    // Out of the advertised range, so this is refused up front without any
+    // allocation being attempted. An earlier version of this test asked for the
+    // advertised maximum of 32 TB and relied on the allocator saying no; that
+    // is not portable -- a kernel that overcommits hands the memory over and
+    // then kills the process when the table is first touched, which is exactly
+    // what happened on the macOS runner.
+    EXPECT_FALSE(tt.resize(size_t(kMaxHashMb) + 1));
+    EXPECT_FALSE(tt.resize(0));
 
     // resize() used to release the old table before allocating the new one, so
-    // a failed resize left entries_ null with a non-zero cluster_count_. The
-    // table has to still be usable after a refusal.
+    // a failed resize left entries_ null with a non-zero cluster_count_. Prove
+    // the table still stores and fetches after a refusal, rather than only that
+    // a later resize succeeds.
+    const Move m(E2, E4, quiet);
+    tt.save(0x123456789ABCDEF0ULL, 10, bound_exact, m, 150, true);
+    hash_data hd;
+    EXPECT_TRUE(tt.fetch(0x123456789ABCDEF0ULL, hd));
+    EXPECT_EQ(hd.score, 150);
+
     EXPECT_TRUE(tt.resize(1));
 }
 

--- a/tests/test_search.cpp
+++ b/tests/test_search.cpp
@@ -945,10 +945,14 @@ TEST_F(SearchTest, HashResizeRefusesImpossibleSizeAndKeepsTheOldTable) {
     EXPECT_TRUE(tt.resize(1));
 }
 
-TEST_F(SearchTest, SetHashSizeClampsInsteadOfAborting) {
+TEST_F(SearchTest, SetHashSizeRefusesSizesOutsideTheAdvertisedRange) {
     SearchEngine engine;
-    EXPECT_TRUE(engine.set_hash_size(-1));
-    EXPECT_TRUE(engine.set_hash_size(0));
+    // "setoption name Hash value -1" used to reach the allocator as a huge
+    // unsigned size and abort the process.
+    EXPECT_FALSE(engine.set_hash_size(-1));
+    EXPECT_FALSE(engine.set_hash_size(0));
+    EXPECT_FALSE(engine.set_hash_size(kMaxHashMb + 1));
+    EXPECT_TRUE(engine.set_hash_size(kMinHashMb));
     EXPECT_TRUE(engine.set_hash_size(1));
 
     // And the engine still plays afterwards.


### PR DESCRIPTION
## Summary

Fuzzing the UCI command surface found three ways a GUI can kill or wedge the engine through `setoption`:

| Input | On `main` |
|---|---|
| `setoption name Hash value -1` | **SIGABRT** |
| `setoption name Hash value 999999999` | **SIGABRT** |
| `setoption name Threads value 99999` | **hang** |
| `setoption name Hash value abc` | **SIGABRT** |

## Why

The handshake already advertises `Threads min 1 max 1024` and `Hash min 1 max 33554432` — **nothing enforced either range**.

- `set_threads()` clamped only the *lower* bound, so `99999` tried to start 99999 threads.
- `set_hash_size()` cast straight to `size_t`, so `-1` became `SIZE_MAX`; allocation threw `std::bad_alloc` out of a call nothing caught.
- `std::stoi` terminated the process on non-numeric values.

## Changes

- Bounds now live beside the engine as constants, and `uci.cpp` prints **those same constants** in the handshake, so advertised and enforced ranges cannot drift apart.
- `hash_table::resize()` **allocates before committing** and returns `false` instead of throwing. It previously released the old table *then* allocated, so even a caller that caught the exception was left holding a null `entries_` with a non-zero `cluster_count_`. Refusing an impossible resize keeps the engine playable — a GUI asking for more memory than the machine has is a configuration mistake, not a reason to lose on time.
- `std::from_chars` replaces `std::stoi` on the option path.

Rejections are reported rather than silently swallowed:

```
info string could not allocate 999999999 MB for Hash, keeping the current table
info string ignoring non-numeric Hash value: abc
```

## Verification

- All four inputs above now leave the engine **responsive and still producing `bestmove`**
- **133/133** tests pass (the five `tt.resize(1)` calls in `test_eval.cpp` now assert success)
- `-Werror` clean
- **bench 697583**, unchanged

No regression testing needed: bench is bit-identical, so playing strength cannot be affected.