### PR TITLE
fix: score a wrong rook pawn as drawn while the king can still reach the corner

### DIFF
--- a/src/eval/hce.cpp
+++ b/src/eval/hce.cpp
@@ -8,6 +8,7 @@
 #include "havoc/utils.hpp"
 
 #include <algorithm>
+#include <bit>
 #include <cmath>
 #include <vector>
 
@@ -75,9 +76,48 @@ template <Color c> inline bool is_wrong_rook_pawn_draw(const position& p) {
     if ((bishops & promo_complex) != 0ULL)
         return false;
 
-    // The defending king must already be on or beside the promotion square.
     const int dk = static_cast<int>(p.king_square(them));
-    return std::max(util::row_dist(dk, promo), util::col_dist(dk, promo)) <= 1;
+    const int dk_to_promo = std::max(util::row_dist(dk, promo), util::col_dist(dk, promo));
+
+    // Already on or beside the promotion square: it can never be evicted, since
+    // the bishop cannot contest that corner and stalemate answers the pawn.
+    if (dk_to_promo <= 1)
+        return true;
+
+    // Otherwise the defender still draws if it can walk back to the corner in
+    // time. Requiring it to be there *already* put a cliff in the evaluation:
+    // with the pawn on h2, a black king on h7 scored 0 and the same king on h6
+    // scored +417, though both are equally dead draws. The search found the
+    // cliff and steered for it, reporting +132 on a position it cannot win.
+    //
+    // Two things have to hold for the walk to succeed. The king must reach the
+    // corner before the pawn does, and it must not be headed off by the
+    // attacking king, which is the one piece that can shoulder it away. Both
+    // are compared in king moves, and both are deliberately strict: a defender
+    // that only draws by a tempo is left to the search rather than asserted
+    // here, because this returns a hard zero and a wrong hard zero is far more
+    // expensive than a missed one.
+    const int lead_pawn =
+        (c == white) ? (63 - std::countl_zero(pawns)) : static_cast<int>(bits::lsb(pawns));
+
+    // Moves the pawn needs, not ranks it has left: one less from the starting
+    // rank, because it may step two. Charging it the rank count called a black
+    // king six moves from a8 a draw against a pawn on a2 that promotes in five.
+    const bool on_start_rank =
+        (c == white) ? util::row(lead_pawn) == Row::r2 : util::row(lead_pawn) == Row::r7;
+    const int pawn_to_promo = util::row_dist(lead_pawn, promo) - (on_start_rank ? 1 : 0);
+
+    const int sk = static_cast<int>(p.king_square(c));
+    const int sk_to_promo = std::max(util::row_dist(sk, promo), util::col_dist(sk, promo));
+
+    // Arriving at the same time as the pawn is not good enough when the
+    // attacker moves first: the pawn promotes on the square the king was
+    // walking to. Whoever is to move gets the tempo.
+    const bool defender_to_move = p.to_move() == them;
+    const bool arrives_in_time =
+        defender_to_move ? dk_to_promo <= pawn_to_promo : dk_to_promo < pawn_to_promo;
+
+    return arrives_in_time && dk_to_promo <= sk_to_promo;
 }
 
 /// The two long diagonals, a1-h8 and a8-h1. Squares are indexed row*8 + col,

--- a/tests/test_eval.cpp
+++ b/tests/test_eval.cpp
@@ -693,6 +693,53 @@ TEST_F(EvalTest, WrongRookPawnAndWrongBishopIsDrawn) {
     }
 }
 
