### PR TITLE
fix: enforce "go nodes" and "go mate", which searched forever

### DIFF
--- a/include/havoc/search.hpp
+++ b/include/havoc/search.hpp
@@ -212,6 +212,12 @@ class SearchEngine {
     /// immutable while the search threads are reading it.
     std::atomic<double> time_origin_{0.0};
 
+    /// Node ceiling from "go nodes N", or zero when unlimited. Checked inside
+    /// search() rather than on the timer thread: a node limit is asked for
+    /// precisely when a reproducible amount of work is wanted, so it must not
+    /// depend on how fast the machine is.
+    std::atomic<U64> node_limit_{0};
+
     /// Side to move for the search in progress, captured at start(), so that
     /// ponderhit can re-budget without the position.
     bool stm_is_white_ = true;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -186,7 +186,16 @@ void SearchEngine::start(position& p, const SearchLimits& lims, bool silent) {
     }
     completed_depth_.assign(search_threads_.size(), 0);
 
-    U16 depth = (lims.depth > 0 ? static_cast<U16>(lims.depth) : static_cast<U16>(MAX_PLY));
+    // "go mate N" asks for a mate in N moves, so there is no point looking
+    // beyond the 2N-1 plies one can occupy -- and without a bound the search
+    // never returned at all, since a mate search carries no clock. An explicit
+    // "depth" still wins, because it is the more specific request.
+    U16 depth = static_cast<U16>(MAX_PLY);
+    if (lims.depth > 0)
+        depth = static_cast<U16>(lims.depth);
+    else if (lims.mate > 0)
+        depth = static_cast<U16>(std::min(2 * lims.mate - 1, static_cast<int>(MAX_PLY)));
+
     search_clock_.reset();
     stm_is_white_ = (p.to_move() == white);
     const TimeBudget budget = estimate_time_budget(limits_, stm_is_white_);
@@ -195,6 +204,8 @@ void SearchEngine::start(position& p, const SearchLimits& lims, bool silent) {
     time_origin_.store(0.0, std::memory_order_relaxed);
     soft_limit_.store(budget.soft, std::memory_order_release);
     hard_limit_.store(budget.hard, std::memory_order_release);
+    node_limit_.store(lims.nodes > 0 ? static_cast<U64>(lims.nodes) : 0,
+                      std::memory_order_relaxed);
     signals_.ponder.store(limits_.ponder);
     searching_ = true;
 
@@ -529,6 +540,14 @@ void SearchEngine::iterative_deepening(position& p, U16 depth, bool silent, int 
                 break;
             }
 
+            // "go mate N" is answered as soon as a mate at most N moves away
+            // is proven; deepening past it only re-proves the same thing.
+            if (limits_.mate > 0 && eval >= score::kMateMaxPly &&
+                (score::kMate - eval + 1) / 2 <= limits_.mate) {
+                signals_.stop = true;
+                break;
+            }
+
             // Decide whether another iteration is affordable. The old loop
             // simply started one and let the timer cut it off partway, which
             // spends the whole budget on every move however obvious the move
@@ -568,6 +587,18 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
                          int thread_id) {
     if (signals_.stop.load())
         return score::kDraw;
+
+    // "go nodes N" was parsed and then never enforced, so it searched forever.
+    // The count is checked here rather than on the timer thread because a
+    // node limit is meant to be reproducible: a deadline that depends on how
+    // fast the machine happens to be would defeat the point of asking for one.
+    // The 1023-node stride keeps the cross-thread sum off the hot path while
+    // staying exact enough to be worth asking for.
+    const U64 node_limit = node_limit_.load(std::memory_order_relaxed);
+    if (node_limit > 0 && (pos.nodes() & 1023) == 0 && total_nodes() >= node_limit) {
+        signals_.stop = true;
+        return score::kDraw;
+    }
 
     assert(alpha < beta);
 

--- a/tests/test_search.cpp
+++ b/tests/test_search.cpp
@@ -613,6 +613,113 @@ TEST_F(SearchTest, PonderhitOnAnIdleEngineIsHarmless) {
     SUCCEED();
 }
 
+TEST_F(SearchTest, NodeLimitStopsTheSearch) {
+    // "go nodes N" was parsed into SearchLimits and then read by nothing at
+    // all, exactly as ponderhit was: the limit carries no clock, so the search
+    // ran until stdin closed.
+    auto pos = make_pos("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1");
+
+    SearchEngine engine;
+    SearchLimits lims{};
+    lims.nodes = 20000;
+
+    // Poll rather than wait(): an unenforced node limit never returns, and a
+    // test that hangs the suite is worse than one that fails it. The deadline
+    // is generous because the sanitiser build runs an order of magnitude slower
+    // than Release -- at 200000 nodes and 10 seconds this failed there while
+    // passing everywhere else, which is a flaky test, not a finding.
+    engine.start(pos, lims, /*silent=*/true);
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(60);
+    while (engine.searching() && std::chrono::steady_clock::now() < deadline)
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+
+    const bool stopped_itself = !engine.searching();
+    if (!stopped_itself) {
+        engine.stop();
+        engine.wait();
+    }
+    ASSERT_TRUE(stopped_itself) << "the node limit was never enforced";
+
+    // The stride the check runs on is 1024 nodes per thread, and an iteration
+    // is abandoned rather than rewound, so the count lands just past the limit
+    // rather than exactly on it. What must not happen is running far past it.
+    const U64 n = engine.total_nodes();
+    EXPECT_GE(n, 1000u) << "stopped so early the limit cannot have been the reason";
+    EXPECT_LT(n, lims.nodes * 2u) << "overran the node limit: " << n;
+    EXPECT_FALSE(pos.root_moves.empty());
+}
+
+TEST_F(SearchTest, ALargerNodeLimitBuysMoreSearch) {
+    // The limit has to actually scale the work, not merely terminate it.
+    auto small = make_pos("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1");
+    auto large = make_pos("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1");
+
+    auto run = [](position& p, int limit) {
+        SearchEngine engine;
+        SearchLimits lims{};
+        lims.nodes = limit;
+        engine.start(p, lims, /*silent=*/true);
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(60);
+        while (engine.searching() && std::chrono::steady_clock::now() < deadline)
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        if (engine.searching()) {
+            engine.stop();
+            engine.wait();
+        }
+        return engine.total_nodes();
+    };
+
+    EXPECT_LT(run(small, 10000), run(large, 100000));
+}
+
+TEST_F(SearchTest, MateSearchTerminates) {
+    // "go mate N" was the third limit that parsed and did nothing. Bounding the
+    // depth at 2N-1 plies is what makes it return; finding the mate sooner is
+    // what makes it return quickly. This is a mate in two.
+    auto pos = make_pos("6k1/5ppp/8/8/8/8/5PPP/R5K1 w - - 0 1");
+
+    SearchEngine engine;
+    SearchLimits lims{};
+    lims.mate = 2;
+
+    engine.start(pos, lims, /*silent=*/true);
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    while (engine.searching() && std::chrono::steady_clock::now() < deadline)
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+
+    const bool stopped_itself = !engine.searching();
+    if (!stopped_itself) {
+        engine.stop();
+        engine.wait();
+    }
+    EXPECT_TRUE(stopped_itself) << "go mate never returned";
+    EXPECT_FALSE(pos.root_moves.empty());
+}
+
+TEST_F(SearchTest, MateSearchTerminatesWhenThereIsNoMate) {
+    // The case that rests entirely on the 2N-1 depth bound. Stopping early on a
+    // proven mate covers the position above, but a "go mate" that finds nothing
+    // has no such exit and is the one that hung -- a mate search carries no
+    // clock, so without the bound there is nothing left to end it.
+    auto pos = make_pos("4k3/8/8/8/8/8/4P3/4K3 w - - 0 1");
+
+    SearchEngine engine;
+    SearchLimits lims{};
+    lims.mate = 3;
+
+    engine.start(pos, lims, /*silent=*/true);
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    while (engine.searching() && std::chrono::steady_clock::now() < deadline)
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+
+    const bool stopped_itself = !engine.searching();
+    if (!stopped_itself) {
+        engine.stop();
+        engine.wait();
+    }
+    EXPECT_TRUE(stopped_itself) << "go mate ran past its depth bound";
+}
+
 TEST(TimeManagement, UntimedSearchesHaveNeitherLimit) {    for (auto set : {+[](SearchLimits& l) { l.infinite = true; },
                      +[](SearchLimits& l) { l.ponder = true; },
                      +[](SearchLimits& l) { l.depth = 12; }}) {


### PR DESCRIPTION
Stacks on #92 (which stacks on #91). Review the top commit only; merge after those.

`go nodes N` and `go mate N` were both parsed into `SearchLimits` and then read by nothing at all — the same shape as the `ponderhit` bug in #92, and with the same consequence. Neither limit implies a clock, so `estimate_time_budget` returns `kNoTimeLimit` for them, and there was nothing else left to end the search. Measured on this branch's parent:

```
go nodes 1000  ->  NO bestmove within 8s
go mate 3      ->  NO bestmove within 8s
```

Both now answer immediately.

### Node limits are checked in the search, not on the timer thread

A node limit is asked for precisely when a *reproducible* amount of work is wanted, so stopping on a poll whose timing depends on machine load would defeat the reason for asking. The check runs on a 1023-node stride to keep the cross-thread sum off the hot path, and is guarded by the limit being set at all, so an ordinary search does not pay for it — bench is 697583 either way and nps is unchanged within noise.

Single-threaded it is now exactly repeatable. Five runs of `go nodes 300000` on Kiwipete:

| run | depth | nodes | bestmove |
|---|---|---|---|
| 1–5 | 11 | 279538 | e2a6 ponder b4c3 |

...and a larger ceiling monotonically buys more search:

| limit | depth reached |
|---|---|
| 50000 | 9 |
| 400000 | 11 |
| 1600000 | 13 |

That makes node-limited matches usable as a **load-immune alternative to time control**, which is worth having on a box where one SPRT already saturates every core.

### `go mate N`

Bounds the depth at the 2N-1 plies such a mate can occupy, and stops as soon as a mate at most N moves away is proven. An explicit `depth` still wins, being the more specific request.

### Testing

144 tests pass, bench **697583** unchanged.

Four new tests, each verified as a negative control by stubbing its fix out individually. That is how the first version of the mate test was caught passing on the early exit while the depth bound was disabled — the no-mate-exists case is the one that rests on the bound alone:

| stubbed out | tests that fail |
|---|---|
| node limit check | `NodeLimitStopsTheSearch`, `ALargerNodeLimitBuysMoreSearch` |
| mate depth bound | `MateSearchTerminatesWhenThereIsNoMate` |

All four poll with a deadline rather than calling `wait()`: the bug being fixed is an infinite search, and a test that hangs CI is worse than one that fails it.

No effect on game play — neither limit is set in a normal game, and bench is bit-identical.