### PR TITLE
fix: answer "go" on a mated or stalemated position

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -272,11 +272,21 @@ void SearchEngine::start(position& p, const SearchLimits& lims, bool silent) {
         // Copy results back to the original position
         p.root_moves = bestRoots;
 
-        if (!silent && !bestRoots.empty()) {
-            std::cout << "bestmove " << uci::move_to_string(bestRoots[0].pv[0]);
-            if (bestRoots[0].pv.size() > 1)
-                std::cout << " ponder " << uci::move_to_string(bestRoots[0].pv[1]);
-            std::cout << std::endl;
+        if (!silent) {
+            // Every "go" must be answered. Checkmate and stalemate leave no
+            // root move, and saying nothing at all left the GUI waiting on a
+            // reply that was never coming -- an unbounded hang on any terminal
+            // position, which is exactly what an analysis GUI sends when it
+            // reaches the end of a game. "(none)" is the established way to
+            // say there is no move.
+            if (bestRoots.empty() || bestRoots[0].pv.empty()) {
+                std::cout << "bestmove (none)" << std::endl;
+            } else {
+                std::cout << "bestmove " << uci::move_to_string(bestRoots[0].pv[0]);
+                if (bestRoots[0].pv.size() > 1)
+                    std::cout << " ponder " << uci::move_to_string(bestRoots[0].pv[1]);
+                std::cout << std::endl;
+            }
         }
 
         searching_ = false;

--- a/tests/test_search.cpp
+++ b/tests/test_search.cpp
@@ -1242,5 +1242,36 @@ TEST_F(SearchTest, SetThreadsClampsToTheAdvertisedRange) {
     EXPECT_EQ(engine.threads(), 1u);
 }
 
+TEST_F(SearchTest, TerminalPositionsStillAnswerWithBestmove) {
+    // A "go" on a position with no legal move produced no output at all: the
+    // emission was guarded on the root move list being non-empty, so checkmate
+    // and stalemate silently swallowed the reply and left the GUI waiting on
+    // one that was never coming. That is an unbounded hang, and reaching the
+    // end of a game is exactly when an analysis GUI asks.
+    for (const auto& [name, fen] : std::vector<std::pair<std::string, std::string>>{
+             {"checkmate", "7k/5KQ1/8/8/8/8/8/8 b - - 0 1"},
+             {"stalemate", "7k/5Q2/6K1/8/8/8/8/8 b - - 0 1"}}) {
+        auto pos = make_pos(fen);
+
+        SearchLimits lims{};
+        lims.wtime = 1000;
+        lims.btime = 1000;
+
+        // The reply goes to stdout, which is the thing under test, so capture
+        // it rather than running the search silently.
+        std::ostringstream captured;
+        std::streambuf* saved = std::cout.rdbuf(captured.rdbuf());
+        {
+            SearchEngine engine;
+            engine.start(pos, lims, /*silent=*/false);
+            engine.wait();
+        }
+        std::cout.rdbuf(saved);
+
+        EXPECT_NE(captured.str().find("bestmove"), std::string::npos)
+            << name << " produced no bestmove at all: \"" << captured.str() << "\"";
+    }
+}
+
 } // namespace
 } // namespace havoc


### PR DESCRIPTION
Branches from `main` and is independent of the #91/#92/#93 stack — mergeable on its own, at any point.

The bestmove line was emitted under `!silent && !bestRoots.empty()`, so a position with no legal move produced **no output whatsoever**. The search itself finished normally; the reply was simply swallowed, and the GUI sat waiting on one that was never coming.

```
before: go on 7k/5KQ1/8/8/8/8/8/8 b   (checkmate)  -> NO bestmove within 6s
        go on 7k/5Q2/6K1/8/8/8/8/8 b  (stalemate)  -> NO bestmove within 6s
after:  bestmove (none) for both
```

Every `go` has to be answered, and reaching the end of a game is exactly when an analysis GUI asks. `(none)` is the established way to say there is no move.

The same line indexed `bestRoots[0].pv[0]` having only checked that `bestRoots` was non-empty, so a root move carrying an empty pv would have read off the end of it. Both are guarded now.

### Testing

134/134, bench **697583** unchanged — normal positions are untouched (`bestmove b1c3 ponder d7d5` from the start position, as before).

Verified as a negative control: reverting `src/search.cpp` alone, keeping the test, fails with

```
checkmate produced no bestmove at all: ""
stalemate produced no bestmove at all: ""
```

Found while probing UCI conformance after #92 and #93, which are the same shape of bug: a command the engine accepts and then never replies to.