### PR TITLE
fix: crash when a UCI command rewrites state the search is using

### DIFF
--- a/include/havoc/search.hpp
+++ b/include/havoc/search.hpp
@@ -126,8 +126,10 @@ class SearchEngine {
     void stop();
     void wait();
 
-    /// True while a search is running. Exposed so a test can tell a ponder
-    /// that is correctly waiting from one that has already given up.
+    /// True while a search is running. stop() only raises a flag, so this is
+    /// how a caller tells that the search threads have actually finished with
+    /// the position and the table; it also lets a test tell a ponder that is
+    /// correctly waiting from one that has already given up.
     [[nodiscard]] bool searching() const { return searching_.load(); }
 
     SearchSignals& signals() { return signals_; }

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -54,10 +54,31 @@ bool parse_command(const std::string& input, SearchEngine& engine, position& uci
     std::string cmd;
     bool running = true;
 
+    // Anything that rewrites state the search is reading has to wait for the
+    // search to be over first. "stop" only raises a flag and returns, so a GUI
+    // that sends "stop" and then sets up the next position -- which is what a
+    // GUI does -- was racing the search threads on their way out.
+    //
+    // Two of these were hard crashes rather than theory. "setoption name Hash"
+    // reallocates the table the search threads are reading, and "setoption name
+    // Threads" reallocates the pool the running threads live in; both segfault
+    // reproducibly in a plain release build. ThreadSanitizer also reports
+    // "position" and "ucinewgame" tearing the position and the table out from
+    // under the search.
+    //
+    // Waiting rather than refusing: a GUI that has moved on to the next
+    // position has no use for the answer to the old one, so there is nothing to
+    // preserve by declining.
+    auto settle = [&engine]() {
+        engine.stop();
+        engine.wait();
+    };
+
     while (instream >> std::skipws >> cmd) {
         std::transform(cmd.begin(), cmd.end(), cmd.begin(), ::tolower);
 
         if (cmd == "position" && instream >> cmd) {
+            settle();
             std::string tmp;
             if (cmd == "startpos") {
                 std::getline(instream, tmp);
@@ -85,6 +106,7 @@ bool parse_command(const std::string& input, SearchEngine& engine, position& uci
                 }
             }
         } else if (cmd == "setoption" && instream >> cmd && instream >> cmd) {
+            settle();
             std::transform(cmd.begin(), cmd.end(), cmd.begin(), ::tolower);
             if (cmd == "hash" && instream >> cmd && instream >> cmd) {
                 int sz = 0;
@@ -131,7 +153,10 @@ bool parse_command(const std::string& input, SearchEngine& engine, position& uci
         } else if (cmd == "isready") {
             std::cout << "readyok" << std::endl;
         } else if (cmd == "go") {
-            engine.wait(); // ensure any prior search is done
+            // A new "go" supersedes whatever is running. Plain wait() hung here
+            // forever if the previous search was "go infinite" or a ponder the GUI
+            // never resolved.
+            settle();
             SearchLimits lims{};
             // GUIs are not always well behaved: they can report a negative
             // clock when an engine has overstepped, and a malformed token
@@ -188,9 +213,11 @@ bool parse_command(const std::string& input, SearchEngine& engine, position& uci
             }
             std::cout << std::endl;
         } else if (cmd == "ucinewgame") {
+            settle();
             engine.clear();
             uci_pos.clear();
         } else if (cmd == "uci") {
+            settle();
             engine.clear();
             uci_pos.clear();
             std::cout << "id name " << ENGINE_NAME << " " << VERSION_STRING << std::endl;
@@ -204,6 +231,7 @@ bool parse_command(const std::string& input, SearchEngine& engine, position& uci
             std::cout << "option name ParamFile type string default <empty>" << std::endl;
             std::cout << "uciok" << std::endl;
         } else if (cmd == "bench") {
+            settle();
             static const std::vector<std::string> bench_fens = {
                 "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
                 "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",

--- a/tests/test_search.cpp
+++ b/tests/test_search.cpp
@@ -1270,6 +1270,52 @@ TEST_F(SearchTest, TerminalPositionsStillAnswerWithBestmove) {
 
         EXPECT_NE(captured.str().find("bestmove"), std::string::npos)
             << name << " produced no bestmove at all: \"" << captured.str() << "\"";
+}
+
+TEST_F(SearchTest, StateChangingCommandsWaitForTheSearch) {
+    // "stop" only raises a flag and returns, so a GUI that stops and then sets
+    // up the next position -- which is what a GUI does -- was rewriting state
+    // the search threads were still reading.
+    //
+    // Two of these were reproducible segfaults in a plain release build, not
+    // merely theory: "setoption name Hash" reallocates the table the search is
+    // reading, and "setoption name Threads" reallocates the pool the running
+    // threads live in. ThreadSanitizer additionally reported "position" and
+    // "ucinewgame" tearing the position and table out from under the search --
+    // ~2600 and ~3200 reports against a 6-report baseline for an undisturbed
+    // search, the baseline being the intentional lockless races in the table.
+    //
+    // Asserting the search has actually finished is what pins it. Relying on
+    // the crash would mean a test that takes the whole suite down with it, and
+    // would say nothing at all on the runs where the race happened to be lost.
+    for (const std::string& command : {std::string("position startpos moves e2e4"),
+                                       std::string("ucinewgame"),
+                                       std::string("setoption name Hash value 8"),
+                                       std::string("setoption name Threads value 2"),
+                                       std::string("go depth 4")}) {
+        auto pos = make_pos("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1");
+
+        SearchEngine engine;
+        SearchLimits lims{};
+        lims.infinite = true;
+
+        engine.start(pos, lims, /*silent=*/true);
+        std::this_thread::sleep_for(std::chrono::milliseconds(120));
+        ASSERT_TRUE(engine.searching()) << "an infinite search should still be running";
+
+        auto scratch = make_pos("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+        uci::parse_command(command, engine, scratch);
+
+        // "go" starts a fresh search of its own, so it is finished rather than
+        // idle that matters; the others must leave the engine idle outright.
+        if (command.rfind("go", 0) == 0)
+            engine.wait();
+
+        EXPECT_FALSE(engine.searching())
+            << '"' << command << "\" returned while the search was still running";
+
+        engine.stop();
+        engine.wait();
     }
 }
 


### PR DESCRIPTION
Branches from `main`, independent of the #91/#92/#93 stack and of #94. **Two reproducible segfaults on `main`.**

`stop` only raises a flag and returns. A GUI that stops and then sets up the next position — which is exactly what a GUI does — was therefore rewriting state the search threads were still reading.

### The crashes

Plain Release build of `main`, 4 threads, command sent 250 ms into a search:

| command during a search | `main` | this PR |
|---|---|---|
| `setoption name Hash value 64` | **SIGSEGV** | ok |
| `setoption name Threads value 3` | **SIGSEGV** | ok |
| `position startpos moves e2e4` | ok | ok |
| `ucinewgame` | ok | ok |

The first reallocates the table the search threads are reading; the second reallocates the pool the running threads live in. Both are use-after-free.

### The rest, under ThreadSanitizer

`main` has no TSan configuration, so this was built by hand (`-fsanitize=thread`, and `setarch -R` to get past the `mmap_rnd_bits` mapping failure on this kernel).

An undisturbed two-thread search reports **6** races — the intentional lockless races in the transposition table, which are by design. That is the baseline. Against it:

| command during a search | `main` | this PR |
|---|---|---|
| baseline (search + `stop` only) | 6 | 6 |
| `position` | **2575** | 6 |
| `ucinewgame` | **3203** | 7 |
| `setoption name Hash` | 1 | 7 |
| `setoption name Threads` | 5 | 6 |

The reads land in `hash_table::fetch` and `position::to_move` while the UCI thread is inside `position::clear`.

### The fix

Every command that rewrites engine or position state — `position`, `setoption`, `ucinewgame`, `uci`, `bench`, `go` — stops and waits for an in-flight search first. Waiting rather than refusing: a GUI that has moved on has no use for the answer to the old position, so there is nothing to preserve by declining.

`go` gets the same treatment, which also removes a hang. It called `wait()` without `stop()`, so a `go` issued while a previous `go infinite` or an unresolved ponder was still running waited for a search that had no reason to ever end.

### Testing

134/134, bench **697583** unchanged.

The test asserts the engine is idle after each command rather than relying on the crash — a crashing test takes the whole suite down with it, and says nothing at all on the runs where the race happens to be lost. Verified as a negative control by reverting `src/uci.cpp` alone:

```
"position startpos moves e2e4" returned while the search was still running
"ucinewgame" returned while the search was still running
```

Adds a `searching()` accessor. #92 adds an identical one; whichever lands second drops it.

> Worth considering separately: there is no TSan build in CI, and it found this in one run.