### PR TITLE
release: bump version to 2.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 3.20)
 
 project(haVoc
-    VERSION 2.0.0
+    VERSION 2.1.0
     DESCRIPTION "A modern UCI chess engine"
-    HOMEPAGE_URL "https://github.com/mjglatzmaier/chess"
+    HOMEPAGE_URL "https://github.com/mjglatzmaier/haVoc"
     LANGUAGES CXX
 )
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ also be driven directly from a terminal:
 
 ```
 $ ./build/havoc
-haVoc v2.0.0
+haVoc v2.1.0
 by M.Glatzmaier
 uci
 position startpos moves e2e4

--- a/include/havoc/version.hpp
+++ b/include/havoc/version.hpp
@@ -8,9 +8,9 @@
 namespace havoc {
 
 inline constexpr int VERSION_MAJOR = 2;
-inline constexpr int VERSION_MINOR = 0;
+inline constexpr int VERSION_MINOR = 1;
 inline constexpr int VERSION_PATCH = 0;
-inline constexpr std::string_view VERSION_STRING = "2.0.0";
+inline constexpr std::string_view VERSION_STRING = "2.1.0";
 inline constexpr std::string_view ENGINE_NAME = "haVoc";
 inline constexpr std::string_view ENGINE_AUTHOR = "M.Glatzmaier";
 


### PR DESCRIPTION
Prepares the v2.1.0 release.

- `VERSION_MINOR` 0 -> 1 and `VERSION_STRING` to "2.1.0" in `version.hpp`
- CMake `project(VERSION)` and the README sample session follow
- `HOMEPAGE_URL` corrected: it still pointed at the pre-rename `mjglatzmaier/chess`

Existing tags are only `v1.0.0` and `v1.1.0` -- 2.0.0 was set in source but never tagged. Tagging 2.1.0 keeps the tag consistent with the `id name` string the engine reports, which is what tournament managers record.

Verified: `id name haVoc 2.1.0`, bench 697583 (unchanged).