+TEST_F(EvalTest, WrongRookPawnIsDrawnWhenTheKingCanStillReachTheCorner) {
+    havoc::parameters params;
+    havoc::pawn_table pt(params);
+    havoc::material_table mt(params);
+    havoc::HCEEvaluator eval(pt, mt, params);
+
+    struct Case {
+        const char* fen;
+        const char* why;
+    };
+
+    // The theorem does not require the defending king to be in the corner
+    // already, only that it gets there before the pawn does. Requiring it to
+    // have arrived put a cliff in the evaluation: with the pawn on h2, a black
+    // king on h7 scored 0 while the same king on h6 scored +417, and the search
+    // steered for the higher side of the cliff and reported +132 on a position
+    // it cannot win.
+    const Case drawn[] = {
+        {"8/8/7k/8/8/8/7P/5BK1 w - - 0 1", "h6 is two moves from h8, the pawn needs five"},
+        {"8/8/8/7k/8/8/7P/5BK1 w - - 0 1", "h5 is three moves from h8"},
+        {"5k2/8/8/8/8/8/7P/5BK1 w - - 0 1", "f8 walks to h8 along the back rank"},
+        {"8/8/8/8/7k/8/7P/5BK1 w - - 0 1", "h4 needs four moves and the pawn five, so even"
+                                           " with White to move the king is there first"},
+    };
+    for (const auto& c : drawn) {
+        auto pos = make_pos(c.fen);
+        EXPECT_EQ(eval.evaluate(pos), 0)
+            << "king arrives in time, so still a dead draw: " << c.why << " (" << c.fen << ")";
+    }
+
+    // A king that does not arrive in time must still lose. The first case is
+    // the one that pins the pawn's travel time down: a2 promotes in five moves
+    // rather than six because of the double step, and a black king on g8 needs
+    // six, so counting ranks instead of moves would call this a draw.
+    const Case winning[] = {
+        {"6k1/8/8/8/8/8/PB6/6K1 w - - 0 1", "g8 needs six moves, the a2 pawn only five"},
+        {"8/8/6KP/7k/8/8/8/5B2 w - - 0 1", "the pawn is on h6 and h5 is three moves away"},
+        {"3k4/8/8/8/7P/8/8/1B4K1 w - - 0 1", "d8 and the h4 pawn are both four moves from h8,"
+                                             " and White moves first"},
+    };
+    for (const auto& c : winning) {
+        auto pos = make_pos(c.fen);
+        EXPECT_GT(eval.evaluate(pos), 200)
+            << "king is too slow, so this is still won: " << c.why << " (" << c.fen << ")";
+    }
+}
+
 TEST_F(EvalTest, OpenFilesBesideTheKingAreScoredAsDanger) {
     havoc::parameters on;
     havoc::parameters off;


### PR DESCRIPTION
### The bug

The wrong-bishop rook-pawn rule only fired when the defending king was **already** on or beside the promotion square. That left a cliff in the evaluation. With a white pawn on h2 and a light-squared bishop:

| black king | static eval | truth |
|---|---|---|
| h8 | 0 | draw |
| h7 | 0 | draw |
| **h6** | **+417** | draw |
| **h5** | **+425** | draw |

All four are equally dead draws — the bishop cannot contest h8 and stalemate answers the pawn. The search found the cliff and steered for the high side of it, reporting **+132 at depth 20** on `7k/8/8/8/8/8/7P/5BK1 w - - 0 1`, a position it cannot win.

### The fix

The theorem does not require the king to have arrived, only that it gets there before the pawn. The rule now also fires when the defending king reaches the promotion square in time and is not headed off by the attacking king — the one piece that can shoulder it away.

Two details decide the cases the old rule got right by accident:

- **The pawn is charged moves, not ranks.** A pawn on its starting rank promotes in five, not six. An existing negative control — a black king six moves from a8 against a pawn on a2 — depends on this, and counting ranks would wrongly call it a draw. It failed while I had this wrong, which is how I found it.
- **Arriving at the same time is only good enough for the side to move.** Otherwise the pawn promotes on the square the king was walking to.

The rule stays deliberately strict in both directions: it returns a hard zero, and a wrong hard zero costs far more than a missed one, so a defender that draws only by a tempo is left to the search.

### Verification

- the reported position now scores **0 at depth 24**, and all four rows above score 0
- **bench 697583, unchanged** — this material cannot arise in the bench set, and nothing outside these endings consults the rule, so normal play is bit-identical
- 134/134 tests pass, `-Werror` clean
- new test covers three reachable-corner draws and three that are still won, including the tempo case where king and pawn are both four moves from h8

Because bench is bit-identical, there is no measurable regression surface outside this endgame class; a confirmation match is queued behind the SPSA run currently using the machine.