### PR TITLE
fix: accept upper-case promotions and report unplayable moves

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -286,15 +286,36 @@ void load_position(const std::string& pos, position& uci_pos) {
 
     ss >> token; // eat "moves" token
     while (ss >> token) {
+        // Promotions are compared against move_to_string, which spells the
+        // piece in lower case. A GUI that sends "a7a8Q" is not wrong -- the
+        // case of the promotion letter is a long-standing interop wart -- and
+        // matching it exactly meant the move was quietly dropped.
+        std::transform(token.begin(), token.end(), token.begin(),
+                       [](unsigned char c) { return static_cast<char>(::tolower(c)); });
+
         Movegen mvs(uci_pos);
         mvs.generate<pseudo_legal, pieces>();
+
+        bool played = false;
         for (int j = 0; j < mvs.size(); ++j) {
             if (!uci_pos.is_legal(mvs[j]))
                 continue;
             if (move_to_string(mvs[j]) == token) {
                 uci_pos.do_move(mvs[j]);
+                played = true;
                 break;
             }
+        }
+
+        // Skipping the move silently is the worst thing to do here. The engine
+        // is now a move behind the GUI and every later move in the list is
+        // applied to the wrong position, so it goes on to answer a position
+        // nobody is playing -- and the first move it returns that is not legal
+        // in the real game loses it. Say so, and stop rather than compound it.
+        if (!played) {
+            std::cout << "info string ignoring unplayable move '" << token
+                      << "' -- position may be out of sync with the GUI" << std::endl;
+            return;
         }
     }
 }

--- a/tests/test_search.cpp
+++ b/tests/test_search.cpp
@@ -1319,5 +1319,42 @@ TEST_F(SearchTest, StateChangingCommandsWaitForTheSearch) {
     }
 }
 
+TEST_F(SearchTest, PromotionsAreAcceptedInEitherCase) {
+    // The move list is matched against move_to_string, which spells the
+    // promotion piece in lower case. A GUI that sends "a7a8Q" is not wrong --
+    // the case of that letter is a long-standing interop wart -- and matching
+    // it exactly meant the move was quietly dropped. The engine was then a move
+    // behind the GUI for the rest of the game, answering a position nobody was
+    // playing, and the first reply that was not legal in the real game lost it.
+    for (const std::string& mv : {std::string("a7a8q"), std::string("a7a8Q")}) {
+        auto pos = make_pos("4k3/P7/8/8/8/8/8/4K3 w - - 0 1");
+        uci::load_position("moves " + mv, pos);
+        EXPECT_EQ(pos.to_fen(), "Q3k3/8/8/8/8/8/8/4K3 b - - 0 2") << "sent " << mv;
+    }
+
+    // Under-promotions too, so this is about the case and not about queens.
+    auto knight = make_pos("4k3/P7/8/8/8/8/8/4K3 w - - 0 1");
+    uci::load_position("moves a7a8N", knight);
+    EXPECT_EQ(knight.to_fen(), "N3k3/8/8/8/8/8/8/4K3 b - - 0 2");
+}
+
+TEST_F(SearchTest, AnUnplayableMoveStopsRatherThanDesyncing) {
+    // Applying the rest of the list after dropping one move is strictly worse
+    // than stopping: every later move lands on the wrong position.
+    auto pos = make_pos("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+
+    std::ostringstream captured;
+    std::streambuf* saved = std::cout.rdbuf(captured.rdbuf());
+    uci::load_position("moves e2e4 e7e5 e2e5 g1f3", pos);
+    std::cout.rdbuf(saved);
+
+    // e2e5 is not legal, so the position must hold after e2e4 e7e5 -- with g1f3
+    // *not* applied, since applying it would put the engine a move ahead of a
+    // GUI that thinks e2e5 was played.
+    EXPECT_EQ(pos.to_fen(), "rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq e6 0 3");
+    EXPECT_NE(captured.str().find("info string"), std::string::npos)
+        << "the desync was not reported at all";
+}
+
 } // namespace
 } // namespace havoc


### PR DESCRIPTION
Found while probing UCI conformance, in the same family as the `go nodes` / `go mate` / terminal-position hangs (#93, #94): input the engine cannot handle is accepted silently rather than rejected loudly.

## The bug

`load_position` compares each move token against `move_to_string`, which spells the promotion piece in **lower case**. So:

| token sent | before | after |
|---|---|---|
| `a7a8q` | played | played |
| `a7a8Q` | **silently dropped** | played |
| `a7a8N` | **silently dropped** | played |
| `zzzz` | **silently dropped** | reported, list stops |
| `e2e5` (illegal) | **silently dropped** | reported, list stops |

The case of the promotion letter is a long-standing UCI interop wart and several GUIs emit upper case. Nothing in the protocol says lower case is required.

Dropping the move is not a cosmetic loss. The engine is now a move behind the GUI, and every later move in the list is applied to the wrong position. It goes on to search a position nobody is playing, and the first bestmove it returns that is not legal in the real game loses it.

## The fix

Lower-case the token before comparing. On a token that matches no legal move, emit `info string` and **stop consuming the list** rather than compounding the error by applying later moves to a position that has already diverged.

## Verification

- New tests `PromotionsAreAcceptedInEitherCase` and `AnUnplayableMoveStopsRatherThanDesyncing`.
- Both verified as negative controls: disabling the lower-casing alone fails the first and passes the second; disabling the report-and-stop alone fails the second and passes the first.
- 135/135 tests pass.
- `bench` **697583**, unchanged.

Branches from `main`, independent of the open stack.