### PR TITLE
feat: split the move budget into a soft and a hard limit (+42 Elo)

### DIFF
--- a/include/havoc/search.hpp
+++ b/include/havoc/search.hpp
@@ -34,8 +34,46 @@ inline constexpr double kMinSearchTime = 50.0;
 /// Returned when the search should run until the GUI stops it.
 inline constexpr double kNoTimeLimit = -1.0;
 
+/// How much longer than the soft budget a single move may run before the timer
+/// thread cuts it off. The soft limit is checked only between iterations, so
+/// the hard limit is what bounds an iteration that turns out to be expensive --
+/// a fail low at the root being the case that matters. Too tight and the engine
+/// cannot spend extra time where it needs to; too loose and one bad move eats
+/// the clock. The 33%-of-remaining cap still applies on top.
+inline constexpr double kHardTimeFactor = 2.5;
+
+/// Scaling of the soft budget by how settled the root move is.
+///
+/// `stable` counts completed iterations in a row that agreed on the best move.
+/// The multiplier runs from kSoftTimeUnstable when the root has just changed
+/// its mind down to kSoftTimeUnstable - kSoftTimeStep * kSoftTimeMaxStable once
+/// it has held for several iterations, so the average move costs about what it
+/// did before and the *distribution* is what moves: cheap when the move is not
+/// in doubt, generous when it is.
+inline constexpr double kSoftTimeUnstable = 1.10;
+inline constexpr double kSoftTimeStep = 0.10;
+inline constexpr int kSoftTimeMaxStable = 5;
+
+/// The two limits a timed search runs under.
+///
+/// `soft` is the budget the search aims at: on finishing an iteration it asks
+/// whether another one is affordable, and stops if it is not. That is where the
+/// engine can be cheap on a position whose best move is not in doubt and
+/// generous on one where it keeps changing its mind -- see the stability factor
+/// in iterative_deepening.
+///
+/// `hard` is the deadline the timer thread enforces regardless. Nothing but a
+/// stop from the GUI gets past it.
+struct TimeBudget {
+    double soft = kNoTimeLimit;
+    double hard = kNoTimeLimit;
+};
+
 /// Milliseconds to spend on one move given the limits the GUI reported.
 /// Kept free of the position so the policy can be tested directly.
+TimeBudget estimate_time_budget(const SearchLimits& lims, bool white_to_move);
+
+/// The hard deadline alone, for callers that only need the ceiling.
 double estimate_move_time(const SearchLimits& lims, bool white_to_move);
 
 // ─── Search signals ─────────────────────────────────────────────────────────
