### PR TITLE
fix: advertise the Hash default the engine actually uses

### DIFF
--- a/include/havoc/tt.hpp
+++ b/include/havoc/tt.hpp
@@ -17,9 +17,14 @@ namespace havoc {
 /// Bounds for the Hash spin option advertised by the "uci" handshake. uci.cpp
 /// prints these and hash_table::resize() enforces them, so the advertised range
 /// and the enforced range cannot drift apart.
+///
+/// kDefaultHashMb must also be the size the constructor actually builds. It
+/// said 1024 while the constructor built 128, so a GUI that only sends
+/// setoption for values the operator changed left the engine on an eighth of
+/// the table it was displaying, and nothing reported the discrepancy.
 constexpr int kMinHashMb = 1;
 constexpr int kMaxHashMb = 33554432;
-constexpr int kDefaultHashMb = 1024;
+constexpr int kDefaultHashMb = 128;
 
 // ─── Bounds ─────────────────────────────────────────────────────────────────
 
@@ -148,6 +153,9 @@ class hash_table {
     void new_search() { ++generation_; }
 
     [[nodiscard]] U8 generation() const { return generation_; }
+
+    /// Size the table was last given, in MB.
+    [[nodiscard]] size_t size_mb() const { return sz_mb_; }
     [[nodiscard]] int hashfull() const;
 
     [[nodiscard]] inline entry* first_entry(U64 key) {

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -17,10 +17,11 @@ inline size_t next_pow2(size_t x) {
 } // namespace
 
 hash_table::hash_table() {
-    // 128 MB at construction. If even this fails the process has no usable
-    // table, but there is nothing useful to do about it here and throwing from
-    // a constructor that runs before main() is worse than starting up.
-    (void)resize(128);
+    // The advertised default, at construction. If even this fails the process
+    // has no usable table, but there is nothing useful to do about it here and
+    // throwing from a constructor that runs before main() is worse than
+    // starting up.
+    (void)resize(kDefaultHashMb);
 }
 bool hash_table::resize(size_t size_mb) {
     // Refuse out-of-range requests outright rather than discovering they are

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -4,6 +4,7 @@
 #include "havoc/movegen.hpp"
 #include "havoc/position.hpp"
 #include "havoc/tablebase.hpp"
+#include "havoc/tt.hpp"
 #include "havoc/version.hpp"
 
 #include <algorithm>

--- a/tests/test_search.cpp
+++ b/tests/test_search.cpp
@@ -1356,5 +1356,32 @@ TEST_F(SearchTest, AnUnplayableMoveStopsRatherThanDesyncing) {
         << "the desync was not reported at all";
 }
 
+TEST_F(SearchTest, TheAdvertisedHashDefaultIsTheOneActuallyUsed) {
+    // `uci` used to advertise "default 1024" while the table was built at 128.
+    // A GUI that only sends setoption for values the operator changed then
+    // leaves the engine on an eighth of the table it is displaying, and nothing
+    // anywhere says so. Measured before the fix: 145.5 MB RSS on a fresh engine
+    // -- identical to an explicit Hash=128 -- against 1041.5 MB for Hash=1024.
+    hash_table fresh;
+    EXPECT_EQ(fresh.size_mb(), static_cast<size_t>(kDefaultHashMb))
+        << "the table is not built at the size the constant names";
+
+    // Parse the advertised default straight out of the `uci` output, so the
+    // two can never drift apart again without failing here.
+    SearchEngine engine;
+    auto pos = make_pos("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+    std::ostringstream captured;
+    std::streambuf* saved = std::cout.rdbuf(captured.rdbuf());
+    uci::parse_command("uci", engine, pos);
+    std::cout.rdbuf(saved);
+
+    const std::string out = captured.str();
+    const std::string key = "option name Hash type spin default ";
+    const size_t at = out.find(key);
+    ASSERT_NE(at, std::string::npos) << "the Hash option is no longer advertised";
+    EXPECT_EQ(std::stoi(out.substr(at + key.size())), kDefaultHashMb)
+        << "advertised Hash default does not match the size actually allocated";
+}
+
 } // namespace
 } // namespace havoc


### PR DESCRIPTION
The `uci` handler advertised:

```
option name Hash type spin default 1024 min 1 max 33554432
```

while `hash_table::hash_table()` built the table at **128 MB**.

Per UCI, `default` is what the engine uses when the option is *not* set. Plenty of GUIs and tournament managers only send `setoption` for values the operator actually changed, so anyone who accepted the displayed 1024 was silently running on **an eighth of the table they were shown** — and nothing anywhere reported it.

## Measured

Fresh engine, RSS after `uci`:

| configuration | RSS |
|---|---|
| default (advertised 1024) | **145.5 MB** |
| explicit `Hash 128` | 145.5 MB |
| explicit `Hash 1024` | 1041.5 MB |

The default is byte-for-byte the 128 MB case.

## Which way to fix it

Advertise the real value rather than raising the actual default to 1024. A 1 GB allocation at startup is a poor default for an engine that gets run many times concurrently — every SPRT worker on this box would take a gigabyte. If you would rather have the bigger table by default, the constant is now in one place and it is a one-line change.

## Verification

- Both sites read one `kDefaultHashMB`.
- New test `TheAdvertisedHashDefaultIsTheOneActuallyUsed` parses the number straight out of the `uci` output and compares it with the size the table was built at, so the two cannot drift apart again.
- Verified as a negative control: restoring the literal `1024` in the advertisement fails the test.
- 134/134 pass. `bench` **697583**, unchanged.

Branches from `main`, independent of the open stack.