### PR TITLE
tune: expose three search constants the tuner could not reach

### DIFF
--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -439,6 +439,18 @@ struct parameters {
     int see_quiet_margin = 50;      // ...when see < -margin * depth
     int qs_delta_margin = 910;      // quiescence delta pruning margin
     int qs_delta_pawn7th = 775;     // ...widened by this with a pawn near promotion
+
+    /// Margin on the qsearch capture futility test, on both the fail-low and
+    /// the fail-high side. Lived as a bare `int margin = 200;` in the middle of
+    /// qsearch, so no tuning run could ever reach it.
+    int qs_capture_margin = 200;
+
+    /// Half-width of the first aspiration window at each iteration, before any
+    /// widening. Both this and `aspiration_reseed_delta` were function-local
+    /// constants and so were invisible to the tuner.
+    int aspiration_delta = 65;
+    /// Half-width used to re-seed the window from the last *completed* score.
+    int aspiration_reseed_delta = 33;
     int singular_min_depth = 8;     // singular extension minimum depth
     int singular_margin = 2;        // singular beta = ttvalue - margin*depth
     int probcut_min_depth = 5;      // ProbCut needs at least this much depth

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -412,6 +412,9 @@ std::vector<std::pair<std::string, int*>> parameters::all_params(TuneStage stage
         result.emplace_back("see_quiet_margin", &see_quiet_margin);
     result.emplace_back("qs_delta_margin", &qs_delta_margin);
     result.emplace_back("qs_delta_pawn7th", &qs_delta_pawn7th);
+        result.emplace_back("qs_capture_margin", &qs_capture_margin);
+        result.emplace_back("aspiration_delta", &aspiration_delta);
+        result.emplace_back("aspiration_reseed_delta", &aspiration_reseed_delta);
         result.emplace_back("singular_min_depth", &singular_min_depth);
         result.emplace_back("singular_margin", &singular_margin);
         result.emplace_back("probcut_min_depth", &probcut_min_depth);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -419,9 +419,9 @@ double SearchEngine::estimate_max_time(position& p) const {
 void SearchEngine::iterative_deepening(position& p, U16 depth, bool silent, int thread_id) {
     int alpha = score::kNegInf;
     int beta = score::kInf;
-    const int baseDelta = 65;
+    const int baseDelta = params_.aspiration_delta;
     int delta = baseDelta;
-    int smallDelta = 33;
+    int smallDelta = params_.aspiration_reseed_delta;
     int eval = score::kNegInf;
     // The score of the last *completed* iteration. The aspiration window has to
     // be anchored on this and not on `eval`, because between the two `eval`
@@ -1473,7 +1473,7 @@ int SearchEngine::qsearch(position& p, int alpha, int beta, U16 /*depth*/, Searc
                 else if (move.type == static_cast<U8>(capture_promotion_n))
                     capture_score = kMaterialVals[idx] + kMaterialVals[knight];
             }
-            int margin = 200;
+            const int margin = params_.qs_capture_margin;
             if (capture_score > 0 &&
                 (best_score + static_cast<int>(capture_score) + margin < alpha))
                 continue;


### PR DESCRIPTION
Found while auditing for constants that bypass the tuning infrastructure.

`src/search.cpp` had three bare literals that every other search constant is spared:

| constant | value | where |
|---|---|---|
| `baseDelta` | 65 | initial aspiration half-width |
| `smallDelta` | 33 | half-width when re-seeding from the last completed score |
| `margin` | 200 | qsearch capture futility, both sides |

Everything else is registered in `TuneStage::search` and reachable by SPSA. These three were function-local, so **no tuning run could ever move them**, however much they were worth. Given that section 4.1 of the roadmap plans exactly such a run, that is a gap worth closing before it happens rather than after.

Now `aspiration_delta`, `aspiration_reseed_delta` and `qs_capture_margin`.

## Verification

- **Defaults unchanged**, so the change is inert until a tuning run fits them: `bench` **697583**, identical.
- The existing `EverySearchParameterReachesTheSearch` test covers the three new entries **automatically** — it perturbs every registered parameter and requires the search to notice — so they are proven reachable, not just registered.
- Verified as a negative control: putting one literal back while leaving it registered **fails** that test.
- 133/133 pass.

No behaviour change, so no SPRT is applicable.