### PR TITLE
fix: score bishops that all share a color complex as a dead draw

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -174,6 +174,29 @@ bool position::is_material_draw() const {
     if (w <= 1 && b <= 1)
         return true;
 
+    // Bishops only, and every bishop on the board standing on the same color
+    // complex. No mate exists, however many bishops there are.
+    //
+    // Mating needs the losing king attacked with no legal reply. Only bishops
+    // of the shared color can give that check, so the mated king has to stand
+    // on that color, which leaves it at least two adjacent squares of the other
+    // color that no bishop can ever see. Even in the corner -- king on a1, dark
+    // bishops -- the flight squares a2 and b1 are light, and the only piece
+    // that could cover both is the enemy king on b2, which is adjacent to a1
+    // and therefore illegal. So the position is dead.
+    //
+    // This is reachable only by underpromotion, but the engine does not need to
+    // reach it to be hurt by it: without this test it scores king and two
+    // same-colored bishops against a bare king at +6.7 pawns and will happily
+    // trade into it. It also generalises the KB-vs-KB case above to any number
+    // of bishops sharing a color.
+    if (wn == 0 && bn == 0) {
+        const U64 bishops = get_pieces<white, bishop>() | get_pieces<black, bishop>();
+        if (bishops && ((bishops & bitboards::colored_sqs[white]) == 0ULL ||
+                        (bishops & bitboards::colored_sqs[black]) == 0ULL))
+            return true;
+    }
+
     // Two knights against a bare king cannot be forced, and the arbiter will
     // never award it, so treating it as anything but a draw only makes the
     // engine trade into it.

--- a/tests/test_position.cpp
+++ b/tests/test_position.cpp
@@ -371,10 +371,17 @@ TEST_F(PositionTest, RecognisesDeadDrawnMaterial) {
     EXPECT_TRUE(material_draw("8/8/2b1k3/8/8/3NK3/8/8 w - - 0 1")); // KN vs KB
     // Two knights cannot force mate, and no arbiter will ever award it.
     EXPECT_TRUE(material_draw("8/8/4k3/8/8/2NNK3/8/8 w - - 0 1")); // KNN vs K
+    // Bishops that all share a color complex can never mate, whatever the
+    // count: the mated king would have to stand on that color, and its
+    // opposite-colored flight squares are unreachable to every bishop.
+    EXPECT_TRUE(material_draw("8/8/4k3/8/8/3BKB2/8/8 w - - 0 1"));  // d3+f3, both light
+    EXPECT_TRUE(material_draw("8/8/4k3/8/8/2B1K1B1/8/8 w - - 0 1")); // c3+g3, both dark
+    EXPECT_TRUE(material_draw("8/8/2b1k3/8/8/3BKB2/8/8 w - - 0 1")); // all three light
+    EXPECT_TRUE(material_draw("8/8/4k3/8/8/1B1BKB2/8/8 w - - 0 1")); // three light bishops
 
     // These are genuinely winnable and must not be written off.
     EXPECT_FALSE(material_draw("8/8/4k3/8/8/3BK3/4P3/8 w - - 0 1")); // KBP vs K
-    EXPECT_FALSE(material_draw("8/8/4k3/8/8/3BKB2/8/8 w - - 0 1"));  // KBB vs K
+    EXPECT_FALSE(material_draw("8/8/4k3/8/8/3BKB2/3B4/8 w - - 0 1")); // d3+f3 light, d2 dark
     EXPECT_FALSE(material_draw("8/8/4k3/8/8/3NKB2/8/8 w - - 0 1"));  // KBN vs K
     EXPECT_FALSE(material_draw("8/8/4k3/8/8/3RK3/8/8 w - - 0 1"));   // KR vs K
     EXPECT_FALSE(material_draw("8/8/4k3/8/8/3QK3/8/8 w - - 0 1"));   // KQ vs K


### PR DESCRIPTION
## The bug

`is_material_draw()` knew about K vs K, K plus one minor vs K, and KNN vs K. It stopped there. **King and two same-colored bishops against a bare king is also a dead position**, and the engine scored it **+670**:

| position | before | after |
|---|---|---|
| `7k/8/8/8/8/8/8/B1B3K1 w` (a1+c1, both dark) | **+670** | **0** |
| `7k/8/8/8/8/8/8/B1B1B1K1 w` (a1+c1+e1, all dark) | **+985** | **0** |
| `8/8/4k3/8/8/3BKB2/3B4/8 w` (d3+f3 light, d2 dark) | +1065 | +1065 |

## Why it is a draw

Mate needs the losing king attacked with no legal reply. Only bishops of the shared color can give that check, so the mated king has to stand on that color — which leaves it adjacent squares of the *other* color that no bishop can ever see.

Take the hardest case, king driven to a1 with dark bishops. The flight squares a2 and b1 are light. The only square from which the enemy king covers both is b2, and b2 is adjacent to a1, so the king cannot stand there. No mate exists, however many bishops there are.

The new test is deliberately narrow: **no knights on the board**, at least one bishop, and every bishop on one color complex. It generalises the existing KB-vs-KB case to any bishop count and leaves everything else alone.

## The existing test was pinning down the bug

```
EXPECT_FALSE(material_draw("8/8/4k3/8/8/3BKB2/8/8 w - - 0 1"));  // KBB vs K
```

`3BKB2` puts the bishops on **d3 and f3 — both light squares**. So the case labelled "genuinely winnable" was in fact the dead draw. The replacement negative control moves the third bishop to d2, which is dark, and stays winnable.

## Reachability

Only by underpromotion, so this will not swing a rating list. But the engine does not have to *reach* the position to be hurt by it: scoring it at +6.7 pawns is a standing invitation to trade into it.

## Verification

- **Bench 697583** — bit-identical to `main`.
- **133/133** tests pass.
- Scores above measured at depth 10 against a `main` build.

Bench being unchanged means no SPRT is required; the change is unreachable from any bench position.