### PR TITLE
ci: run the UCI fuzz corpus against the sanitizer build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,3 +107,16 @@ jobs:
         run: >
           ctest -C Debug --output-on-failure --parallel 4
           -E 'EverySearchParameterReachesTheSearch'
+
+      # The unit tests drive the engine through its C++ interface, so they
+      # cannot reach the UCI layer's own parsing. Every case in this corpus
+      # crashed or hung a released build at some point. Run against the
+      # sanitizer build so a surviving-but-corrupt case is still caught.
+      #
+      # ~70s wall clock, of which only ~30s is CPU -- most of it is waiting on
+      # searches that must be given time to finish, because a "go" followed
+      # immediately by "quit" aborts the search and looks like a hang.
+      # The seed is fixed so a failure here is reproducible.
+      - name: Fuzz UCI (ASan + UBSan)
+        if: matrix.os == 'ubuntu-latest' && matrix.compiler == 'gcc'
+        run: ./scripts/testing/fuzz-uci.sh build-debug/havoc 7


### PR DESCRIPTION
The unit tests drive the engine through its C++ interface, so they cannot reach the UCI layer's own parsing — which is where seven crash bugs were found previously, and where `fuzz-uci.sh`'s corpus comes from. The script has been sitting in the tree as something you had to remember to run.

Attached to the **existing ASan+UBSan job** rather than the release build, so a case that survives but corrupts memory is still caught.

Verified locally against that exact configuration (`Debug` + `HAVOC_ENABLE_SANITIZERS=ON`, `HAVOC_NATIVE=OFF`) before wiring it up, because a slow instrumented build tripping the script's timeouts would look like a hang and make CI flaky:

    3031 cases, all survived
    real 1m11s   user 0m30s

The gap between wall clock and CPU is deliberate — a `go` followed immediately by `quit` aborts the search, so each case has to be given time to finish.

Seed fixed at the script default so a CI failure is reproducible rather than a one-off nobody can reproduce.

Roadmap item; no engine code changes.