### PR TITLE
docs: add CI, language, platform and licence badges to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # haVoc
 
+[![CI](https://github.com/mjglatzmaier/haVoc/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/mjglatzmaier/haVoc/actions/workflows/ci.yml)
+[![C++20](https://img.shields.io/badge/C%2B%2B-20-blue.svg)](https://en.cppreference.com/w/cpp/20)
+[![Platforms](https://img.shields.io/badge/platforms-Linux%20%7C%20macOS%20%7C%20Windows-lightgrey.svg)](https://github.com/mjglatzmaier/haVoc/actions/workflows/ci.yml)
+[![License](https://img.shields.io/github/license/mjglatzmaier/haVoc.svg)](LICENSE)
+
 A UCI chess engine written in C++20.
 
 haVoc is a hobby chess engine I've developed on and off for several years.


### PR DESCRIPTION
Adds four badges to the top of the README:

- **CI** — live status of the `ci.yml` workflow on `main` (gcc, clang, appleclang, msvc)
- **C++20**
- **Platforms** — Linux / macOS / Windows
- **License** — read from the repo, resolves to MIT

All four URLs verified to return HTTP 200 and render the expected label. The CI one currently reads *failing* because it reflects the last completed run on `main`, which predates #80 — it should flip to *passing* once the post-#80 runs finish, which is exactly the point of having it.

Docs-only.