### PR TITLE
fix: give each search thread its own selective depth

### DIFF
--- a/include/havoc/position.hpp
+++ b/include/havoc/position.hpp
@@ -112,6 +112,21 @@ class position {
 
     Rootmoves root_moves;
 
+    /// Deepest ply reached on the current iteration, quiescence included.
+    ///
+    /// This lives here because the engine gives each search thread its own
+    /// `position`, so a field on it is per-thread by construction and costs
+    /// nothing to reach: the search already holds this object in a register.
+    /// It was previously a single `std::atomic<int>` on the engine shared by
+    /// every thread, which made the reported `seldepth` describe no thread in
+    /// particular once `Threads > 1` -- each thread reset it at the top of
+    /// every aspiration window and each thread incremented it.
+    ///
+    /// Like `root_moves` above, this is per-search state rather than board
+    /// state. Both belong in a per-thread search-state type; that refactor is
+    /// worth doing when per-thread history tables arrive, not before.
+    int sel_depth = 0;
+
     // setup / clear
     /// Returns false if the FEN does not describe a legal position, in which
     /// case the board is left cleared rather than half-parsed.

--- a/include/havoc/search.hpp
+++ b/include/havoc/search.hpp
@@ -164,7 +164,6 @@ class SearchEngine {
     SearchSignals signals_;
     parameters params_;
     std::atomic<bool> searching_{false};
-    std::atomic<int> sel_depth_{0};
     std::mutex output_mutex_;
     int multi_pv_ = 1;
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -43,6 +43,7 @@ position& position::operator=(const position& p) {
         return *this;
     history_ = p.history_;
     root_moves = p.root_moves;
+    sel_depth = p.sel_depth;
     ifo = p.ifo;
     pcs = p.pcs;
     nodes_searched = p.nodes_searched;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -489,7 +489,7 @@ void SearchEngine::iterative_deepening(position& p, U16 depth, bool silent, int 
 
         // Aspiration window search
         while (true) {
-            sel_depth_ = 0;
+            p.sel_depth = 0;
             eval = search<root>(p, alpha, beta, static_cast<U16>(id), stack + 2, thread_id);
 
             // The sort deliberately runs before the stop check, so an
@@ -649,7 +649,6 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
     // given PV reductions by reduction(pvNode, ...). Neither is defensible for
     // a search that can only ever return a bound.
     const bool pvNode = (root_node || (type == Nodetype::pv && beta - alpha > 1));
-    bool is_main = (thread_id == 0);
 
     const Move excluded_move = stack->excluded_move;
     const bool singular_search = !excluded_move.is_null();
@@ -664,8 +663,11 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
     if (!singular_search)
         stack->threat_move = Move{};
 
-    if (pvNode && sel_depth_.load() < stack->ply + 1 && is_main)
-        sel_depth_++;
+    // Every thread tracks its own selective depth on its own position, so
+    // this is no longer gated on being the main thread: each one is now
+    // reporting about itself rather than racing on one shared counter.
+    if (pvNode && pos.sel_depth < stack->ply + 1)
+        pos.sel_depth++;
 
     // The search stack is a fixed MAX_PLY + 4 array and every recursion steps
     // one node forward, so the tree has to be cut off before it can run off the
@@ -1212,7 +1214,7 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
                 auto& rm = *it;
                 if (moves_searched == 1 || score_val > alpha) {
                     rm.score = static_cast<int16_t>(score_val);
-                    rm.selDepth = sel_depth_.load();
+                    rm.selDepth = pos.sel_depth;
                     rm.pv.resize(1);
                     for (Move* m = (stack + 1)->pv; m; ++m) {
                         if (m->f == m->t || m->type == static_cast<U8>(no_type))
@@ -1346,8 +1348,8 @@ int SearchEngine::qsearch(position& p, int alpha, int beta, U16 /*depth*/, Searc
     bool pv_type = (type == Nodetype::pv && beta - alpha > 1);
 
     stack->ply = (stack - 1)->ply + 1;
-    if (pv_type && sel_depth_.load() < stack->ply + 1)
-        sel_depth_++;
+    if (pv_type && p.sel_depth < stack->ply + 1)
+        p.sel_depth++;
     U16 root_dist = stack->ply;
 
     bool in_check = p.in_check();

--- a/tests/test_search.cpp
+++ b/tests/test_search.cpp
@@ -1420,5 +1420,49 @@ TEST_F(SearchTest, InfoLinesCarryTimeNpsAndHashfull) {
     EXPECT_GT(info_lines, 0) << "the search reported nothing at all";
 }
 
+TEST_F(SearchTest, SelectiveDepthIsPerThreadNotShared) {
+    // Selective depth was a single atomic on the engine. Every thread reset it
+    // to zero at the top of every aspiration window and every thread
+    // incremented it, so with Threads > 1 the number reported described no
+    // thread in particular -- it was whatever the race left behind.
+    //
+    // The invariant that catches it: the principal variation at depth d
+    // reaches ply d, so seldepth can never be less than depth. Before the fix
+    // this engine reported "depth 6 seldepth 0" and "depth 7 seldepth 2".
+    auto pos = make_pos("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+    SearchEngine engine;
+    engine.set_threads(8);
+    SearchLimits lims{};
+    lims.depth = 12;
+
+    std::ostringstream captured;
+    std::streambuf* saved = std::cout.rdbuf(captured.rdbuf());
+    engine.start(pos, lims, /*silent=*/false);
+    engine.wait();
+    std::cout.rdbuf(saved);
+
+    std::istringstream lines(captured.str());
+    std::string line;
+    int checked = 0;
+    while (std::getline(lines, line)) {
+        if (line.rfind("info", 0) != 0)
+            continue;
+        std::istringstream fields(line);
+        std::string tok;
+        int depth = -1, seldepth = -1;
+        while (fields >> tok) {
+            if (tok == "depth")
+                fields >> depth;
+            else if (tok == "seldepth")
+                fields >> seldepth;
+        }
+        if (depth < 0 || seldepth < 0)
+            continue;
+        ++checked;
+        EXPECT_GE(seldepth, depth) << "seldepth below depth in: " << line;
+    }
+    EXPECT_GT(checked, 0) << "no info line carried both depth and seldepth";
+}
+
 } // namespace
 } // namespace havoc

--- a/tests/test_search.cpp
+++ b/tests/test_search.cpp
@@ -1426,19 +1426,35 @@ TEST_F(SearchTest, SelectiveDepthIsPerThreadNotShared) {
     // incremented it, so with Threads > 1 the number reported described no
     // thread in particular -- it was whatever the race left behind.
     //
-    // The invariant that catches it: the principal variation at depth d
-    // reaches ply d, so seldepth can never be less than depth. Before the fix
-    // this engine reported "depth 6 seldepth 0" and "depth 7 seldepth 2".
+    // The invariant that catches it: every move on the reported PV was played
+    // from a PV node, and entering a PV node at ply k raises that thread's
+    // selective depth to at least k + 1. So a PV of length L forces
+    // seldepth >= L. Before the fix this engine reported "depth 6 seldepth 0"
+    // and "depth 7 seldepth 2" against PVs many moves long.
+    //
+    // The tempting assertion is seldepth >= depth, and it holds in practice
+    // (measured over 72 searches across 1/4/8/32 threads and six positions the
+    // slack never fell below +1). It is not guaranteed though: internal
+    // iterative reduction shortens PV nodes that have no hash move, so a
+    // completed iteration may never descend a full `depth` plies. That would
+    // be a rare CI flake rather than a real defect, so assert the structural
+    // relation instead of the likely one.
+    //
+    // Whether the old race actually surfaced depended on thread scheduling, so
+    // one search caught it only about half the time. Repeating it brings the
+    // detection rate up without making the test able to fail on fixed code.
     auto pos = make_pos("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
-    SearchEngine engine;
-    engine.set_threads(8);
     SearchLimits lims{};
     lims.depth = 12;
 
     std::ostringstream captured;
     std::streambuf* saved = std::cout.rdbuf(captured.rdbuf());
-    engine.start(pos, lims, /*silent=*/false);
-    engine.wait();
+    for (int rep = 0; rep < 4; ++rep) {
+        SearchEngine engine;
+        engine.set_threads(8);
+        engine.start(pos, lims, /*silent=*/false);
+        engine.wait();
+    }
     std::cout.rdbuf(saved);
 
     std::istringstream lines(captured.str());
@@ -1449,19 +1465,24 @@ TEST_F(SearchTest, SelectiveDepthIsPerThreadNotShared) {
             continue;
         std::istringstream fields(line);
         std::string tok;
-        int depth = -1, seldepth = -1;
+        int depth = -1, seldepth = -1, pv_len = -1;
         while (fields >> tok) {
             if (tok == "depth")
                 fields >> depth;
             else if (tok == "seldepth")
                 fields >> seldepth;
+            else if (tok == "pv") {
+                pv_len = 0;
+                while (fields >> tok)
+                    ++pv_len;
+            }
         }
-        if (depth < 0 || seldepth < 0)
+        if (depth < 0 || seldepth < 0 || pv_len <= 0)
             continue;
         ++checked;
-        EXPECT_GE(seldepth, depth) << "seldepth below depth in: " << line;
+        EXPECT_GE(seldepth, pv_len) << "seldepth below pv length in: " << line;
     }
-    EXPECT_GT(checked, 0) << "no info line carried both depth and seldepth";
+    EXPECT_GT(checked, 0) << "no info line carried a pv and a seldepth";
 }
 
 } // namespace


### PR DESCRIPTION
## The bug

`sel_depth_` was a single `std::atomic<int>` on `SearchEngine`, but the engine runs Lazy SMP: N threads each search their own `position` inside one shared `SearchEngine`. Every thread reset that counter to zero at the top of every aspiration window, and every thread incremented it. The reported `seldepth` therefore described no thread in particular — it was whatever the race left behind.

The pre-fix binary prints output that cannot be true:

```
info depth 6 seldepth 0 ...      (8 threads)
info depth 7 seldepth 2 ...      (32 threads)
```

A principal variation seven moves long cannot have been found two plies deep.

`search()` also gated its update on `is_main` while `qsearch()` did not, so the two update sites disagreed about whose depth was being tracked.

## The fix

Move the counter to `position::sel_depth`. Each thread already owns its own `position` — that is where `root_moves` lives — so this needs no synchronisation and each thread now reports about itself. `is_main` becomes unused in `search()` and is removed.

`position::operator=` copies its members explicitly rather than defaulting, so the new field is added there too; leaving it out would have silently dropped it.

## Placement matters for speed

The first attempt used a `std::vector<ThreadState>` indexed by `thread_id`. That cost **5% single-threaded** (403 ms vs 383 ms bench) — a dependent load through the vector on a cold line at every node. Hanging it off the `position` reference, which is already in a register at every call site, ends up **faster than baseline** (373 ms vs 380 ms) because it removes an atomic load and a `lock xadd` from the node path.

Note this is a correctness fix, not a threading win: at 32 threads the shared atomic was measured at 16.56M nps before and 16.35M after — noise. The SMP throughput gap is elsewhere.

## Test

`SearchTest.SelectiveDepthIsPerThreadNotShared` searches with 8 threads and asserts `seldepth >= pv length` on every info line.

That relation holds by construction: every move on the PV was played from a PV node, and entering a PV node at ply k raises that thread's selective depth to at least k+1.

The more obvious assertion, `seldepth >= depth`, is deliberately **not** used. It held across 72 measured searches (1/4/8/32 threads, six positions — slack never below +1), but it is not guaranteed: internal iterative reduction shortens PV nodes that have no hash move, so a completed iteration need not descend a full `depth` plies. That would be a rare CI flake rather than a real defect.

Because the race surfaced only about half the time from a single search, the test repeats it four times.

| build | result |
|---|---|
| pre-fix | **8/8 fail** |
| post-fix | 8/8 pass |

Runtime ~0.5 s.

## Verification

- bench **697583** before and after — the search tree is untouched
- **161/161** tests pass
- negative control built from `main` with only the new test file applied, confirming it fails on the old code

Rubber-duck reviewed; the review is what moved the assertion off `seldepth >= depth`.