### PR TITLE
fix: answer ponderhit, instead of pondering until stdin closes

### DIFF
--- a/include/havoc/search.hpp
+++ b/include/havoc/search.hpp
@@ -98,7 +98,11 @@ double soft_time_target(double soft, int stable_iterations);
 
 struct SearchSignals {
     std::atomic<bool> stop{false};
-    std::atomic<bool> ponder_hit{false};
+    /// True while the current search is a ponder, i.e. the GUI has not yet
+    /// confirmed the move we are assuming. Cleared by ponder_hit(), which is
+    /// what puts the search on a clock. Was previously an atomic named
+    /// ponder_hit that nothing ever read or wrote.
+    std::atomic<bool> ponder{false};
 };
 
 // ─── Forward declarations for move_to_string (used by readout) ──────────────
@@ -115,8 +119,16 @@ class SearchEngine {
     ~SearchEngine();
 
     void start(position& p, const SearchLimits& lims, bool silent);
+    /// The GUI confirms the move the current ponder search assumed. The search
+    /// continues, but from now on it is on the clock.
+    void ponder_hit();
+
     void stop();
     void wait();
+
+    /// True while a search is running. Exposed so a test can tell a ponder
+    /// that is correctly waiting from one that has already given up.
+    [[nodiscard]] bool searching() const { return searching_.load(); }
 
     SearchSignals& signals() { return signals_; }
     hash_table& tt() { return tt_; }
@@ -187,9 +199,22 @@ class SearchEngine {
     /// search would then overspend by exactly that much.
     util::Clock search_clock_{};
 
-    /// The budget the main thread aims at, in milliseconds, or kNoTimeLimit
-    /// when the search is not on a clock. The timer thread owns the hard one.
-    double soft_limit_ = kNoTimeLimit;
+    /// The two budgets, as *durations* in milliseconds, or kNoTimeLimit when
+    /// the search is not on a clock. Atomic because ponderhit rewrites them
+    /// from the UCI thread while the search is running.
+    std::atomic<double> soft_limit_{kNoTimeLimit};
+    std::atomic<double> hard_limit_{kNoTimeLimit};
+
+    /// Milliseconds on search_clock_ at which the budgets start counting.
+    /// Zero for an ordinary search; on ponderhit it moves to "now", because the
+    /// time spent pondering was free -- the GUI's clock only started then.
+    /// Moving an origin rather than resetting the clock leaves the clock
+    /// immutable while the search threads are reading it.
+    std::atomic<double> time_origin_{0.0};
+
+    /// Side to move for the search in progress, captured at start(), so that
+    /// ponderhit can re-budget without the position.
+    bool stm_is_white_ = true;
 
     void search_timer(position& p);
     double estimate_max_time(position& p) const;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -188,7 +188,14 @@ void SearchEngine::start(position& p, const SearchLimits& lims, bool silent) {
 
     U16 depth = (lims.depth > 0 ? static_cast<U16>(lims.depth) : static_cast<U16>(MAX_PLY));
     search_clock_.reset();
-    soft_limit_ = estimate_time_budget(limits_, p.to_move() == white).soft;
+    stm_is_white_ = (p.to_move() == white);
+    const TimeBudget budget = estimate_time_budget(limits_, stm_is_white_);
+    // Origin before limits, as in ponder_hit(): readers pair a limit they have
+    // acquired with the origin, so the origin must never be the newer of the two.
+    time_origin_.store(0.0, std::memory_order_relaxed);
+    soft_limit_.store(budget.soft, std::memory_order_release);
+    hard_limit_.store(budget.hard, std::memory_order_release);
+    signals_.ponder.store(limits_.ponder);
     searching_ = true;
 
     // Launch the entire search on the worker thread so UCI loop stays responsive.
@@ -275,37 +282,54 @@ void SearchEngine::wait() {
 
 // ─── Timer ──────────────────────────────────────────────────────────────────
 
-void SearchEngine::search_timer(position& p) {
+void SearchEngine::search_timer(position&) {
     // Deliberately the clock start() reset, not a fresh one: a local clock here
     // starts only once this thread is scheduled, so the setup it misses is time
     // the engine has already spent and would then overspend by.
     const util::Clock& c = search_clock_;
-    bool fixed_time = limits_.movetime > 0;
-    int delay = 1;
-    double time_limit = estimate_max_time(p);
-    auto sleep = [delay]() {
-        std::this_thread::sleep_for(std::chrono::milliseconds(delay));
-    };
 
-    double elapsed = 0;
-    if (fixed_time) {
-        do {
-            elapsed = c.elapsed_ms();
-            sleep();
-        } while (!signals_.stop.load() && searching_.load() &&
-                 elapsed <= static_cast<double>(limits_.movetime));
-    } else if (time_limit > -1) {
-        do {
-            elapsed = c.elapsed_ms();
-            sleep();
-        } while (!signals_.stop.load() && searching_.load() && elapsed <= time_limit);
-    } else {
-        do {
-            elapsed = c.elapsed_ms();
-            sleep();
-        } while (!signals_.stop.load() && searching_.load());
+    // The deadline is re-read every poll rather than captured once, because
+    // ponderhit moves it: a search that began as a ponder has no deadline at
+    // all until the GUI says the guess was right. The three near-identical
+    // loops this replaces each captured their limit up front, so nothing the
+    // GUI said afterwards could be heard.
+    while (!signals_.stop.load() && searching_.load()) {
+        const double limit = hard_limit_.load(std::memory_order_acquire);
+        const double origin = time_origin_.load(std::memory_order_relaxed);
+        if (limit > kNoTimeLimit && c.elapsed_ms() - origin > limit)
+            break;
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
     signals_.stop = true;
+}
+
+void SearchEngine::ponder_hit() {
+    // The GUI played the move we guessed, so the search continues -- but it is
+    // now on the clock, and was not a moment ago. Without this the engine
+    // pondered on until stdin closed: measured at 20+ seconds of thinking on a
+    // 2 second clock, which is a loss on time in every game a GUI ponders.
+    if (!signals_.ponder.exchange(false))
+        return;
+
+    limits_.ponder = false;
+    const TimeBudget b = estimate_time_budget(limits_, stm_is_white_);
+
+    // Time spent pondering was free -- the GUI's clock only started now -- so
+    // the budget runs from this instant. Moving the origin rather than
+    // resetting the clock keeps the clock immutable while search threads read
+    // it, and keeps the budgets as durations, which is what the stability
+    // factor in iterative_deepening multiplies.
+    //
+    // The three are a tuple, and readers must not see it half-updated. A fresh
+    // limit paired with the old origin (0) would charge the whole ponder to
+    // this move and stop the search on the spot, so the origin is published
+    // first and the limits with release; readers acquire the limit and then
+    // read the origin. The reverse pairing -- old limit, new origin -- is what
+    // remains, and is harmless: the old limit is kNoTimeLimit, so the timer
+    // simply has no deadline for the 1 ms until its next poll.
+    time_origin_.store(search_clock_.elapsed_ms(), std::memory_order_relaxed);
+    soft_limit_.store(b.soft, std::memory_order_release);
+    hard_limit_.store(b.hard, std::memory_order_release);
 }
 
 TimeBudget estimate_time_budget(const SearchLimits& lims, bool white_to_move) {
@@ -517,13 +541,18 @@ void SearchEngine::iterative_deepening(position& p, U16 depth, bool silent, int 
             // go back on the clock for a move that needs them; a root that is
             // still changing its mind buys extra time, bounded by the hard
             // limit the timer thread enforces.
-            if (soft_limit_ > 0.0 && !p.root_moves.empty()) {
+            // `soft_limit_` is loaded with acquire and `time_origin_` after it,
+            // so a fresh limit is never paired with a stale origin -- see
+            // ponder_hit(), which publishes the two together.
+            const double soft = soft_limit_.load(std::memory_order_acquire);
+            if (soft > 0.0 && !p.root_moves.empty()) {
                 const Move best = p.root_moves[0].pv[0];
                 stable_iterations = (best == prev_best) ? stable_iterations + 1 : 0;
                 prev_best = best;
 
-                const double target = soft_time_target(soft_limit_, stable_iterations);
-                if (search_clock_.elapsed_ms() >= target) {
+                const double target = soft_time_target(soft, stable_iterations);
+                const double origin = time_origin_.load(std::memory_order_relaxed);
+                if (search_clock_.elapsed_ms() - origin >= target) {
                     signals_.stop = true;
                     break;
                 }

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -173,6 +173,11 @@ bool parse_command(const std::string& input, SearchEngine& engine, position& uci
             engine.start(uci_pos, lims, silent);
         } else if (cmd == "stop") {
             engine.stop();
+        } else if (cmd == "ponderhit") {
+            // The GUI played the move the ponder search assumed. Keep
+            // searching, but start charging it to the clock. Without this the
+            // engine pondered on until stdin closed and lost on time.
+            engine.ponder_hit();
         } else if (cmd == "moves") {
             Movegen mvs(uci_pos);
             mvs.generate<pseudo_legal, pieces>();

--- a/tests/test_search.cpp
+++ b/tests/test_search.cpp
@@ -16,6 +16,8 @@
 #include <limits>
 #include <utility>
 #include <set>
+#include <chrono>
+#include <thread>
 
 #include "mirror.hpp"
 
@@ -547,8 +549,71 @@ TEST(TimeManagement, AHardLimitExistsToBeSpentOnHardMoves) {
     EXPECT_LT(b.hard, lims.wtime * 0.34);
 }
 
-TEST(TimeManagement, UntimedSearchesHaveNeitherLimit) {
-    for (auto set : {+[](SearchLimits& l) { l.infinite = true; },
+TEST_F(SearchTest, PonderhitPutsTheSearchOnTheClock) {
+    // A ponder search has no deadline: the GUI has not yet confirmed the move
+    // it assumes, and the engine's clock is not running. When ponderhit says
+    // the guess was right, the search must keep going *and* start charging
+    // itself for the time.
+    //
+    // Before this existed, nothing in the engine read the word: the search ran
+    // until stdin closed. Measured against a 2-second clock, that was 20+
+    // seconds of thinking, which is a lost game every time a GUI ponders.
+    auto pos = make_pos("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+
+    SearchEngine engine;
+    SearchLimits lims{};
+    lims.wtime = 2000;
+    lims.btime = 2000;
+    lims.winc = 100;
+    lims.binc = 100;
+    lims.ponder = true;
+
+    const auto t0 = std::chrono::steady_clock::now();
+    engine.start(pos, lims, /*silent=*/true);
+
+    // Let it settle into the ponder, and confirm it has *not* stopped: an
+    // engine that finished here would be answering the GUI before the GUI has
+    // committed to anything.
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    EXPECT_TRUE(engine.searching()) << "a ponder search must not stop on its own";
+
+    engine.ponder_hit();
+
+    // Poll rather than wait(). An engine that ignores ponderhit never stops, so
+    // wait() would hang the whole suite instead of failing this one test --
+    // which is how the bug behaved: it searched until stdin closed. A test that
+    // hangs CI is worse than a test that fails it.
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (engine.searching() && std::chrono::steady_clock::now() < deadline)
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+
+    const bool stopped_itself = !engine.searching();
+    if (!stopped_itself) {
+        engine.stop();
+        engine.wait();
+    }
+
+    const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                        std::chrono::steady_clock::now() - t0)
+                        .count();
+
+    EXPECT_TRUE(stopped_itself) << "ponderhit did not put the search on a clock";
+    // The hard limit for a 2s clock is min(2.5 x (2000/25 + 90), 660) = 425 ms,
+    // and the 300 ms ponder before it was free. Generous upper bound so a
+    // loaded CI machine does not fail this, but far below "never stops".
+    EXPECT_LT(ms, 5000) << "took " << ms << " ms";
+    EXPECT_FALSE(pos.root_moves.empty());
+}
+
+TEST_F(SearchTest, PonderhitOnAnIdleEngineIsHarmless) {
+    // GUIs do send it spuriously, and the UCI layer forwards whatever arrives.
+    SearchEngine engine;
+    engine.ponder_hit();
+    engine.ponder_hit();
+    SUCCEED();
+}
+
+TEST(TimeManagement, UntimedSearchesHaveNeitherLimit) {    for (auto set : {+[](SearchLimits& l) { l.infinite = true; },
                      +[](SearchLimits& l) { l.ponder = true; },
                      +[](SearchLimits& l) { l.depth = 12; }}) {
         SearchLimits lims{};


### PR DESCRIPTION
> **Stacks on #91.** The diff is against `feat/soft-time-limit`; merge #91 first.

## The bug

The UCI loop parses `go ponder`, and the engine emits `bestmove X ponder Y`. But **nothing anywhere reads the word `ponderhit`**. `SearchSignals` carried an atomic called `ponder_hit` that was never read or written — the feature was declared and never built.

A ponder search deliberately has no deadline: the GUI has not confirmed the move being assumed, and the engine's clock is not running. So when the GUI said the guess was right, the search just carried on.

```
main: NO bestmove within 15s of ponderhit  (engine ignored it)
this: bestmove 0.43s after ponderhit -> bestmove e2e4 ponder e7e5
```

Against a 2-second clock, `main` produced no move within 15 seconds of `ponderhit` and only moved when stdin closed, at 23 seconds. **Any GUI that ponders wins every game on time.**

`Ponder` is not in the `uci` handshake, so conforming GUIs will not have hit this. But the engine accepts the command *and* advertises a ponder move, which makes it a landmine rather than a missing feature.

## The fix

`ponder_hit()` clears the ponder flag, re-budgets, and moves the **origin** the budgets count from to now — time spent pondering was free, because the GUI's clock only started at `ponderhit`.

Moving an origin rather than resetting the clock does two things: it leaves the clock immutable while the search threads are reading it, and it keeps the budgets as *durations*, which is what the stability factor from #91 multiplies.

The timer thread now re-reads its deadline every poll instead of capturing it once. **That is what makes `ponderhit` audible at all** — the three near-identical loops it replaces each captured their limit up front, so nothing the GUI said afterwards could be heard. The three collapse into one, since a fixed `movetime` is now just a budget like any other.

## The test is a real negative control

It **polls rather than calling `wait()`**. An engine that ignores `ponderhit` never stops, so `wait()` would hang the entire suite instead of failing one test — which is exactly how the bug behaved. A test that hangs CI is worse than one that fails it.

Verified by stubbing `ponder_hit()` out and re-running: the test **fails in 5.4 s**, rather than passing or hanging.

A second test checks that a spurious `ponderhit` on an idle engine is harmless, since GUIs do send them and the UCI layer forwards whatever arrives.

## Verification

- **Bench 697583**, unchanged.
- **139/139** tests pass.
