### PR TITLE
docs: write down the pawnless scaling cliff, and close out the shelter SPSA

### DIFF
--- a/docs/revisit-after-tuning.md
+++ b/docs/revisit-after-tuning.md
@@ -99,6 +99,40 @@ sees no gradient for them and they keep their defaults. Listed in
   themselves tuned, so fitting both sides of the product is rank deficient.
   `pinned_scaling` is a divisor the tuner could drive to zero. The reasoning is
   recorded in `src/parameters.cpp`; revisit only if a fit wants that freedom.
+- **The pawnless scaling rule has a cliff in it, and the obvious repairs are
+  both wrong.** `no_pawn_scale` is applied when `is_pawnless_endgame(p) &&
+  std::abs(score) < 400`, so the *finished* score decides whether the finished
+  score gets quartered. A position scoring 399 is damped to 99 and one scoring
+  401 is left alone: two centipawns of raw evaluation are worth three hundred,
+  and a search that can nudge the raw score over the line collects the jump for
+  free. To see it, score a few hundred random pawnless positions at depth 1 and
+  histogram them -- across 583 such positions not one could land between 100 and
+  400. The band is not sparse, it is unreachable, because everything below the
+  threshold is multiplied by 32/128 and everything above it is not. Disabling
+  `minor_advantage_no_pawn_scale` does not close the gap, which rules out the
+  other scaling rule as the cause.
+
+  Two repairs were written and both were discarded after measurement, which is
+  why this is a note and not a patch:
+
+  - *Ramp the damping out linearly as the score approaches 400.* Removes the
+    discontinuity and is monotone, but it only moved 8 of the 583 positions,
+    because `minor_advantage_no_pawn_scale` is the binding constraint through
+    `std::min` almost everywhere the ramp would matter.
+  - *Key the rule on material instead of on the score,* which is the
+    principled version -- whether an ending is drawish is a property of the
+    material, and material only changes on a capture, so there is no boundary
+    left to cross by shuffling. It scored rook-versus-knight and
+    two-bishops-versus-knight at +370 and +394 instead of +92 and +98. Those
+    endings are drawish and the old rule was right about them by accident, so
+    the principled version is worse where it differs.
+
+  What that leaves is that `ei.me->score` does not mean what the neighbouring
+  rule assumes it means: rook versus knight is a 180cp material edge, yet it
+  does not satisfy `std::abs(ei.me->score) <= 315`, so the "single minor piece
+  advantage" rule never fires on it. Establish what that field actually holds
+  before touching either rule; the threshold and the damping factor both need
+  refitting afterwards, so this belongs with tuning rather than ahead of it.
 
 ## The history table lives on the wrong scale for its own thresholds
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -166,6 +166,23 @@ tripled the dynamic range as a side effect (+21/−45 against the old +6/−22),
 the merged variant measured −11.9 ± 31.8. Hand-tuning fails. This is a small,
 well-defined search space and a good first SPSA target.
 
+**Tried, and it found nothing.** 120 SPSA iterations at 40 games each
+(10+0.1, `scripts/testing/spsa.py`), roughly three hours and 4800 games, over
+all four `king_shelter` entries. The objective never moved: mean score 0.497
+across the first forty iterations and 0.497 across the last forty. The
+parameters oscillated in a narrow band around where they started
+(`-15, 7, 1, -4` → `-17, 8, -1, -5`) without ever leaving it, which is what a
+random walk on a flat objective looks like rather than a descent.
+
+Two readings fit. Either these four numbers are already near a local optimum
+and the remaining gain is smaller than 40 games can see, or -- more likely
+given §6 -- king shelter does not decide enough positions for its magnitude to
+show up in a game result at all, so no amount of tuning it will measure. The
+run was stopped rather than carried to 300 iterations; `--resume` works if
+someone wants to argue with that. Before spending another three hours here,
+raise games-per-iteration substantially or pick a target that demonstrably
+changes moves.
+
 ### 4.3 Move ordering
 
 Untouched by the recent work and historically the highest-leverage area in an


### PR DESCRIPTION
Two negative results from a night of measurement. Both cost hours to establish and are cheap to rediscover the hard way, so they are written down rather than left in a session log.

### The pawnless scaling cliff

`no_pawn_scale` fires on `is_pawnless_endgame(p) && std::abs(score) < 400` — the finished score decides whether the finished score gets quartered. A position scoring 399 is damped to 99, one scoring 401 is left alone, so two centipawns of raw evaluation are worth three hundred and a search that can nudge the score over the line collects the jump for free.

Score a few hundred random pawnless positions at depth 1 and the band between 100 and 400 is **unreachable**, not merely sparse — 0 of 583. Turning off `minor_advantage_no_pawn_scale` does not close it, which rules out the other scaling rule.

I wrote both obvious repairs and discarded both:

| Repair | Why it was dropped |
|---|---|
| Ramp the damping out linearly toward 400 | Monotone and removes the cliff, but moved only **8 of 583** positions — `minor_advantage_no_pawn_scale` binds first through `std::min` almost everywhere it would matter |
| Key the rule on material rather than score (the principled version) | Scored rook-vs-knight and two-bishops-vs-knight at **+370 and +394** instead of +92 and +98. Those endings are drawish; the old rule was right about them by accident |

The blocker underneath both is that `ei.me->score` does not hold what the neighbouring rule assumes: rook versus knight is a 180cp material edge yet does not satisfy `std::abs(ei.me->score) <= 315`, so the "single minor piece advantage" rule never fires on it. That needs establishing before either rule is touched, and the refit belongs with tuning rather than ahead of it.

### Roadmap 4.2, king shelter SPSA

Run and found nothing: 120 iterations × 40 games at 10+0.1, ~4800 games. Mean objective **0.497 over the first forty iterations and 0.497 over the last forty**, with the four parameters oscillating around their starting values rather than descending — a random walk on a flat objective.

Either they are already near optimal and the gain is under the resolution of 40 games, or king shelter does not change enough moves for its magnitude to reach a game result, which is what §6 already suspects. Stopped rather than carried to 300 iterations; the note records what to change before anyone spends another three hours there.

Docs only — no code changes.