### PR TITLE
fix: give each search thread its own move-ordering history

### DIFF
--- a/include/havoc/search.hpp
+++ b/include/havoc/search.hpp
@@ -152,10 +152,12 @@ class SearchEngine {
     /// to perturb them in-process.
     parameters& params() { return params_; }
 
-    /// Read-only view of the history heuristic. Exposed so that tests can
-    /// assert which moves the search rewarded, which is otherwise only
-    /// observable as a change in move ordering several plies away.
-    const Movehistory& history() const { return history_; }
+    /// Read-only view of the first search thread's history heuristic. Exposed
+    /// so that tests can assert which moves the search rewarded, which is
+    /// otherwise only observable as a change in move ordering several plies
+    /// away. Each thread now keeps its own tables, so this is the whole story
+    /// only for a single-threaded search -- which is what the tests run.
+    const Movehistory& history() const { return search_threads_[0]->history; }
 
   private:
     hash_table tt_;
@@ -173,7 +175,12 @@ class SearchEngine {
     /// Used to pick which thread's result to play; a thread's raw score is not
     /// comparable across different depths.
     std::vector<int> completed_depth_;
-    Movehistory history_;
+
+    /// Move-ordering statistics for one search thread. One accessor rather than
+    /// 26 direct reaches into the thread pool, so that where this state lives is
+    /// decided in exactly one place -- moving it into a per-thread search
+    /// context later is then a change to this function and nothing else.
+    Movehistory& thread_history(int thread_id) { return search_threads_[thread_id]->history; }
 
     // Search methods
     void iterative_deepening(position& p, U16 depth, bool silent, int thread_id);

--- a/include/havoc/thread_pool.hpp
+++ b/include/havoc/thread_pool.hpp
@@ -3,6 +3,7 @@
 /// @file thread_pool.hpp
 /// @brief Thread pool for search workers and timer threads.
 
+#include "havoc/move_order.hpp"
 #include "havoc/eval/evaluator.hpp"
 #include "havoc/eval/hce.hpp"
 #include "havoc/material_table.hpp"
@@ -41,6 +42,12 @@ class Workerthread {
 class Searchthread : public Workerthread {
   public:
     parameters params;
+    /// Move-ordering statistics. Per thread, not shared: Lazy SMP has every
+    /// thread writing these tables concurrently, and they are plain ints with
+    /// no synchronisation, so a shared instance is a data race. Sharing also
+    /// defeats the point of running different threads down different parts of
+    /// the tree -- they would all be steered by one another's statistics.
+    Movehistory history;
     pawn_table pawn_tbl{params};
     material_table material_tbl{params};
     std::unique_ptr<IEvaluator> evaluator;
@@ -99,6 +106,7 @@ template <class T> class Threadpool {
     }
 
     T* operator[](int idx) { return workers_[idx].get(); }
+    const T* operator[](int idx) const { return workers_[idx].get(); }
 
     void init(int numThreads) {
         if (!stop_.load())

--- a/src/move_order.cpp
+++ b/src/move_order.cpp
@@ -15,6 +15,10 @@ Movehistory::Movehistory() : continuation_(std::make_unique<ContinuationHistory>
 
 Movehistory& Movehistory::operator=(const Movehistory& mh) {
     std::copy(std::begin(mh.history_), std::end(mh.history_), std::begin(history_));
+    // corrections_ was missing here. Every other table was carried and this one
+    // was silently reset, so any copy quietly threw away the accumulated
+    // eval-versus-search bias while appearing to preserve the history.
+    corrections_ = mh.corrections_;
     countermoves = mh.countermoves;
     *continuation_ = *mh.continuation_;
     cont_pct1_ = mh.cont_pct1_;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -84,7 +84,22 @@ void SearchEngine::set_threads(int n) {
     // enforced: "setoption name Threads value 99999" tried to start 99999
     // threads and wedged the engine.
     n = std::clamp(n, kMinThreads, kMaxThreads);
+
+    // Threadpool::init() destroys and recreates every Searchthread, and the
+    // move-ordering history lives on those objects. start() documents that
+    // history persists through a game and is reset only by ucinewgame, and a
+    // GUI may change Threads at any point, so carry the tables across instead
+    // of quietly returning every thread to ordering-blind mid-game.
+    const bool had_threads = search_threads_.size() > 0;
+    Movehistory carried;
+    if (had_threads)
+        carried = search_threads_[0]->history;
+
     search_threads_.init(n);
+
+    if (had_threads)
+        for (unsigned i = 0; i < search_threads_.size(); ++i)
+            search_threads_[i]->history = carried;
 }
 
 bool SearchEngine::set_hash_size(int mb) {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -99,7 +99,8 @@ bool SearchEngine::set_hash_size(int mb) {
 
 void SearchEngine::clear() {
     tt_.clear();
-    history_.clear();
+    for (unsigned i = 0; i < search_threads_.size(); ++i)
+        search_threads_[i]->history.clear();
 }
 
 void SearchEngine::load_params(const std::string& filename) {
@@ -164,7 +165,9 @@ void SearchEngine::start(position& p, const SearchLimits& lims, bool silent) {
     // through a game and is reset between games.
 
     signals_.stop = false;
-    history_.set_continuation_weights(params_.cont_hist1_pct, params_.cont_hist2_pct);
+    for (unsigned i = 0; i < search_threads_.size(); ++i)
+        search_threads_[i]->history.set_continuation_weights(params_.cont_hist1_pct,
+                                                             params_.cont_hist2_pct);
     tt_.new_search();
 
     p.set_nodes_searched(0);
@@ -728,10 +731,10 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
                     // and in TT-heavy regions this is the only thing that
                     // populates killers and countermoves at all -- nodes that
                     // return here never reach a move loop. Leave it.
-                    history_.update(pos.to_move(), ttm, (stack - 1)->curr_move,
+                    thread_history(thread_id).update(pos.to_move(), ttm, (stack - 1)->curr_move,
                                     history_bonus(depth), static_cast<int16_t>(ttvalue), quiets,
                                     stack->killers);
-                    history_.update_continuation(pos, stack, ttm, history_bonus(depth), quiets);
+                    thread_history(thread_id).update_continuation(pos, stack, ttm, history_bonus(depth), quiets);
                     return ttvalue;
                 }
             }
@@ -756,7 +759,7 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
         // when there is no such value, and to give the update below a corrected
         // baseline so the table converges instead of chasing its own output.
         static_eval_val = static_cast<int16_t>(std::clamp(
-            static_eval_val + history_.correction(pos.to_move(), pos.pawnkey()),
+            static_eval_val + thread_history(thread_id).correction(pos.to_move(), pos.pawnkey()),
             static_cast<int>(-score::kMate + 100), static_cast<int>(score::kMate - 100)));
     }
     const int16_t corrected_static_eval = static_eval_val;
@@ -872,7 +875,7 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
         const int see_threshold = probcut_beta - static_eval_val;
         const int probcut_depth = static_cast<int>(depth) - params_.probcut_depth_reduction;
 
-        Moveorder pc_mvs(pos, ttm, stack, &history_);
+        Moveorder pc_mvs(pos, ttm, stack, &thread_history(thread_id));
         Move pc_move;
         Move pc_prev = (stack - 1)->curr_move;
         Move pc_prevprev = (stack - 2)->curr_move;
@@ -924,7 +927,7 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
 
     // Main search
     U16 moves_searched = 0;
-    Moveorder mvs(pos, ttm, stack, &history_);
+    Moveorder mvs(pos, ttm, stack, &thread_history(thread_id));
     Move move;
     Move pre_move = (stack - 1)->curr_move;
     Move pre_pre_move = (stack - 2)->curr_move;
@@ -1016,7 +1019,7 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
         // History pruning: skip quiet moves with terrible history at shallow depths
         if (!pvNode && !in_check && depth <= params_.history_prune_depth && !hashOrKiller &&
             isQuiet && bestScore > score::kMatedMaxPly) {
-            int hist_score = history_.score(move, pos.to_move());
+            int hist_score = thread_history(thread_id).score(move, pos.to_move());
             if (hist_score < -params_.history_prune_margin * depth) {
                 continue;
             }
@@ -1163,7 +1166,7 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
                 unsigned R = reduction(pvNode, improving, depth, moves_searched);
 
                 // Reduce more for moves with bad history
-                int hist = history_.score(move, to_mv);
+                int hist = thread_history(thread_id).score(move, to_mv);
                 R += (hist < -params_.lmr_hist_bad) ? 1 : 0;
 
                 // NOTE: non-PV nodes are *not* reduced further here. The
@@ -1233,10 +1236,10 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
             stack->best_move = move;
 
             if (score_val >= beta) {
-                history_.update(pos.to_move(), best_move, (stack - 1)->curr_move,
+                thread_history(thread_id).update(pos.to_move(), best_move, (stack - 1)->curr_move,
                                 history_bonus(depth), static_cast<int16_t>(bestScore), quiets,
                                 stack->killers);
-                history_.update_continuation(pos, stack, best_move, history_bonus(depth), quiets);
+                thread_history(thread_id).update_continuation(pos, stack, best_move, history_bonus(depth), quiets);
                 break;
             }
 
@@ -1262,8 +1265,8 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
     // continuation tables at every cutoff node in the search.
     if (bestScore <= alpha_orig && !quiets.empty()) {
         const int malus = history_bonus(depth) * params_.history_malus_pct / 100;
-        history_.malus(to_mv, malus, quiets);
-        history_.malus_continuation(pos, stack, malus, quiets);
+        thread_history(thread_id).malus(to_mv, malus, quiets);
+        thread_history(thread_id).malus_continuation(pos, stack, malus, quiets);
     }
 
     // Best move bonus
@@ -1308,7 +1311,7 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
         !best_is_capture && std::abs(bestScore) < score::kMate - 100 &&
         (bound == bound_exact || (bound == bound_low && bestScore > corrected_static_eval) ||
          (bound == bound_high && bestScore < corrected_static_eval))) {
-        history_.update_correction(to_mv, pos.pawnkey(), depth,
+        thread_history(thread_id).update_correction(to_mv, pos.pawnkey(), depth,
                                    bestScore - corrected_static_eval);
     }
 
@@ -1432,7 +1435,7 @@ int SearchEngine::qsearch(position& p, int alpha, int beta, U16 /*depth*/, Searc
     // counter: it has no late-move reduction or move-count pruning to feed one,
     // and the one it used to declare was incremented and never read.
     U16 legal_moves = 0;
-    QMoveorder mvs(p, ttm, stack, &history_);
+    QMoveorder mvs(p, ttm, stack, &thread_history(thread_id));
     Move move;
     Move pre_move = (stack - 1)->curr_move;
     Move pre_pre_move = (stack - 2)->curr_move;

--- a/tests/test_search.cpp
+++ b/tests/test_search.cpp
@@ -1485,5 +1485,68 @@ TEST_F(SearchTest, SelectiveDepthIsPerThreadNotShared) {
     EXPECT_GT(checked, 0) << "no info line carried a pv and a seldepth";
 }
 
+
+// ─── History survives a Threads change ─────────────────────────────────────
+//
+// Move-ordering history lives on the search threads, and setting Threads
+// destroys and recreates every one of them. start() documents that history
+// persists through a game and is reset only by ucinewgame, so a GUI changing
+// Threads mid-game must not quietly return the search to ordering-blind.
+//
+// This also pins Movehistory's copy assignment. It carried every table except
+// corrections_, so a copy looked like it preserved the history while silently
+// discarding the accumulated eval-versus-search bias -- invisible except as a
+// change in node counts several moves later.
+TEST_F(SearchTest, HistorySurvivesThreadCountChange) {
+    auto pos = make_pos("r1bqkbnr/pppp1ppp/2n5/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 4 4");
+    SearchEngine engine;
+    SearchLimits lims{};
+    lims.depth = 8;
+    engine.start(pos, lims, /*silent=*/true);
+    engine.wait();
+
+    // Snapshot enough of the tables that a reset cannot pass unnoticed. The
+    // butterfly table is what move ordering reads; corrections_ is the member
+    // the copy used to drop.
+    std::vector<int> before;
+    int nonzero_hist = 0, nonzero_corr = 0;
+    for (int f = 0; f < 64; ++f)
+        for (int t = 0; t < 64; ++t) {
+            Move m;
+            m.set(static_cast<Square>(f), static_cast<Square>(t), quiet);
+            const int s = engine.history().score(m, white);
+            before.push_back(s);
+            nonzero_hist += (s != 0);
+        }
+    std::vector<int> corr_before;
+    for (U64 k = 0; k < 64; ++k) {
+        const int c = engine.history().correction(white, k);
+        corr_before.push_back(c);
+        nonzero_corr += (c != 0);
+    }
+
+    // A search this deep must have written *something*, or the test below
+    // would pass by comparing zeroes to zeroes.
+    ASSERT_GT(nonzero_hist, 0) << "search wrote no butterfly history; test is vacuous";
+
+    engine.set_threads(4);
+
+    size_t i = 0;
+    for (int f = 0; f < 64; ++f)
+        for (int t = 0; t < 64; ++t, ++i) {
+            Move m;
+            m.set(static_cast<Square>(f), static_cast<Square>(t), quiet);
+            EXPECT_EQ(engine.history().score(m, white), before[i])
+                << "butterfly history was reset by set_threads() at " << f << "->" << t;
+        }
+    for (U64 k = 0; k < 64; ++k)
+        EXPECT_EQ(engine.history().correction(white, k), corr_before[k])
+            << "correction history was reset by set_threads() at key " << k;
+
+    // Every new thread must start from the carried tables, not just thread 0.
+    EXPECT_EQ(engine.threads(), 4u);
+}
+
+
 } // namespace
 } // namespace havoc


### PR DESCRIPTION
`Movehistory` was a single `SearchEngine` member that every Lazy SMP thread wrote to concurrently. Its tables are plain `int`s with no synchronisation — butterfly history, two 2.4 MB continuation planes, and correction history — so **any multi-threaded search was a data race, and therefore undefined behaviour**, not merely a lossy update.

Sharing was also working against the search: Lazy SMP gets its value from threads taking different routes through the tree, and steering all of them with one set of cutoff statistics pushes them back down the same route.

## The change

- `Movehistory` moves into `Searchthread`, alongside the per-thread `parameters`, pawn/material caches and evaluator already there.
- One accessor (`thread_history(thread_id)`) rather than 26 direct member references, so where this state lives stays a single decision.
- `clear()` and the continuation-weight setup fan out across the pool.

## Two bugs found while doing it

`Threadpool::init()` destroys and recreates every `Searchthread`, so putting history there made `setoption name Threads` silently reset move ordering mid-game — contradicting `start()`, where history is documented to persist through a game and reset only on `ucinewgame`. The tables are now carried across the resize.

Fixing that exposed a second bug: `Movehistory::operator=` copied the butterfly table, countermoves and both continuation planes, **but not `corrections_`**. Any copy looked like it preserved the history while throwing away the accumulated eval-versus-search bias.

## Evidence

ThreadSanitizer, `go depth 8` at `Threads 4` (ASLR disabled via `setarch -R`):

| | races | `Movehistory` frames |
|---|---|---|
| `main` | 2651 | `apply_history_bonus` ×5837, `ContinuationHistory` ×2170, `update`/`malus`/`update_continuation`/`update_correction` |
| this branch | 542 | **zero** |

538 of the 542 remaining are on the single 128 MB heap block — the transposition table's intentional lockless races. The other 4 are pre-existing `position::qnodes()` node-counter reads in `readout_pv`, unrelated to this diff.

- Bench **697583**, identical to `main` — single-threaded search is unaffected by construction.
- **162/162** tests pass, including a new regression test.
- Peak RSS at `Hash 16`: 1 thread 161→161 MB, 16 threads 220→259 MB, 64 threads 788→930 MB (~2.4 MB/thread, as predicted).

## Test

`HistorySurvivesThreadCountChange` searches to depth 8, snapshots the butterfly and correction tables, changes `Threads`, and asserts both survive. It asserts the search actually wrote something first, so it cannot pass by comparing zeroes.

Negative controls — both bugs are caught:
- drop the `corrections_` copy → `correction history was reset by set_threads() at key 0`
- drop the carry in `set_threads` → `butterfly history was reset by set_threads() at 1->11`

## Not covered

Helper threads no longer share ordering statistics, which is a real behavioural change at high thread counts that single-threaded bench cannot see. Filed as follow-up rather than blocking a UB fix.