### PR TITLE
feat: record which features change when a move is made

### DIFF
--- a/include/havoc/feature_delta.hpp
+++ b/include/havoc/feature_delta.hpp
@@ -22,9 +22,10 @@ namespace havoc {
 /// See `docs/nnue-integration.md`.
 ///
 /// This is a log of the most recent mutation, not part of the board state. It
-/// is valid only between a `do_move` and the matching `undo_move`, and it is
-/// not restored on undo -- an accumulator pops its own stack rather than
-/// replaying events backwards.
+/// is non-empty only immediately after a move was made: `undo_move` and
+/// `undo_null_move` empty it again, because undoing runs the same primitives
+/// and would otherwise leave the inverse events visible, and an accumulator
+/// pops its own stack rather than replaying events backwards.
 struct FeatureDelta {
     struct Event {
         Color c;
@@ -40,22 +41,30 @@ struct FeatureDelta {
     static constexpr int max_events = 4;
 
     std::array<Event, max_events> events{};
+
+    /// Number of events recorded. A value greater than `max_events` means a
+    /// caller recorded more than one mutation without clearing, which is a bug
+    /// in the caller; the surplus events are dropped rather than written past
+    /// the buffer, so it stays detectable instead of corrupting the board state
+    /// that sits next to it in memory.
     int n = 0;
 
     void clear() { n = 0; }
 
-    void add(const Color& c, const Piece& p, const Square& sq) {
-        assert(n < max_events);
-        events[static_cast<std::size_t>(n++)] = Event{c, p, sq, true};
-    }
+    void add(const Color& c, const Piece& p, const Square& sq) { record(c, p, sq, true); }
 
-    void remove(const Color& c, const Piece& p, const Square& sq) {
-        assert(n < max_events);
-        events[static_cast<std::size_t>(n++)] = Event{c, p, sq, false};
-    }
+    void remove(const Color& c, const Piece& p, const Square& sq) { record(c, p, sq, false); }
 
     const Event* begin() const { return events.data(); }
-    const Event* end() const { return events.data() + n; }
+    const Event* end() const { return events.data() + (n < max_events ? n : max_events); }
+
+  private:
+    void record(const Color& c, const Piece& p, const Square& sq, bool added) {
+        assert(n < max_events);
+        if (n < max_events)
+            events[static_cast<std::size_t>(n)] = Event{c, p, sq, added};
+        ++n;
+    }
 };
 
 } // namespace havoc

--- a/include/havoc/feature_delta.hpp
+++ b/include/havoc/feature_delta.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "havoc/types.hpp"
+
+#include <array>
+#include <cassert>
+#include <cstdint>
+
+namespace havoc {
+
+/// What changed on the board when the last move was made.
+///
+/// An NNUE-style evaluator is affordable only because its first layer is kept
+/// in an accumulator and updated by adding and subtracting the few columns a
+/// move touches. That requires the board to be able to answer, cheaply and
+/// exactly, *which (colour, piece, square) features appeared and disappeared*.
+/// This is that answer, and nothing more.
+///
+/// Deliberately it says what changed, never what it means: the mapping from
+/// these events to feature indices, king buckets and output buckets belongs to
+/// the evaluator, so changing the network topology does not touch move-making.
+/// See `docs/nnue-integration.md`.
+///
+/// This is a log of the most recent mutation, not part of the board state. It
+/// is valid only between a `do_move` and the matching `undo_move`, and it is
+/// not restored on undo -- an accumulator pops its own stack rather than
+/// replaying events backwards.
+struct FeatureDelta {
+    struct Event {
+        Color c;
+        Piece p;
+        Square sq;
+        bool added; ///< true if the feature appeared, false if it disappeared.
+    };
+
+    /// Four is the exact worst case, not a guess. A piece moving is a remove
+    /// plus an add, so castling -- two pieces moving -- is four events, and
+    /// nothing else reaches it: promotion-capture is three (remove the captured
+    /// piece, remove the pawn, add the promoted piece).
+    static constexpr int max_events = 4;
+
+    std::array<Event, max_events> events{};
+    int n = 0;
+
+    void clear() { n = 0; }
+
+    void add(const Color& c, const Piece& p, const Square& sq) {
+        assert(n < max_events);
+        events[static_cast<std::size_t>(n++)] = Event{c, p, sq, true};
+    }
+
+    void remove(const Color& c, const Piece& p, const Square& sq) {
+        assert(n < max_events);
+        events[static_cast<std::size_t>(n++)] = Event{c, p, sq, false};
+    }
+
+    const Event* begin() const { return events.data(); }
+    const Event* end() const { return events.data() + n; }
+};
+
+} // namespace havoc

--- a/include/havoc/position.hpp
+++ b/include/havoc/position.hpp
@@ -268,6 +268,8 @@ inline void piece_data::clear() {
     for (auto& v : square_of)
         for (auto& w : v)
             std::fill(w.begin(), w.end(), no_square);
+
+    delta.clear();
 }
 
 inline void piece_data::do_quiet(const Color& c, const Piece& p, const Square& f, const Square& t,

--- a/include/havoc/position.hpp
+++ b/include/havoc/position.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "havoc/bitboard.hpp"
+#include "havoc/feature_delta.hpp"
 #include "havoc/magics.hpp"
 #include "havoc/types.hpp"
 #include "havoc/utils.hpp"
@@ -62,6 +63,11 @@ struct piece_data {
     std::array<std::array<U64, no_piece + 1>, colors> bitmap{};
     std::array<std::array<std::array<std::uint8_t, squares>, pieces>, 2> piece_idx{};
     std::array<std::array<std::array<Square, 11>, pieces>, 2> square_of;
+
+    /// Change log for the most recent mutation. Not board state: see
+    /// `feature_delta.hpp`. Written by the three primitives below, cleared by
+    /// `position::do_move`/`undo_move`, read by an incremental evaluator.
+    FeatureDelta delta;
 
     piece_data() {
         color_on.fill(no_color);
@@ -220,6 +226,10 @@ class position {
     [[nodiscard]] inline Square king_square() const { return ifo.ks[ifo.stm]; }
     [[nodiscard]] inline Color color_on(const Square& s) const { return pcs.color_on[s]; }
 
+    /// The features that changed on the last `do_move`. Valid only until the
+    /// next board mutation; see `feature_delta.hpp`.
+    [[nodiscard]] inline const FeatureDelta& delta() const { return pcs.delta; }
+
     [[nodiscard]] bool is_cap_promotion(const Movetype& mt);
     [[nodiscard]] bool is_promotion(const U8& mt);
 
@@ -286,6 +296,9 @@ inline void piece_data::do_quiet(const Color& c, const Piece& p, const Square& f
         ifo.pawnkey ^= zobrist::piece(f, c, p);
         ifo.pawnkey ^= zobrist::piece(t, c, p);
     }
+
+    delta.remove(c, p, f);
+    delta.add(c, p, t);
 }
 
 inline void piece_data::do_cap(const Color& c, const Piece& p, const Square& f, const Square& t,
@@ -365,6 +378,8 @@ inline void piece_data::remove_piece(const Color& c, const Piece& p, const Squar
     ifo.repkey ^= zobrist::piece(s, c, p);
     if (p == pawn)
         ifo.pawnkey ^= zobrist::piece(s, c, p);
+
+    delta.remove(c, p, s);
 }
 
 inline void piece_data::add_piece(const Color& c, const Piece& p, const Square& s, info& ifo) {
@@ -382,6 +397,8 @@ inline void piece_data::add_piece(const Color& c, const Piece& p, const Square& 
     ifo.repkey ^= zobrist::piece(s, c, p);
     if (p == pawn)
         ifo.pawnkey ^= zobrist::piece(s, c, p);
+
+    delta.add(c, p, s);
 }
 
 inline void piece_data::set(const Color& c, const Piece& p, const Square& s, info& ifo) {

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -422,6 +422,11 @@ void position::undo_move(const Move& m) {
     const Piece p = piece_on(from);
     const Color us = Color(to_move() ^ 1);
     Piece cp = ifo.captured;
+
+    // Cleared on the way in as well as on the way out: undoing runs the same
+    // primitives, so without this the move's own events would still be present
+    // and the inverse events would be appended to them, overflowing a buffer
+    // sized for one mutation.
     pcs.delta.clear();
 
     if (t == quiet) {
@@ -452,6 +457,13 @@ void position::undo_move(const Move& m) {
     }
     ifo = history_.back();
     history_.pop_back();
+
+    // Undoing runs the same primitives, so they have just recorded the inverse
+    // events. Those describe a mutation no evaluator asked about -- an
+    // accumulator pops its own stack rather than replaying backwards -- so the
+    // delta is emptied here. That keeps the rule simple enough to rely on: the
+    // delta is non-empty only immediately after a move was made.
+    pcs.delta.clear();
 }
 
 // ─── null moves ─────────────────────────────────────────────────────────────
@@ -483,6 +495,7 @@ void position::do_null_move() {
 void position::undo_null_move() {
     ifo = history_.back();
     history_.pop_back();
+    pcs.delta.clear();
 }
 
 // ─── SEE ────────────────────────────────────────────────────────────────────

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -329,6 +329,7 @@ void position::do_move(const Move& m) {
     ifo.cmask = static_cast<U16>(ifo.cmask & castle_rights_after(from) & castle_rights_after(to));
 
     ifo.captured = no_piece;
+    pcs.delta.clear();
 
     if (t == quiet) {
         pcs.do_quiet(us, p, from, to, ifo);
@@ -421,6 +422,7 @@ void position::undo_move(const Move& m) {
     const Piece p = piece_on(from);
     const Color us = Color(to_move() ^ 1);
     Piece cp = ifo.captured;
+    pcs.delta.clear();
 
     if (t == quiet) {
         pcs.do_quiet(us, p, from, to, ifo);
@@ -459,6 +461,7 @@ void position::do_null_move() {
     const Color them = Color(us ^ 1);
 
     history_.push_back(ifo);
+    pcs.delta.clear();
 
     if (ifo.eps != no_square) {
         ifo.key ^= zobrist::ep(util::col(ifo.eps));

--- a/tests/test_position.cpp
+++ b/tests/test_position.cpp
@@ -753,4 +753,159 @@ TEST_F(PositionTest, RejectedFenLeavesAnEmptyBoardNotAHalfParsedOne) {
     EXPECT_EQ(p.get_pieces<black>(), 0ULL);
 }
 
+// ─── Incremental feature deltas ─────────────────────────────────────────────
+//
+// An NNUE accumulator is only as correct as the board's answer to "which
+// features changed?". A missed event does not crash and does not corrupt the
+// position -- it silently desynchronises the accumulator from the board, and
+// the first symptom is an evaluation that is wrong by an unpredictable amount
+// in positions nobody can characterise. That is close to undebuggable later,
+// and trivial to catch here, which is why this test exists before any
+// evaluator consumes the delta.
+//
+// The oracle is the board itself: replay the recorded events onto the
+// pre-move squares and the result must equal the post-move squares exactly.
+
+namespace {
+
+struct BoardSnapshot {
+    std::array<Color, squares> color{};
+    std::array<Piece, squares> piece{};
+};
+
+BoardSnapshot snapshot_of(const position& p) {
+    BoardSnapshot b;
+    for (int s = 0; s < squares; ++s) {
+        b.color[static_cast<std::size_t>(s)] = p.color_on(Square(s));
+        b.piece[static_cast<std::size_t>(s)] = p.piece_on(Square(s));
+    }
+    return b;
+}
+
+::testing::AssertionResult delta_reproduces_board(const BoardSnapshot& before,
+                                                  const FeatureDelta& d,
+                                                  const BoardSnapshot& after,
+                                                  const std::string& what) {
+    BoardSnapshot b = before;
+    for (const auto& e : d) {
+        const auto sq = static_cast<std::size_t>(e.sq);
+        if (e.added) {
+            if (b.piece[sq] != no_piece)
+                return ::testing::AssertionFailure()
+                       << what << ": delta adds a feature on square " << int(e.sq)
+                       << ", which is already occupied";
+            b.color[sq] = e.c;
+            b.piece[sq] = e.p;
+        } else {
+            if (b.piece[sq] != e.p || b.color[sq] != e.c)
+                return ::testing::AssertionFailure()
+                       << what << ": delta removes colour " << int(e.c) << " piece " << int(e.p)
+                       << " from square " << int(e.sq) << ", which holds colour "
+                       << int(b.color[sq]) << " piece " << int(b.piece[sq]);
+            b.color[sq] = no_color;
+            b.piece[sq] = no_piece;
+        }
+    }
+    for (int s = 0; s < squares; ++s) {
+        const auto sq = static_cast<std::size_t>(s);
+        if (b.piece[sq] != after.piece[sq] || b.color[sq] != after.color[sq])
+            return ::testing::AssertionFailure()
+                   << what << ": after replaying " << d.n << " events, square " << s
+                   << " holds colour " << int(b.color[sq]) << " piece " << int(b.piece[sq])
+                   << " but the board holds colour " << int(after.color[sq]) << " piece "
+                   << int(after.piece[sq]);
+    }
+    return ::testing::AssertionSuccess();
+}
+
+void walk_and_check_deltas(position& p, int depth, long& checked, std::array<long, 16>& by_type,
+                           std::string& failure) {
+    if (depth == 0 || !failure.empty())
+        return;
+
+    Movegen mv(p);
+    mv.generate<pseudo_legal, pieces>();
+    for (int i = 0; i < mv.size(); ++i) {
+        const Move m = mv[i];
+        if (!p.is_legal(m))
+            continue;
+
+        const BoardSnapshot before = snapshot_of(p);
+        p.do_move(m);
+        const BoardSnapshot after = snapshot_of(p);
+
+        ++checked;
+        ++by_type[static_cast<std::size_t>(m.type) & 15u];
+
+        const auto r = delta_reproduces_board(
+            before, p.delta(), after,
+            "move type " + std::to_string(int(m.type)) + " " + std::to_string(int(m.f)) + "->" +
+                std::to_string(int(m.t)));
+        if (!r) {
+            failure = r.message();
+            p.undo_move(m);
+            return;
+        }
+
+        walk_and_check_deltas(p, depth - 1, checked, by_type, failure);
+        p.undo_move(m);
+        if (!failure.empty())
+            return;
+    }
+}
+
+} // namespace
+
+TEST_F(PositionTest, FeatureDeltaReproducesEveryMoveOnTheBoard) {
+    // Chosen so that between them every move type occurs: kiwipete supplies
+    // castling both ways and captures, the third supplies en passant, and the
+    // fourth supplies promotions and promotion-captures.
+    const std::vector<std::pair<std::string, int>> suite{
+        {"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1", 4},
+        {"r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1", 3},
+        {"rnbqkbnr/ppp1p1pp/8/3pPp2/8/8/PPPP1PPP/RNBQKBNR w KQkq f6 0 3", 3},
+        {"n1n5/PPPk4/8/8/8/8/4Kppp/5N1N b - - 0 1", 4},
+    };
+
+    long checked = 0;
+    std::array<long, 16> by_type{};
+
+    for (const auto& [fen, depth] : suite) {
+        std::istringstream ss(fen);
+        position p(ss);
+        std::string failure;
+        walk_and_check_deltas(p, depth, checked, by_type, failure);
+        ASSERT_TRUE(failure.empty()) << "in " << fen << "\n" << failure;
+    }
+
+    EXPECT_GT(checked, 500000) << "the walk did not actually cover much";
+
+    // Without this the test could pass by never generating the move types that
+    // are hardest to decompose, which are exactly the ones worth testing.
+    EXPECT_GT(by_type[quiet], 0) << "no quiet moves were exercised";
+    EXPECT_GT(by_type[capture], 0) << "no captures were exercised";
+    EXPECT_GT(by_type[ep], 0) << "no en passant captures were exercised";
+    EXPECT_GT(by_type[castle_ks], 0) << "no kingside castling was exercised";
+    EXPECT_GT(by_type[castle_qs], 0) << "no queenside castling was exercised";
+    EXPECT_GT(by_type[promotion_q], 0) << "no promotions were exercised";
+    EXPECT_GT(by_type[capture_promotion_q], 0) << "no promotion-captures were exercised";
+}
+
+// A null move changes no features, so the delta must report none rather than
+// leaving the previous move's events visible to an evaluator that would then
+// apply them a second time.
+TEST_F(PositionTest, NullMoveReportsAnEmptyDelta) {
+    std::istringstream ss("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+    position p(ss);
+
+    Movegen mv(p);
+    mv.generate<pseudo_legal, pieces>();
+    ASSERT_GT(mv.size(), 0);
+    p.do_move(mv[0]);
+    ASSERT_GT(p.delta().n, 0) << "a real move should have recorded something";
+
+    p.do_null_move();
+    EXPECT_EQ(p.delta().n, 0);
+}
+
 } // namespace havoc

--- a/tests/test_position.cpp
+++ b/tests/test_position.cpp
@@ -823,6 +823,29 @@ void walk_and_check_deltas(position& p, int depth, long& checked, std::array<lon
     if (depth == 0 || !failure.empty())
         return;
 
+    // Replaying to the right board proves nothing was missed, but not that
+    // nothing spurious was added: a balanced remove/add pair for an unrelated
+    // feature replays to the same board while making an accumulator do work,
+    // and on a king move would trigger a needless bucket refresh. So the event
+    // count is pinned exactly. A piece moving is a remove plus an add, which
+    // fixes every entry here.
+    auto expected_events = [](Movetype t) -> int {
+        switch (t) {
+        case quiet:
+            return 2;
+        case capture:
+        case ep:
+            return 3;
+        case castle_ks:
+        case castle_qs:
+            return 4;
+        default:
+            // Promotion is remove pawn + add piece; promotion-capture is that
+            // plus removing the captured piece.
+            return t < capture_promotion_q ? 2 : 3;
+        }
+    };
+
     Movegen mv(p);
     mv.generate<pseudo_legal, pieces>();
     for (int i = 0; i < mv.size(); ++i) {
@@ -837,10 +860,18 @@ void walk_and_check_deltas(position& p, int depth, long& checked, std::array<lon
         ++checked;
         ++by_type[static_cast<std::size_t>(m.type) & 15u];
 
-        const auto r = delta_reproduces_board(
-            before, p.delta(), after,
-            "move type " + std::to_string(int(m.type)) + " " + std::to_string(int(m.f)) + "->" +
-                std::to_string(int(m.t)));
+        const std::string what = "move type " + std::to_string(int(m.type)) + " " +
+                                 std::to_string(int(m.f)) + "->" + std::to_string(int(m.t));
+
+        const int want = expected_events(Movetype(m.type));
+        if (p.delta().n != want) {
+            failure = what + ": recorded " + std::to_string(p.delta().n) +
+                      " events but this move type changes exactly " + std::to_string(want);
+            p.undo_move(m);
+            return;
+        }
+
+        const auto r = delta_reproduces_board(before, p.delta(), after, what);
         if (!r) {
             failure = r.message();
             p.undo_move(m);
@@ -849,6 +880,15 @@ void walk_and_check_deltas(position& p, int depth, long& checked, std::array<lon
 
         walk_and_check_deltas(p, depth - 1, checked, by_type, failure);
         p.undo_move(m);
+
+        // The delta describes the move that was just made and nothing else, so
+        // once it is taken back there is nothing left to describe. Leaving the
+        // inverse events here would let an evaluator apply them twice.
+        if (p.delta().n != 0) {
+            failure = what + ": undo_move left " + std::to_string(p.delta().n) +
+                      " events behind instead of an empty delta";
+            return;
+        }
         if (!failure.empty())
             return;
     }
@@ -881,14 +921,19 @@ TEST_F(PositionTest, FeatureDeltaReproducesEveryMoveOnTheBoard) {
     EXPECT_GT(checked, 500000) << "the walk did not actually cover much";
 
     // Without this the test could pass by never generating the move types that
-    // are hardest to decompose, which are exactly the ones worth testing.
+    // are hardest to decompose, which are exactly the ones worth testing. Each
+    // promotion type is named separately because underpromotions travel a
+    // different branch of do_move's dispatch than queen promotions do.
     EXPECT_GT(by_type[quiet], 0) << "no quiet moves were exercised";
     EXPECT_GT(by_type[capture], 0) << "no captures were exercised";
     EXPECT_GT(by_type[ep], 0) << "no en passant captures were exercised";
     EXPECT_GT(by_type[castle_ks], 0) << "no kingside castling was exercised";
     EXPECT_GT(by_type[castle_qs], 0) << "no queenside castling was exercised";
-    EXPECT_GT(by_type[promotion_q], 0) << "no promotions were exercised";
-    EXPECT_GT(by_type[capture_promotion_q], 0) << "no promotion-captures were exercised";
+    for (const Movetype t : {promotion_q, promotion_r, promotion_b, promotion_n})
+        EXPECT_GT(by_type[t], 0) << "promotion type " << int(t) << " was never exercised";
+    for (const Movetype t :
+         {capture_promotion_q, capture_promotion_r, capture_promotion_b, capture_promotion_n})
+        EXPECT_GT(by_type[t], 0) << "promotion-capture type " << int(t) << " was never exercised";
 }
 
 // A null move changes no features, so the delta must report none rather than


### PR DESCRIPTION
Steps 1 and 2 of [`docs/nnue-integration.md`](../blob/main/docs/nnue-integration.md): make the board able to report **which features changed**, then prove the report is complete. Nothing consumes it yet.

### Why

An NNUE accumulator is affordable only because it is updated incrementally — add and subtract the few columns a move touches instead of recomputing the first layer. That needs an exact, cheap answer to *which (colour, piece, square) features appeared and disappeared*. `do_move` returned `void` and exposed nothing.

As `nnue-integration.md` found, the decomposition already existed and was already centralised: every board mutation goes through `do_quiet`, `add_piece` and `remove_piece`. The primitives only had to stop discarding what they already knew. Four events is the exact worst case, not a guess — a piece moving is a remove plus an add, so castling is four and promotion-capture three — so the buffer is fixed size with no allocation.

`FeatureDelta` reports *what changed, never what it means*. Mapping events to feature indices, king buckets and output buckets belongs to the evaluator, so changing network topology will not touch move-making.

### Inert

Bench is **697583 nodes** before and after — identical. 165/165 tests pass (163 before).

### Correctness

A missed event would not crash and would not corrupt the position; it would silently desynchronise an accumulator from the board and surface much later as an evaluation wrong by an unpredictable amount in positions nobody can characterise. So `FeatureDeltaReproducesEveryMoveOnTheBoard` replays the recorded events onto the pre-move squares and requires the result to equal the post-move squares exactly, over every legal move of a four-position walk (~500k moves). It additionally pins the event count per move type, requires `undo_move` to leave the delta empty, and asserts a move-type histogram covering all four promotion and all four promotion-capture types, so it cannot pass by never generating the hard cases.

**Negative controls run** — each makes the tests fail as intended: dropping `do_quiet`'s remove event, dropping `remove_piece`'s event, dropping the null-move clear, and dropping `undo_move`'s entry clear (Debug assert).

### A bug found in review

`undo_move` runs the same primitives, so it records the inverse events. Clearing only on the way out left the move's own events in the buffer while undo appended more — overflowing it and writing into the board state next to it in memory. Fixed by clearing on entry as well; recording now also drops surplus events rather than writing past the buffer, so the failure mode is a visible count rather than corruption.

### Not in this change

Steps 3-5: `IEvaluator::push`/`pop` hooks, a trivial incremental material evaluator checked against from-scratch, then the real accumulator.

The nps cost of recording (step 1's other requirement) is still to be measured on an idle machine — the box is currently running an SPRT and wall-clock nps under that contention has ~15% variance. `perf` is blocked and valgrind unavailable here. Bench node count being identical bounds the *behavioural* risk at zero regardless.