@@ -118,6 +156,17 @@ class SearchEngine {
     /// left the timer thread reading a dead stack frame and budgeting the move
     /// from whatever the next command wrote there. Owned here instead.
     SearchLimits limits_{};
+
+    /// Started once in start(), before any thread is spawned, and read by both
+    /// the timer thread and the main search thread. Shared so that the two
+    /// agree on when the move began: a clock created inside the timer thread
+    /// starts late by however long the thread took to be scheduled, and the
+    /// search would then overspend by exactly that much.
+    util::Clock search_clock_{};
+
+    /// The budget the main thread aims at, in milliseconds, or kNoTimeLimit
+    /// when the search is not on a clock. The timer thread owns the hard one.
+    double soft_limit_ = kNoTimeLimit;
 
     void search_timer(position& p);
     double estimate_max_time(position& p) const;

--- a/include/havoc/search.hpp
+++ b/include/havoc/search.hpp
@@ -76,6 +76,15 @@ TimeBudget estimate_time_budget(const SearchLimits& lims, bool white_to_move);
 /// The hard deadline alone, for callers that only need the ceiling.
 double estimate_move_time(const SearchLimits& lims, bool white_to_move);
 
+/// The elapsed time at which a search holding `soft` as its budget should
+/// decline to start another iteration, given how many consecutive completed
+/// iterations have agreed on the root best move.
+///
+/// Free-standing so the scaling can be tested without running a search.
+/// Returns kNoTimeLimit when there is no soft budget, which is the signal to
+/// leave the decision entirely to the hard deadline.
+double soft_time_target(double soft, int stable_iterations);
+
 // ─── Search signals ─────────────────────────────────────────────────────────
 
 struct SearchSignals {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -178,6 +178,8 @@ void SearchEngine::start(position& p, const SearchLimits& lims, bool silent) {
     completed_depth_.assign(search_threads_.size(), 0);
 
     U16 depth = (lims.depth > 0 ? static_cast<U16>(lims.depth) : static_cast<U16>(MAX_PLY));
+    search_clock_.reset();
+    soft_limit_ = estimate_time_budget(limits_, p.to_move() == white).soft;
     searching_ = true;
 
     // Launch the entire search on the worker thread so UCI loop stays responsive.
@@ -265,7 +267,10 @@ void SearchEngine::wait() {
 // ─── Timer ──────────────────────────────────────────────────────────────────
 
 void SearchEngine::search_timer(position& p) {
-    util::Clock c;
+    // Deliberately the clock start() reset, not a fresh one: a local clock here
+    // starts only once this thread is scheduled, so the setup it misses is time
+    // the engine has already spent and would then overspend by.
+    const util::Clock& c = search_clock_;
     bool fixed_time = limits_.movetime > 0;
     int delay = 1;
     double time_limit = estimate_max_time(p);
@@ -294,11 +299,15 @@ void SearchEngine::search_timer(position& p) {
     signals_.stop = true;
 }
 
-double estimate_move_time(const SearchLimits& lims, bool white_to_move) {
+TimeBudget estimate_time_budget(const SearchLimits& lims, bool white_to_move) {
     if (lims.infinite || lims.ponder || lims.depth > 0)
-        return kNoTimeLimit;
-    if (lims.movetime != 0)
-        return static_cast<double>(lims.movetime);
+        return {kNoTimeLimit, kNoTimeLimit};
+    if (lims.movetime != 0) {
+        // The GUI asked for exactly this much. There is nothing to ration, so
+        // the soft limit is the hard one and the search runs the clock out.
+        const double t = static_cast<double>(lims.movetime);
+        return {t, t};
+    }
 
     double our_time = (white_to_move ? lims.wtime : lims.btime);
     double our_inc = (white_to_move ? lims.winc : lims.binc);
@@ -308,14 +317,14 @@ double estimate_move_time(const SearchLimits& lims, bool white_to_move) {
     const bool has_clock = lims.wtime > 0 || lims.btime > 0 || lims.winc > 0 || lims.binc > 0 ||
                            lims.movestogo > 0;
     if (!has_clock)
-        return kNoTimeLimit;
+        return {kNoTimeLimit, kNoTimeLimit};
 
     // Our clock is spent, or the GUI reported a negative value that the UCI
     // layer clamped to zero. Returning kNoTimeLimit here used to mean "no
     // limit", so the engine answered a flag-fall by thinking forever and
     // losing on time. Move as quickly as we can instead.
     if (our_time <= 0)
-        return kMinSearchTime;
+        return {kMinSearchTime, kMinSearchTime};
 
     // Sudden death: assume a fixed number of moves still to play.
     const double moves_left = (lims.movestogo > 0 ? static_cast<double>(lims.movestogo) : 25.0);
@@ -324,11 +333,18 @@ double estimate_move_time(const SearchLimits& lims, bool white_to_move) {
     // Never commit more than a third of what is left to a single move.
     const double max_time = our_time * 0.33;
 
-    return std::max(kMinSearchTime, std::min(base_time, max_time));
+    const double hard =
+        std::max(kMinSearchTime, std::min(base_time * kHardTimeFactor, max_time));
+    const double soft = std::max(kMinSearchTime, std::min(base_time, hard));
+    return {soft, hard};
+}
+
+double estimate_move_time(const SearchLimits& lims, bool white_to_move) {
+    return estimate_time_budget(lims, white_to_move).hard;
 }
 
 double SearchEngine::estimate_max_time(position& p) const {
-    return estimate_move_time(limits_, p.to_move() == white);
+    return estimate_time_budget(limits_, p.to_move() == white).hard;
 }
 
 // ─── Iterative deepening ────────────────────────────────────────────────────
@@ -362,6 +378,12 @@ void SearchEngine::iterative_deepening(position& p, U16 depth, bool silent, int 
     (stack + 2)->pv = pv_line;
 
     bool is_main = (thread_id == 0);
+
+    // Best move of the previous completed iteration, and how many completed
+    // iterations in a row have agreed on it. Only the main thread budgets time,
+    // so only the main thread tracks this.
+    Move prev_best{};
+    int stable_iterations = 0;
 
     for (unsigned id = 1 + static_cast<unsigned>(thread_id); id <= depth; ++id) {
         if (signals_.stop.load())
@@ -459,6 +481,32 @@ void SearchEngine::iterative_deepening(position& p, U16 depth, bool silent, int 
             if (id == depth) {
                 signals_.stop = true;
                 break;
+            }
+
+            // Decide whether another iteration is affordable. The old loop
+            // simply started one and let the timer cut it off partway, which
+            // spends the whole budget on every move however obvious the move
+            // is: an aborted iteration contributes nothing, so that time is
+            // burnt rather than banked.
+            //
+            // The budget is scaled by how settled the root is. A best move that
+            // has survived several iterations is unlikely to be overturned by
+            // one more, so the search leaves early and the saved milliseconds
+            // go back on the clock for a move that needs them; a root that is
+            // still changing its mind buys extra time, bounded by the hard
+            // limit the timer thread enforces.
+            if (soft_limit_ > 0.0 && !p.root_moves.empty()) {
+                const Move best = p.root_moves[0].pv[0];
+                stable_iterations = (best == prev_best) ? stable_iterations + 1 : 0;
+                prev_best = best;
+
+                const double factor =
+                    kSoftTimeUnstable -
+                    kSoftTimeStep * std::min(stable_iterations, kSoftTimeMaxStable);
+                if (search_clock_.elapsed_ms() >= soft_limit_ * factor) {
+                    signals_.stop = true;
+                    break;
+                }
             }
         }
     }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -303,10 +303,11 @@ TimeBudget estimate_time_budget(const SearchLimits& lims, bool white_to_move) {
     if (lims.infinite || lims.ponder || lims.depth > 0)
         return {kNoTimeLimit, kNoTimeLimit};
     if (lims.movetime != 0) {
-        // The GUI asked for exactly this much. There is nothing to ration, so
-        // the soft limit is the hard one and the search runs the clock out.
-        const double t = static_cast<double>(lims.movetime);
-        return {t, t};
+        // The GUI asked for exactly this much, so there is nothing to ration
+        // and no later move to bank the savings for. Leaving a soft limit here
+        // would be actively wrong: the stability scaling would cut a settled
+        // search off at 0.6 of the time the GUI asked it to spend.
+        return {kNoTimeLimit, static_cast<double>(lims.movetime)};
     }
 
     double our_time = (white_to_move ? lims.wtime : lims.btime);
@@ -341,6 +342,18 @@ TimeBudget estimate_time_budget(const SearchLimits& lims, bool white_to_move) {
 
 double estimate_move_time(const SearchLimits& lims, bool white_to_move) {
     return estimate_time_budget(lims, white_to_move).hard;
+}
+
+double soft_time_target(double soft, int stable_iterations) {
+    if (soft <= 0.0)
+        return kNoTimeLimit;
+    const double factor =
+        kSoftTimeUnstable - kSoftTimeStep * std::min(stable_iterations, kSoftTimeMaxStable);
+    // kMinSearchTime is a floor, so it has to survive the scaling. Without this
+    // clamp a settled root turns the 50ms the engine is guaranteed on a spent
+    // clock into 30ms, which is the one situation where the margin is being
+    // relied on.
+    return std::max(kMinSearchTime, soft * factor);
 }
 
 double SearchEngine::estimate_max_time(position& p) const {
@@ -500,10 +513,8 @@ void SearchEngine::iterative_deepening(position& p, U16 depth, bool silent, int 
                 stable_iterations = (best == prev_best) ? stable_iterations + 1 : 0;
                 prev_best = best;
 
-                const double factor =
-                    kSoftTimeUnstable -
-                    kSoftTimeStep * std::min(stable_iterations, kSoftTimeMaxStable);
-                if (search_clock_.elapsed_ms() >= soft_limit_ * factor) {
+                const double target = soft_time_target(soft_limit_, stable_iterations);
+                if (search_clock_.elapsed_ms() >= target) {
                     signals_.stop = true;
                     break;
                 }

--- a/tests/test_search.cpp
+++ b/tests/test_search.cpp
@@ -473,6 +473,72 @@ TEST(TimeManagement, MovetimeIsHonouredExactly) {
     EXPECT_DOUBLE_EQ(estimate_move_time(lims, true), 1234.0);
 }
 
+TEST(TimeManagement, SoftLimitNeverExceedsTheHardOne) {
+    // The soft limit is what the main thread aims at and the hard one is what
+    // the timer enforces. If they ever crossed, the timer would cut the search
+    // off before it had a chance to decide for itself, and the whole point of
+    // the split -- being cheap on an obvious move and generous on a hard one --
+    // would be unreachable.
+    for (int clock : {60, 200, 1000, 10000, 300000}) {
+        for (int inc : {0, 100, 1000, 60000}) {
+            for (int mtg : {0, 1, 5, 40}) {
+                SearchLimits lims{};
+                lims.wtime = clock;
+                lims.winc = inc;
+                lims.movestogo = mtg;
+                const auto b = estimate_time_budget(lims, true);
+                EXPECT_LE(b.soft, b.hard)
+                    << "clock=" << clock << " inc=" << inc << " mtg=" << mtg;
+                EXPECT_LE(b.hard, std::max(kMinSearchTime, clock * 0.33))
+                    << "clock=" << clock << " inc=" << inc << " mtg=" << mtg;
+            }
+        }
+    }
+}
+
+TEST(TimeManagement, TheSoftLimitIsTheBudgetTheEngineUsedToSpendOutright) {
+    // The split did not change what a move is *worth*, only what happens when
+    // the search wants more than that. So the soft limit has to reproduce the
+    // old single budget exactly: clock/25 + 0.9*inc, capped at a third of the
+    // clock and floored at kMinSearchTime.
+    for (int clock : {1000, 10000, 300000}) {
+        for (int inc : {0, 100, 1000}) {
+            SearchLimits lims{};
+            lims.wtime = clock;
+            lims.winc = inc;
+            const double base = clock / 25.0 + inc * 0.9;
+            const double expected = std::max(kMinSearchTime, std::min(base, clock * 0.33));
+            EXPECT_DOUBLE_EQ(estimate_time_budget(lims, true).soft, expected)
+                << "clock=" << clock << " inc=" << inc;
+        }
+    }
+}
+
+TEST(TimeManagement, AHardLimitExistsToBeSpentOnHardMoves) {
+    // A position the engine keeps changing its mind about must be able to buy
+    // real extra time, otherwise the stability scaling has nothing to scale
+    // into. Equally, it must not be able to buy the whole clock.
+    SearchLimits lims{};
+    lims.wtime = 60000;
+    lims.winc = 100;
+    const auto b = estimate_time_budget(lims, true);
+    EXPECT_GT(b.hard, b.soft * 2.0);
+    EXPECT_LT(b.hard, lims.wtime * 0.34);
+}
+
+TEST(TimeManagement, UntimedSearchesHaveNeitherLimit) {
+    for (auto set : {+[](SearchLimits& l) { l.infinite = true; },
+                     +[](SearchLimits& l) { l.ponder = true; },
+                     +[](SearchLimits& l) { l.depth = 12; }}) {
+        SearchLimits lims{};
+        lims.wtime = 60000;
+        set(lims);
+        const auto b = estimate_time_budget(lims, true);
+        EXPECT_DOUBLE_EQ(b.soft, kNoTimeLimit);
+        EXPECT_DOUBLE_EQ(b.hard, kNoTimeLimit);
+    }
+}
+
 
 // ─── Draws that arrive while in check ───────────────────────────────────────
 // The draw test in search() was guarded by !in_check, so a repetition or a

--- a/tests/test_search.cpp
+++ b/tests/test_search.cpp
@@ -471,6 +471,27 @@ TEST(TimeManagement, MovetimeIsHonouredExactly) {
     lims.movetime = 1234;
     lims.wtime = 60000;
     EXPECT_DOUBLE_EQ(estimate_move_time(lims, true), 1234.0);
+
+    // ...and *only* the hard deadline applies. A soft limit here would be
+    // scaled by root stability like any other, so a settled search would stop
+    // at 0.6 * 1234ms and hand back time the GUI explicitly asked it to spend.
+    const auto b = estimate_time_budget(lims, true);
+    EXPECT_DOUBLE_EQ(b.soft, kNoTimeLimit);
+    EXPECT_DOUBLE_EQ(soft_time_target(b.soft, 5), kNoTimeLimit);
+}
+
+TEST(TimeManagement, StabilityScalingNeverBreachesTheFloor) {
+    // A spent clock budgets exactly kMinSearchTime, and that is a floor, not an
+    // aim: it is the least time in which a move can be produced at all. The
+    // stability factor bottoms out at 0.6, so scaling it unguarded would turn
+    // the guarantee into 30ms in the one case that relies on it.
+    for (int stable = 0; stable <= 8; ++stable)
+        EXPECT_GE(soft_time_target(kMinSearchTime, stable), kMinSearchTime) << "stable=" << stable;
+
+    // Above the floor the scaling is live and monotonically decreasing.
+    EXPECT_DOUBLE_EQ(soft_time_target(1000.0, 0), 1000.0 * kSoftTimeUnstable);
+    EXPECT_LT(soft_time_target(1000.0, 5), soft_time_target(1000.0, 0));
+    EXPECT_DOUBLE_EQ(soft_time_target(1000.0, 9), soft_time_target(1000.0, kSoftTimeMaxStable));
 }
 
 TEST(TimeManagement, SoftLimitNeverExceedsTheHardOne) {


### PR DESCRIPTION
## The bug, really

Time management had **one** limit and always spent it. The timer thread cut the search off mid-iteration, and an aborted iteration contributes nothing to the move that gets played — so every move cost the full budget however obvious the move was.

That is visible in the raw numbers. Eight positions at 10+0.1, milliseconds per move:

```
main   501   502   501   501   502    10   501   501     mean 440
```

Flat to within a millisecond, because the timer is the only thing that ever stops it. The engine spent the same on a forced recapture as on a critical middlegame decision.

## The change

The main thread now decides *between iterations* whether another one is affordable; the timer thread only enforces a ceiling.

| limit | value | enforced by |
|---|---|---|
| **soft** | `clock/25 + 0.9*inc`, scaled by root stability | main thread, after each completed iteration |
| **hard** | `min(2.5 x soft, a third of the clock)` | timer thread, as before |

The scale keys on **how many completed iterations in a row have agreed on the best move**. A move that has survived several iterations is unlikely to be overturned by one more, so the search leaves early and banks the time; a root still changing its mind buys more, bounded by the hard limit.

```
soft   460   326   589   558   314    10   472   391     mean 390
```

A 1.9x spread where there was none.

## Result

```
Score of cand vs base: 352 - 229 - 438  [0.560] 1019
Elo difference: 42.1 +/- 16.1, LOS: 100.0 %, DrawRatio: 43.0 %
SPRT: llr 2.96 (100.5%), lbound -2.94, ubound 2.94 - H1 was accepted
```

**H1 accepted at 1019 games** — 10+0.1, concurrency 30, `elo0=0 elo1=5`. Both binaries verified to share codegen flags (`-O3 -DNDEBUG -std=c++20 -march=native`) before the match.

**No time losses and no stalls**: zero occurrences of either in the log. The 29 "No result" games are the ones in flight when the SPRT concluded and cutechess shut down — the count is identical for both players.

A confirmation run at **60+0.6** is in progress; I will post it here. This result is large enough that it deserves checking at a second time control before anyone trusts the number.

## How the 1.10 factor was picked

Swept, not guessed. The unstable-end factor was run at 1.35, 1.25, 1.20, 1.15, 1.10, 1.00 and 0.90, reading mean move time off each:

| factor | 1.35 | 1.25 | 1.20 | 1.15 | 1.10 | 1.00 | 0.90 |
|---|---|---|---|---|---|---|---|
| mean ms | 549 | 535 | 534 | 495 | **390** | 360 | 315 |

1.10 banks about 11% against the old engine rather than front-loading the clock, which is the safer direction — the opening is the cheapest place to be spending extra time. The steps between 1.10 and 1.15 are large because the decision only happens on iteration boundaries.

## Also fixed

The timer thread constructed **its own** clock. That clock starts only once the thread is scheduled, so the setup time it misses is time the engine has already spent and would then overspend by. It now shares the clock `start()` resets.

## Verification

- **Bench 697583**, unchanged — bench is a fixed-depth search, so no time management runs at all.
- **137/137** tests pass, including five new ones pinning the invariants: soft never exceeds hard, hard never exceeds a third of the clock, the soft limit reproduces the old single budget *exactly* (so only the "wants more than a move is worth" path changed), a hard move can really buy extra time, and an untimed search has neither limit.
