### PR TITLE
fix: keep tuned parameters when Threads changes

### DIFF
--- a/include/havoc/search.hpp
+++ b/include/havoc/search.hpp
@@ -182,6 +182,14 @@ class SearchEngine {
     /// context later is then a change to this function and nothing else.
     Movehistory& thread_history(int thread_id) { return search_threads_[thread_id]->history; }
 
+    /// Push every piece of engine-owned state onto one search thread.
+    /// Threadpool::init() destroys and recreates Searchthread objects, so this
+    /// is also the restore path after a Threads change: anything per-thread
+    /// that the engine owns must be listed here exactly once, or it silently
+    /// reverts to its default the next time the pool is resized. `carried` is
+    /// the history to restore, or nullptr to leave the thread's own alone.
+    void configure_thread(unsigned i, const Movehistory* carried);
+
     // Search methods
     void iterative_deepening(position& p, U16 depth, bool silent, int thread_id);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -85,11 +85,12 @@ void SearchEngine::set_threads(int n) {
     // threads and wedged the engine.
     n = std::clamp(n, kMinThreads, kMaxThreads);
 
-    // Threadpool::init() destroys and recreates every Searchthread, and the
-    // move-ordering history lives on those objects. start() documents that
-    // history persists through a game and is reset only by ucinewgame, and a
-    // GUI may change Threads at any point, so carry the tables across instead
-    // of quietly returning every thread to ordering-blind mid-game.
+    // Threadpool::init() destroys and recreates every Searchthread, so every
+    // piece of engine-owned per-thread state has to be put back afterwards.
+    // History is carried because start() documents that it persists through a
+    // game and resets only on ucinewgame, and a GUI may change Threads at any
+    // point; the tuned parameters are carried because otherwise the freshly
+    // constructed threads evaluate with the compiled-in defaults.
     const bool had_threads = search_threads_.size() > 0;
     Movehistory carried;
     if (had_threads)
@@ -97,9 +98,8 @@ void SearchEngine::set_threads(int n) {
 
     search_threads_.init(n);
 
-    if (had_threads)
-        for (unsigned i = 0; i < search_threads_.size(); ++i)
-            search_threads_[i]->history = carried;
+    for (unsigned i = 0; i < search_threads_.size(); ++i)
+        configure_thread(i, had_threads ? &carried : nullptr);
 }
 
 bool SearchEngine::set_hash_size(int mb) {
@@ -118,20 +118,27 @@ void SearchEngine::clear() {
         search_threads_[i]->history.clear();
 }
 
+void SearchEngine::configure_thread(unsigned i, const Movehistory* carried) {
+    Searchthread* t = search_threads_[i];
+
+    t->params = params_;
+
+    // The pawn and material tables cache scores computed under the old
+    // parameters. They are keyed by pawn/material structure, not by the
+    // parameter set, so without an explicit clear the new values would be
+    // masked by stale hits for the rest of the session.
+    t->pawn_tbl.clear();
+    t->material_tbl.clear();
+    t->evaluator = std::make_unique<HCEEvaluator>(t->pawn_tbl, t->material_tbl, t->params);
+
+    if (carried)
+        t->history = *carried;
+}
+
 void SearchEngine::load_params(const std::string& filename) {
     params_.load(filename);
-    for (unsigned i = 0; i < search_threads_.size(); ++i) {
-        search_threads_[i]->params = params_;
-        // The pawn and material tables cache scores computed under the old
-        // parameters. They are keyed by pawn/material structure, not by the
-        // parameter set, so without an explicit clear the new values would be
-        // masked by stale hits for the rest of the session.
-        search_threads_[i]->pawn_tbl.clear();
-        search_threads_[i]->material_tbl.clear();
-        search_threads_[i]->evaluator = std::make_unique<HCEEvaluator>(
-            search_threads_[i]->pawn_tbl, search_threads_[i]->material_tbl,
-            search_threads_[i]->params);
-    }
+    for (unsigned i = 0; i < search_threads_.size(); ++i)
+        configure_thread(i, nullptr);
 }
 
 // ─── Pruning helpers ────────────────────────────────────────────────────────

--- a/tests/test_search.cpp
+++ b/tests/test_search.cpp
@@ -7,6 +7,8 @@
 #include "havoc/uci.hpp"
 #include "havoc/zobrist.hpp"
 
+#include <cstdio>
+#include <fstream>
 #include <iostream>
 #include <random>
 #include <sstream>
@@ -1547,6 +1549,60 @@ TEST_F(SearchTest, HistorySurvivesThreadCountChange) {
     EXPECT_EQ(engine.threads(), 4u);
 }
 
+// ─── Tuned parameters survive a Threads change ─────────────────────────────
+//
+// Threadpool::init() destroys and recreates every Searchthread, and the
+// evaluation parameters live on those objects -- each new thread default
+// constructs its own `parameters` and builds its evaluator against that copy.
+// Nothing put the loaded values back, so
+//
+//     setoption name ParamFile value tuned.txt
+//     setoption name Threads value 8
+//
+// silently reverted the evaluation to the compiled-in defaults. Search-side
+// heuristics read the engine's own params_ and were unaffected, which is why
+// this was invisible except as a strength change.
+//
+// Measured through node counts, which are deterministic at one thread: a
+// reverted evaluation searches a different tree.
+TEST_F(SearchTest, TunedParametersSurviveThreadCountChange) {
+    const std::string pf = "/tmp/havoc_test_params.txt";
+    {
+        std::ofstream out(pf);
+        ASSERT_TRUE(out.good()) << "could not write " << pf;
+        out << "knight_mobility_scale=400\n";
+    }
+
+    auto nodes_at = [&](bool reload, bool bounce) {
+        SearchEngine engine;
+        if (reload)
+            engine.load_params(pf);
+        if (bounce)
+            engine.set_threads(1);
+        auto pos = make_pos("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+        SearchLimits lims{};
+        lims.depth = 9;
+        engine.start(pos, lims, /*silent=*/true);
+        engine.wait();
+        // Not pos.nodes(): start() searches per-thread copies of the position,
+        // so the caller's object never sees a node.
+        return engine.total_nodes();
+    };
+
+    const U64 baseline = nodes_at(/*reload=*/false, /*bounce=*/false);
+    const U64 tuned = nodes_at(/*reload=*/true, /*bounce=*/false);
+    const U64 tuned_after_bounce = nodes_at(/*reload=*/true, /*bounce=*/true);
+
+    std::remove(pf.c_str());
+
+    // Without this the test cannot distinguish "parameters were kept" from
+    // "the parameter had no effect", and would pass on the broken build.
+    ASSERT_NE(tuned, baseline) << "param file changed nothing; test is vacuous";
+
+    EXPECT_EQ(tuned_after_bounce, tuned)
+        << "set_threads() reverted the tuned evaluation parameters: searched "
+        << tuned_after_bounce << " nodes, expected " << tuned << " (untuned is " << baseline << ")";
+}
 
 } // namespace
 } // namespace havoc

--- a/tests/test_search.cpp
+++ b/tests/test_search.cpp
@@ -8,6 +8,7 @@
 #include "havoc/zobrist.hpp"
 
 #include <cstdio>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <random>
@@ -1566,7 +1567,10 @@ TEST_F(SearchTest, HistorySurvivesThreadCountChange) {
 // Measured through node counts, which are deterministic at one thread: a
 // reverted evaluation searches a different tree.
 TEST_F(SearchTest, TunedParametersSurviveThreadCountChange) {
-    const std::string pf = "/tmp/havoc_test_params.txt";
+    // Not "/tmp": that path does not exist on Windows, where this silently
+    // failed to open and the test asserted on a file it had never written.
+    const std::string pf =
+        (std::filesystem::temp_directory_path() / "havoc_test_params.txt").string();
     {
         std::ofstream out(pf);
         ASSERT_TRUE(out.good()) << "could not write " << pf;


### PR DESCRIPTION
Closes #111.

`Threadpool::init()` destroys and recreates every `Searchthread`, and the evaluation parameters live on those objects — each new thread default-constructs its own `parameters` and builds its pawn/material caches and `HCEEvaluator` against that copy. `load_params()` pushed the loaded values into the threads, but nothing put them back after a later `init()`, so this sequence silently reverted the evaluation to the compiled-in defaults:

    setoption name ParamFile value tuned.txt
    setoption name Threads value 8

The search-side heuristics read the engine's own `params_` and were unaffected. It is the *evaluation* that reverted, which is why this was invisible except as a strength change — and it would have quietly invalidated any tuning run or match where a GUI set `Threads` after `ParamFile`.

## The fix

Rather than adding a second copy of the restore logic, `load_params()` and `set_threads()` now share one `configure_thread()`, so per-thread state the engine owns is listed in exactly one place. The next member added to `Searchthread` cannot reintroduce this by being forgotten in one of the two paths — which is precisely how the history reset fixed in #110 arose.

## Evidence

Node counts, deterministic at one thread — a reverted evaluation searches a different tree:

| | default | after `ParamFile` | after `Threads` change |
|---|---|---|---|
| before | 697583 | 587378 | **697583** ← reverted |
| after | 697583 | 587378 | **587378** |

## Test

`TunedParametersSurviveThreadCountChange` loads a param file, searches, changes `Threads`, and asserts the node count does not move. It first asserts the param file changed the node count at all, so it cannot pass by measuring a parameter with no effect.

Negative control — restoring only the history and not the parameters:

    set_threads() reverted the tuned evaluation parameters:
    searched 18896 nodes, expected 7215 (untuned is 18896)

The reverted count matches the untuned baseline exactly.

Bench **697583** unchanged. **163/163** tests pass.