### PR TITLE
fix: restore the loop brace lost while rebasing the merge queue

### DIFF
--- a/tests/test_search.cpp
+++ b/tests/test_search.cpp
@@ -1270,6 +1270,7 @@ TEST_F(SearchTest, TerminalPositionsStillAnswerWithBestmove) {
 
         EXPECT_NE(captured.str().find("bestmove"), std::string::npos)
             << name << " produced no bestmove at all: \"" << captured.str() << "\"";
+    }
 }
 
 TEST_F(SearchTest, StateChangingCommandsWaitForTheSearch) {


### PR DESCRIPTION
Build fix for `main`.

Six PRs each appended a `TEST_F` at the same point in `tests/test_search.cpp`, so every one of them conflicted with the next as the queue was merged. While resolving that, `TerminalPositionsStillAnswerWithBestmove` (#94) lost the brace closing its `for` loop. Every test declared after it then nested inside its body and gcc rejected the file:

```
error: local class ... shall not have static data member ... test_info_
```

One brace. Verified after the fix:

- **159/159 tests pass.**
- All tests accounted for: 32 `SearchTest` + 11 `TimeManagement` declared in the file, 32 and 11 registered — nothing was swallowed.
- Braces balance (148/148).
- `bench` **697583**, unchanged.

My mistake, caught by building `main` after the merges rather than trusting the per-branch runs.