### PR TITLE
feat: report time, nps and hashfull in info lines

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1538,6 +1538,13 @@ void SearchEngine::readout_pv(SearchNode* /*stack*/, const Rootmoves& mRoots, in
         nodes += t->qnodes();
     }
 
+    // Without `time` a GUI cannot show think time and cannot derive nps, so it
+    // has nothing to display while the engine is working. `hashfull` was
+    // implemented and unit-tested but never actually reported to anyone.
+    const double elapsed = search_clock_.elapsed_ms();
+    const U64 elapsed_ms = static_cast<U64>(elapsed);
+    const U64 nps = static_cast<U64>(static_cast<double>(nodes) * 1000.0 / std::max(1.0, elapsed));
+
     int numLines = std::min(multi_pv_, static_cast<int>(mRoots.size()));
     for (int i = 0; i < numLines; ++i) {
         if (i >= static_cast<int>(mRoots.size()))
@@ -1550,6 +1557,8 @@ void SearchEngine::readout_pv(SearchNode* /*stack*/, const Rootmoves& mRoots, in
             res += std::string(uci::move_to_string(m)) + " ";
         }
 
+        // `pv` has to stay last: it is the one field of variable length, and a
+        // GUI reading it consumes tokens until end of line.
         std::cout << "info"
                   << " depth " << depth
                   << " seldepth " << mRoots[i].selDepth
@@ -1558,7 +1567,11 @@ void SearchEngine::readout_pv(SearchNode* /*stack*/, const Rootmoves& mRoots, in
                   << (eval >= beta    ? " lowerbound"
                       : eval <= alpha ? " upperbound"
                                       : "")
-                  << " nodes " << nodes << " pv " << res << std::endl;
+                  << " nodes " << nodes
+                  << " nps " << nps
+                  << " hashfull " << tt_.hashfull()
+                  << " time " << elapsed_ms
+                  << " pv " << res << std::endl;
     }
 }
 

--- a/tests/test_search.cpp
+++ b/tests/test_search.cpp
@@ -1384,5 +1384,41 @@ TEST_F(SearchTest, TheAdvertisedHashDefaultIsTheOneActuallyUsed) {
         << "advertised Hash default does not match the size actually allocated";
 }
 
+TEST_F(SearchTest, InfoLinesCarryTimeNpsAndHashfull) {
+    // Without `time` a GUI has nothing to show while the engine thinks and no
+    // way to derive nps for itself. `hashfull` was implemented and unit-tested
+    // but never reported to anyone, so table saturation was invisible from the
+    // outside for the whole life of the engine.
+    auto pos = make_pos("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+    SearchEngine engine;
+    SearchLimits lims{};
+    lims.depth = 10;
+
+    std::ostringstream captured;
+    std::streambuf* saved = std::cout.rdbuf(captured.rdbuf());
+    engine.start(pos, lims, /*silent=*/false);
+    engine.wait();
+    std::cout.rdbuf(saved);
+
+    std::istringstream lines(captured.str());
+    std::string line;
+    int info_lines = 0;
+    while (std::getline(lines, line)) {
+        if (line.rfind("info", 0) != 0)
+            continue;
+        ++info_lines;
+        for (const char* field : {" nodes ", " nps ", " hashfull ", " time ", " pv "})
+            EXPECT_NE(line.find(field), std::string::npos)
+                << "missing" << field << "in: " << line;
+
+        // `pv` is the only variable-length field, so a GUI reads it to end of
+        // line. Anything emitted after it would be swallowed as part of the PV.
+        const size_t pv_at = line.find(" pv ");
+        for (const char* field : {" nodes ", " nps ", " hashfull ", " time ", " score "})
+            EXPECT_LT(line.find(field), pv_at) << field << "must precede pv in: " << line;
+    }
+    EXPECT_GT(info_lines, 0) << "the search reported nothing at all";
+}
+
 } // namespace
 } // namespace havoc


### PR DESCRIPTION
The engine emitted `depth`, `seldepth`, `multipv`, `score`, `nodes` and `pv` — and nothing else.

- **No `time`.** A GUI cannot show how long the engine has been thinking, and cannot derive nps for itself, so it has nothing to display while a search runs.
- **No `nps`.**
- **No `hashfull`.** `hash_table::hashfull()` is implemented in `tt.cpp` and covered by a unit test, but was **never reported to anyone** — table saturation has been invisible from outside the engine for its entire life.

Before:

```
info depth 12 seldepth 18 multipv 1 score cp 33 nodes 69598 pv b1c3 d7d5 ...
```

After:

```
info depth 12 seldepth 18 multipv 1 score cp 33 nodes 69598 nps 569895 hashfull 4 time 122 pv b1c3 d7d5 ...
```

`pv` stays last deliberately: it is the only variable-length field and a GUI reads it to end of line, so anything emitted after it would be swallowed into the PV. The test asserts that ordering as well as the presence of each field.

## Verification

- Node counts and PVs are **identical** to before at every depth — this only adds reporting.
- New test `InfoLinesCarryTimeNpsAndHashfull`, verified as a negative control: removing the three fields fails it.
- 145/145 pass at the time of writing. `bench` **697583**, unchanged.