### PR TITLE
feat: let an evaluator follow the search incrementally

### DIFF
--- a/include/havoc/eval/evaluator.hpp
+++ b/include/havoc/eval/evaluator.hpp
@@ -59,7 +59,10 @@ class IEvaluator {
     ///
     /// Needed whenever the board changes by something other than a move --
     /// setting up a new position, or replaying a game from UCI -- since there
-    /// is no delta to follow across such a jump.
+    /// is no delta to follow across such a jump. The search calls this once per
+    /// thread at the start of every search, unconditionally: unlike push/pop it
+    /// is not per-node, so an evaluator that keeps state without wanting deltas
+    /// still gets it.
     virtual void refresh(const position& pos) { (void)pos; }
 };
 

--- a/include/havoc/eval/evaluator.hpp
+++ b/include/havoc/eval/evaluator.hpp
@@ -3,6 +3,8 @@
 /// @file evaluator.hpp
 /// @brief Abstract evaluation interface.
 
+#include "havoc/feature_delta.hpp"
+
 #include <string>
 
 namespace havoc {
@@ -24,6 +26,41 @@ class IEvaluator {
 
     /// Human-readable name of this evaluator.
     [[nodiscard]] virtual std::string name() const = 0;
+
+    /// Whether this evaluator maintains state incrementally and therefore
+    /// needs to be told about every move.
+    ///
+    /// This exists so that the hooks below cost nothing at all when they are
+    /// not wanted. The search caches the answer once per thread and skips the
+    /// calls entirely, which matters because an unconditional virtual call on
+    /// every `do_move` would be an indirect branch the compiler cannot inline
+    /// away, taken millions of times a second, in exchange for an empty body.
+    ///
+    /// The answer must not change over an evaluator's lifetime.
+    [[nodiscard]] virtual bool wants_deltas() const { return false; }
+
+    /// A move was made. `pos` is the position after it, `d` the features it
+    /// changed. Called only when `wants_deltas()` is true, and paired with
+    /// exactly one `pop()`.
+    ///
+    /// Null moves push an empty delta rather than being skipped, so that the
+    /// evaluator's stack depth always matches the search's. An evaluator whose
+    /// output depends on side to move must therefore not infer "nothing
+    /// changed" from an empty delta.
+    virtual void push(const position& pos, const FeatureDelta& d) {
+        (void)pos;
+        (void)d;
+    }
+
+    /// The move most recently pushed was taken back.
+    virtual void pop() {}
+
+    /// Discard all incremental state and rebuild it from `pos`.
+    ///
+    /// Needed whenever the board changes by something other than a move --
+    /// setting up a new position, or replaying a game from UCI -- since there
+    /// is no delta to follow across such a jump.
+    virtual void refresh(const position& pos) { (void)pos; }
 };
 
 } // namespace havoc

--- a/include/havoc/search.hpp
+++ b/include/havoc/search.hpp
@@ -10,6 +10,8 @@
 #include "havoc/utils.hpp"
 
 #include <atomic>
+#include <functional>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <vector>
@@ -159,6 +161,27 @@ class SearchEngine {
     /// only for a single-threaded search -- which is what the tests run.
     const Movehistory& history() const { return search_threads_[0]->history; }
 
+    /// How each search thread's evaluator is built.
+    ///
+    /// The engine owns one evaluator per thread and rebuilds them whenever the
+    /// thread count changes, so "which evaluator" cannot be a property of a
+    /// thread the caller hands in -- it has to be a rule the engine can reapply.
+    /// This is that rule. It is the seam an NNUE evaluator will be installed
+    /// through, and the one tests use to substitute an instrumented evaluator
+    /// without the engine knowing anything about it.
+    using EvaluatorFactory = std::function<std::unique_ptr<IEvaluator>(Searchthread&)>;
+
+    /// Installs a factory and rebuilds every thread's evaluator with it.
+    /// Passing nullptr restores the built-in hand-crafted evaluation.
+    void set_evaluator_factory(EvaluatorFactory factory);
+
+    /// Name of the evaluator installed on one search thread. Which evaluator a
+    /// thread ended up with is otherwise unobservable, and it is exactly what
+    /// silently reverts when the pool is rebuilt.
+    [[nodiscard]] std::string evaluator_name(unsigned thread_id) const {
+        return search_threads_[static_cast<int>(thread_id)]->evaluator().name();
+    }
+
   private:
     hash_table tt_;
     Threadpool<Searchthread> search_threads_;
@@ -189,6 +212,36 @@ class SearchEngine {
     /// reverts to its default the next time the pool is resized. `carried` is
     /// the history to restore, or nullptr to leave the thread's own alone.
     void configure_thread(unsigned i, const Movehistory* carried);
+
+    /// See set_evaluator_factory. Null means the built-in HCE.
+    EvaluatorFactory evaluator_factory_;
+
+    /// Make the move and tell an incremental evaluator what changed. Both
+    /// halves live here so that a new call site cannot make a move without
+    /// telling the evaluator, which would silently desynchronise it.
+    void do_move(position& pos, const Move& m, int thread_id) {
+        pos.do_move(m);
+        if (search_threads_[thread_id]->wants_deltas())
+            search_threads_[thread_id]->evaluator().push(pos, pos.delta());
+    }
+
+    void undo_move(position& pos, const Move& m, int thread_id) {
+        if (search_threads_[thread_id]->wants_deltas())
+            search_threads_[thread_id]->evaluator().pop();
+        pos.undo_move(m);
+    }
+
+    void do_null_move(position& pos, int thread_id) {
+        pos.do_null_move();
+        if (search_threads_[thread_id]->wants_deltas())
+            search_threads_[thread_id]->evaluator().push(pos, pos.delta());
+    }
+
+    void undo_null_move(position& pos, int thread_id) {
+        if (search_threads_[thread_id]->wants_deltas())
+            search_threads_[thread_id]->evaluator().pop();
+        pos.undo_null_move();
+    }
 
     // Search methods
     void iterative_deepening(position& p, U16 depth, bool silent, int thread_id);

--- a/include/havoc/thread_pool.hpp
+++ b/include/havoc/thread_pool.hpp
@@ -50,13 +50,33 @@ class Searchthread : public Workerthread {
     Movehistory history;
     pawn_table pawn_tbl{params};
     material_table material_tbl{params};
-    std::unique_ptr<IEvaluator> evaluator;
 
-    Searchthread() { evaluator = std::make_unique<HCEEvaluator>(pawn_tbl, material_tbl, params); }
+    Searchthread() { set_evaluator(std::make_unique<HCEEvaluator>(pawn_tbl, material_tbl, params)); }
 
     explicit Searchthread(std::function<void()> func) : Workerthread(std::move(func)) {
-        evaluator = std::make_unique<HCEEvaluator>(pawn_tbl, material_tbl, params);
+        set_evaluator(std::make_unique<HCEEvaluator>(pawn_tbl, material_tbl, params));
     }
+
+    /// Installs the evaluator and caches whether it wants move deltas.
+    ///
+    /// The two travel together deliberately: the cached flag is read on every
+    /// node, and a flag that disagreed with the installed evaluator would
+    /// either silently stop feeding an incremental evaluator -- desynchronising
+    /// its accumulator from the board -- or pay for calls nobody consumes.
+    void set_evaluator(std::unique_ptr<IEvaluator> e) {
+        evaluator_ = std::move(e);
+        wants_deltas_ = evaluator_->wants_deltas();
+    }
+
+    [[nodiscard]] IEvaluator& evaluator() { return *evaluator_; }
+    [[nodiscard]] const IEvaluator& evaluator() const { return *evaluator_; }
+
+    /// Cached `evaluator().wants_deltas()`; see `IEvaluator::wants_deltas`.
+    [[nodiscard]] bool wants_deltas() const { return wants_deltas_; }
+
+  private:
+    std::unique_ptr<IEvaluator> evaluator_;
+    bool wants_deltas_ = false;
 };
 
 // ─── Thread pool ────────────────────────────────────────────────────────────

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -129,10 +129,18 @@ void SearchEngine::configure_thread(unsigned i, const Movehistory* carried) {
     // masked by stale hits for the rest of the session.
     t->pawn_tbl.clear();
     t->material_tbl.clear();
-    t->evaluator = std::make_unique<HCEEvaluator>(t->pawn_tbl, t->material_tbl, t->params);
+    t->set_evaluator(evaluator_factory_
+                         ? evaluator_factory_(*t)
+                         : std::make_unique<HCEEvaluator>(t->pawn_tbl, t->material_tbl, t->params));
 
     if (carried)
         t->history = *carried;
+}
+
+void SearchEngine::set_evaluator_factory(EvaluatorFactory factory) {
+    evaluator_factory_ = std::move(factory);
+    for (unsigned i = 0; i < search_threads_.size(); ++i)
+        configure_thread(i, nullptr);
 }
 
 void SearchEngine::load_params(const std::string& filename) {
@@ -164,7 +172,7 @@ int SearchEngine::futility_move_count(bool improving, U16 depth) {
 /// needed but the position cannot be searched any further.
 int SearchEngine::static_eval(position& p, int thread_id) {
     auto* sthread = search_threads_[thread_id];
-    return sthread->evaluator->evaluate(p, -1);
+    return sthread->evaluator().evaluate(p, -1);
 }
 
 // ─── Start search ───────────────────────────────────────────────────────────
@@ -208,6 +216,14 @@ void SearchEngine::start(position& p, const SearchLimits& lims, bool silent) {
     // Create per-thread copies
     for (unsigned i = 0; i < search_threads_.size(); ++i) {
         positions_.emplace_back(std::make_unique<position>(p));
+
+        // The root arrives by a jump, not by a move, so there is no delta that
+        // gets an incremental evaluator from wherever it was to here. Every
+        // search therefore starts by rebuilding that state from the board.
+        // Without this an accumulator would be one game's worth of moves out of
+        // date and every evaluation after it silently wrong.
+        if (search_threads_[i]->wants_deltas())
+            search_threads_[i]->evaluator().refresh(*positions_[i]);
     }
     completed_depth_.assign(search_threads_.size(), 0);
 
@@ -773,7 +789,7 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
         static_eval_val = score::kNegInf;
     } else {
         auto* sthread = search_threads_[thread_id];
-        static_eval_val = static_cast<int16_t>(std::lround(sthread->evaluator->evaluate(pos)));
+        static_eval_val = static_cast<int16_t>(std::lround(sthread->evaluator().evaluate(pos)));
 
         // Correction history adjusts the raw evaluation, before the TT gets a
         // say. The TT value has a real search behind it and needs no help; the
@@ -854,12 +870,12 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
         // looking at. Record the null explicitly.
         stack->curr_move = Move{};
         stack->push_context(no_piece, 0);
-        pos.do_null_move();
+        do_null_move(pos, thread_id);
         int null_eval =
             (ndepth <= 0 ? -qsearch<non_pv>(pos, -beta, -beta + 1, 0, stack + 1, thread_id)
                          : -search<non_pv>(pos, -beta, -beta + 1, static_cast<U16>(ndepth),
                                            stack + 1, thread_id));
-        pos.undo_null_move();
+        undo_null_move(pos, thread_id);
         (stack + 1)->null_search = false;
 
         if (null_eval >= beta) {
@@ -919,7 +935,7 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
                 continue;
 
             stack->push_context(pos.piece_on(static_cast<Square>(pc_move.f)), pc_move.t);
-            pos.do_move(pc_move);
+            do_move(pos, pc_move, thread_id);
             stack->curr_move = pc_move;
 
             // Qsearch first: it is nearly free and rejects most candidates, so
@@ -930,7 +946,7 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
                 pc_score = -search<non_pv>(pos, -probcut_beta, -probcut_beta + 1,
                                            static_cast<U16>(probcut_depth), stack + 1, thread_id);
             }
-            pos.undo_move(pc_move);
+            undo_move(pos, pc_move, thread_id);
 
             if (signals_.stop.load())
                 return score::kDraw;
@@ -1096,7 +1112,7 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
         }
 
         stack->push_context(pos.piece_on(static_cast<Square>(move.f)), move.t);
-        pos.do_move(move);
+        do_move(pos, move, thread_id);
         stack->curr_move = move;
 
         bool givesCheck = pos.in_check();
@@ -1227,7 +1243,7 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
         if (move.type == static_cast<U8>(Movetype::quiet))
             quiets.emplace_back(move);
 
-        pos.undo_move(move);
+        undo_move(pos, move, thread_id);
 
         if (signals_.stop.load())
             return score::kDraw;
@@ -1410,7 +1426,7 @@ int SearchEngine::qsearch(position& p, int alpha, int beta, U16 /*depth*/, Searc
 
     if (!in_check) {
         auto* sthread = search_threads_[thread_id];
-        best_score = static_cast<int>(std::lround(sthread->evaluator->evaluate(p)));
+        best_score = static_cast<int>(std::lround(sthread->evaluator().evaluate(p)));
 
         // As in search(): a TT score has a search behind it and is the better
         // estimate, but only in the direction its bound supports. This was an
@@ -1513,12 +1529,12 @@ int SearchEngine::qsearch(position& p, int alpha, int beta, U16 /*depth*/, Searc
         if (!in_check && p.see(move) < 0)
             continue;
 
-        p.do_move(move);
+        do_move(p, move, thread_id);
         p.adjust_qnodes(1);
 
         int score_val = -qsearch<type>(p, -beta, -alpha, 0, stack + 1, thread_id);
 
-        p.undo_move(move);
+        undo_move(p, move, thread_id);
 
         if (score_val > best_score) {
             best_score = score_val;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -129,15 +129,32 @@ void SearchEngine::configure_thread(unsigned i, const Movehistory* carried) {
     // masked by stale hits for the rest of the session.
     t->pawn_tbl.clear();
     t->material_tbl.clear();
-    t->set_evaluator(evaluator_factory_
-                         ? evaluator_factory_(*t)
-                         : std::make_unique<HCEEvaluator>(t->pawn_tbl, t->material_tbl, t->params));
+
+    auto e = evaluator_factory_
+                 ? evaluator_factory_(*t)
+                 : std::unique_ptr<IEvaluator>(
+                       std::make_unique<HCEEvaluator>(t->pawn_tbl, t->material_tbl, t->params));
+    // A factory that returns nothing would leave the thread with no evaluator
+    // at all, which is a null dereference on the first node rather than
+    // anything diagnosable.
+    assert(e && "evaluator factory returned nullptr");
+    if (!e)
+        e = std::make_unique<HCEEvaluator>(t->pawn_tbl, t->material_tbl, t->params);
+    t->set_evaluator(std::move(e));
 
     if (carried)
         t->history = *carried;
 }
 
 void SearchEngine::set_evaluator_factory(EvaluatorFactory factory) {
+    // configure_thread() destroys the evaluator a search thread may be calling
+    // into right now, so reconfiguring under a live search is a use-after-free.
+    // Waiting rather than refusing, as the UCI layer does for "position": a
+    // caller changing the evaluator has no use for the answer being computed
+    // with the old one.
+    stop();
+    wait();
+
     evaluator_factory_ = std::move(factory);
     for (unsigned i = 0; i < search_threads_.size(); ++i)
         configure_thread(i, nullptr);
@@ -222,8 +239,12 @@ void SearchEngine::start(position& p, const SearchLimits& lims, bool silent) {
         // search therefore starts by rebuilding that state from the board.
         // Without this an accumulator would be one game's worth of moves out of
         // date and every evaluation after it silently wrong.
-        if (search_threads_[i]->wants_deltas())
-            search_threads_[i]->evaluator().refresh(*positions_[i]);
+        //
+        // Unconditional, unlike push/pop: this happens once per search rather
+        // than per node, so it is not worth making an evaluator that keeps
+        // state but does not want deltas -- a cache, say -- opt in separately
+        // and be silently skipped if it forgets.
+        search_threads_[i]->evaluator().refresh(*positions_[i]);
     }
     completed_depth_.assign(search_threads_.size(), 0);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ set(HAVOC_TEST_SOURCES
     test_position.cpp
     test_eval.cpp
     test_eval_discrimination.cpp
+    test_incremental_eval.cpp
     test_search.cpp
 )
 

--- a/tests/test_incremental_eval.cpp
+++ b/tests/test_incremental_eval.cpp
@@ -1,0 +1,241 @@
+/// @file test_incremental_eval.cpp
+/// @brief Proves the incremental-evaluation seam end to end.
+///
+/// Step 4 of `docs/nnue-integration.md`. The mechanism an NNUE accumulator will
+/// ride on -- `FeatureDelta`, `IEvaluator::push`/`pop`/`refresh`, and the
+/// search calling them around every move -- is exercised here with an
+/// evaluation whose correct answer is independently known: material.
+///
+/// Doing it with material rather than a network is the whole point. Material
+/// can be computed from scratch at any moment, so every incremental step has an
+/// oracle, and a desynchronisation is caught at the node it happens on rather
+/// than surfacing much later as an evaluation that is wrong by an
+/// uncharacterisable amount. A bug found here is a bug that would otherwise be
+/// found by staring at a network that plays slightly badly.
+
+#include "havoc/bitboard.hpp"
+#include "havoc/eval/evaluator.hpp"
+#include "havoc/kpk.hpp"
+#include "havoc/magics.hpp"
+#include "havoc/position.hpp"
+#include "havoc/search.hpp"
+#include "havoc/zobrist.hpp"
+
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace havoc {
+namespace {
+
+int piece_value(Piece p) {
+    switch (p) {
+    case pawn:
+        return 100;
+    case knight:
+        return 300;
+    case bishop:
+        return 315;
+    case rook:
+        return 480;
+    case queen:
+        return 910;
+    default:
+        return 0; // kings never leave the board, so their value cannot matter
+    }
+}
+
+/// Material from White's point of view, computed from the board with no
+/// incremental state involved at all. This is the oracle.
+int material_from_scratch(const position& p) {
+    int total = 0;
+    for (int s = 0; s < squares; ++s) {
+        const Piece pc = p.piece_on(Square(s));
+        if (pc == no_piece)
+            continue;
+        const int v = piece_value(pc);
+        total += p.color_on(Square(s)) == white ? v : -v;
+    }
+    return total;
+}
+
+/// Maintains the same number incrementally, through the seam, and checks it
+/// against the oracle every time anyone can observe it.
+class CheckedIncrementalMaterial : public IEvaluator {
+  public:
+    [[nodiscard]] std::string name() const override { return "checked-incremental-material"; }
+
+    [[nodiscard]] bool wants_deltas() const override { return true; }
+
+    void refresh(const position& pos) override {
+        acc_ = material_from_scratch(pos);
+        stack_.clear();
+        ++refreshes_;
+    }
+
+    void push(const position& pos, const FeatureDelta& d) override {
+        stack_.push_back(acc_);
+        for (const auto& e : d) {
+            const int v = e.c == white ? piece_value(e.p) : -piece_value(e.p);
+            acc_ += e.added ? v : -v;
+        }
+        ++pushes_;
+        verify(pos, "after push");
+    }
+
+    void pop() override {
+        if (stack_.empty()) {
+            ++unbalanced_pops_;
+            return;
+        }
+        acc_ = stack_.back();
+        stack_.pop_back();
+        ++pops_;
+    }
+
+    int evaluate(const position& pos, int = -1) override {
+        verify(pos, "at evaluate");
+        // Sign convention: the interface is side-to-move relative.
+        return pos.to_move() == white ? acc_ : -acc_;
+    }
+
+    [[nodiscard]] long pushes() const { return pushes_; }
+    [[nodiscard]] long pops() const { return pops_; }
+    [[nodiscard]] long refreshes() const { return refreshes_; }
+    [[nodiscard]] long checks() const { return checks_; }
+    [[nodiscard]] long unbalanced_pops() const { return unbalanced_pops_; }
+    [[nodiscard]] const std::string& first_mismatch() const { return first_mismatch_; }
+
+  private:
+    void verify(const position& pos, const char* when) {
+        ++checks_;
+        const int truth = material_from_scratch(pos);
+        if (acc_ != truth && first_mismatch_.empty())
+            first_mismatch_ = std::string(when) + ": incremental material is " +
+                              std::to_string(acc_) + " but the board says " +
+                              std::to_string(truth);
+    }
+
+    int acc_ = 0;
+    std::vector<int> stack_;
+    long pushes_ = 0, pops_ = 0, refreshes_ = 0, checks_ = 0, unbalanced_pops_ = 0;
+    std::string first_mismatch_;
+};
+
+class IncrementalEvalTest : public ::testing::Test {
+  protected:
+    void SetUp() override {
+        bitboards::init();
+        magics::init();
+        zobrist::init();
+        kpk::init();
+    }
+};
+
+} // namespace
+
+// The search prunes, reduces, re-searches, makes null moves and drops into
+// quiescence, and every one of those paths makes and unmakes moves. A hand
+// walk over legal moves would miss the asymmetric ones. So this runs the real
+// search and lets it drive the seam.
+TEST_F(IncrementalEvalTest, SearchKeepsAnIncrementalEvaluatorInSyncWithTheBoard) {
+    const std::vector<std::string> fens{
+        "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+        // Kiwipete: castling both ways, many captures.
+        "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",
+        // Promotions and promotion-captures.
+        "n1n5/PPPk4/8/8/8/8/4Kppp/5N1N b - - 0 1",
+        // An en passant is available immediately.
+        "rnbqkbnr/ppp1p1pp/8/3pPp2/8/8/PPPP1PPP/RNBQKBNR w KQkq f6 0 3",
+    };
+
+    for (const auto& fen : fens) {
+        SearchEngine engine;
+        engine.set_threads(1);
+
+        CheckedIncrementalMaterial* probe = nullptr;
+        engine.set_evaluator_factory([&probe](Searchthread&) {
+            auto e = std::make_unique<CheckedIncrementalMaterial>();
+            probe = e.get();
+            return e;
+        });
+
+        std::istringstream ss(fen);
+        position p(ss);
+
+        SearchLimits lims;
+        lims.depth = 7;
+        engine.start(p, lims, /*silent=*/true);
+        engine.wait();
+
+        ASSERT_NE(probe, nullptr) << "the factory was never used for " << fen;
+        EXPECT_TRUE(probe->first_mismatch().empty()) << "in " << fen << "\n"
+                                                     << probe->first_mismatch();
+        EXPECT_EQ(probe->unbalanced_pops(), 0)
+            << "in " << fen << ": the search popped more times than it pushed";
+        EXPECT_GT(probe->pushes(), 1000) << "in " << fen << ": the search barely ran";
+        EXPECT_EQ(probe->pushes(), probe->pops())
+            << "in " << fen << ": every move made must be taken back exactly once";
+        EXPECT_GT(probe->refreshes(), 0) << "in " << fen << ": the root was never refreshed";
+    }
+}
+
+// The oracle above only proves agreement if disagreement is detectable, and a
+// seam that is never invoked agrees trivially. This checks the probe's own
+// alarm works by desynchronising it deliberately.
+TEST_F(IncrementalEvalTest, TheSyncCheckActuallyDetectsDesynchronisation) {
+    class BrokenIncrementalMaterial : public CheckedIncrementalMaterial {
+      public:
+        // Ignores the delta entirely: the accumulator stays at the root value
+        // while the board moves on beneath it.
+        void push(const position& pos, const FeatureDelta&) override {
+            CheckedIncrementalMaterial::push(pos, FeatureDelta{});
+        }
+    };
+
+    SearchEngine engine;
+    engine.set_threads(1);
+
+    BrokenIncrementalMaterial* probe = nullptr;
+    engine.set_evaluator_factory([&probe](Searchthread&) {
+        auto e = std::make_unique<BrokenIncrementalMaterial>();
+        probe = e.get();
+        return e;
+    });
+
+    std::istringstream ss("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1");
+    position p(ss);
+
+    SearchLimits lims;
+    lims.depth = 5;
+    engine.start(p, lims, /*silent=*/true);
+    engine.wait();
+
+    ASSERT_NE(probe, nullptr);
+    EXPECT_FALSE(probe->first_mismatch().empty())
+        << "an evaluator that ignores the delta went undetected, so the check above proves nothing";
+}
+
+// Installing an evaluator must not be a one-way door, and it must survive the
+// pool being torn down and rebuilt -- which is what a Threads change does.
+TEST_F(IncrementalEvalTest, EvaluatorFactorySurvivesThreadCountChangeAndCanBeCleared) {
+    SearchEngine engine;
+    engine.set_threads(1);
+    engine.set_evaluator_factory(
+        [](Searchthread&) { return std::make_unique<CheckedIncrementalMaterial>(); });
+
+    engine.set_threads(2);
+    for (unsigned i = 0; i < engine.threads(); ++i)
+        EXPECT_EQ(engine.evaluator_name(i), "checked-incremental-material")
+            << "thread " << i << " lost the installed evaluator when Threads changed";
+
+    engine.set_evaluator_factory(nullptr);
+    for (unsigned i = 0; i < engine.threads(); ++i)
+        EXPECT_NE(engine.evaluator_name(i), "checked-incremental-material")
+            << "thread " << i << " kept the installed evaluator after it was cleared";
+}
+
+} // namespace havoc

--- a/tests/test_incremental_eval.cpp
+++ b/tests/test_incremental_eval.cpp
@@ -21,6 +21,8 @@
 #include "havoc/search.hpp"
 #include "havoc/zobrist.hpp"
 
+#include <bitset>
+#include <functional>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -64,26 +66,67 @@ int material_from_scratch(const position& p) {
 
 /// Maintains the same number incrementally, through the seam, and checks it
 /// against the oracle every time anyone can observe it.
+///
+/// It also tracks the exact set of active (colour, piece, square) features,
+/// because material alone is a weak oracle: it is invariant under piece
+/// *movement*, so an evaluator that dropped every quiet move, or that was told
+/// the wrong from/to squares, or that castled the rook to the wrong square,
+/// would still report the right material. Those are precisely the errors that
+/// break a network, whose input is the feature set itself. The bitset is what a
+/// real accumulator's input layer indexes, so checking it checks the thing that
+/// will actually matter.
 class CheckedIncrementalMaterial : public IEvaluator {
   public:
+    /// (colour, piece, square), the shape an NNUE input layer is indexed by.
+    using FeatureSet = std::bitset<2 * 6 * 64>;
+
+    static std::size_t feature_index(Color c, Piece p, Square sq) {
+        return (static_cast<std::size_t>(c) * 6 + static_cast<std::size_t>(p)) * 64 +
+               static_cast<std::size_t>(sq);
+    }
+
+    static FeatureSet features_from_scratch(const position& p) {
+        FeatureSet f;
+        for (int s = 0; s < squares; ++s) {
+            const Piece pc = p.piece_on(Square(s));
+            if (pc != no_piece)
+                f.set(feature_index(p.color_on(Square(s)), pc, Square(s)));
+        }
+        return f;
+    }
+
     [[nodiscard]] std::string name() const override { return "checked-incremental-material"; }
 
     [[nodiscard]] bool wants_deltas() const override { return true; }
 
     void refresh(const position& pos) override {
         acc_ = material_from_scratch(pos);
+        features_ = features_from_scratch(pos);
         stack_.clear();
         ++refreshes_;
     }
 
     void push(const position& pos, const FeatureDelta& d) override {
-        stack_.push_back(acc_);
+        stack_.push_back({acc_, features_});
         for (const auto& e : d) {
             const int v = e.c == white ? piece_value(e.p) : -piece_value(e.p);
             acc_ += e.added ? v : -v;
+
+            const std::size_t idx = feature_index(e.c, e.p, e.sq);
+            // A delta that turns a feature on twice, or off when it was never
+            // on, is describing a board that cannot exist. Catching it here
+            // names the event; letting it through would leave the accumulator
+            // wrong in a way only the final comparison could see.
+            if (features_.test(idx) == e.added && first_mismatch_.empty())
+                first_mismatch_ = std::string("push: event ") + (e.added ? "adds" : "removes") +
+                                  " feature " + std::to_string(idx) + " which is already " +
+                                  (e.added ? "present" : "absent");
+            features_.set(idx, e.added);
         }
         ++pushes_;
         verify(pos, "after push");
+        if (on_push_)
+            on_push_(pushes_);
     }
 
     void pop() override {
@@ -91,7 +134,8 @@ class CheckedIncrementalMaterial : public IEvaluator {
             ++unbalanced_pops_;
             return;
         }
-        acc_ = stack_.back();
+        acc_ = stack_.back().material;
+        features_ = stack_.back().features;
         stack_.pop_back();
         ++pops_;
     }
@@ -102,25 +146,52 @@ class CheckedIncrementalMaterial : public IEvaluator {
         return pos.to_move() == white ? acc_ : -acc_;
     }
 
+    /// Called after each push, so a test can interrupt the search mid-tree.
+    void set_on_push(std::function<void(long)> f) { on_push_ = std::move(f); }
+
     [[nodiscard]] long pushes() const { return pushes_; }
     [[nodiscard]] long pops() const { return pops_; }
     [[nodiscard]] long refreshes() const { return refreshes_; }
     [[nodiscard]] long checks() const { return checks_; }
     [[nodiscard]] long unbalanced_pops() const { return unbalanced_pops_; }
+    [[nodiscard]] std::size_t depth() const { return stack_.size(); }
     [[nodiscard]] const std::string& first_mismatch() const { return first_mismatch_; }
 
   private:
+    struct Frame {
+        int material;
+        FeatureSet features;
+    };
+
     void verify(const position& pos, const char* when) {
         ++checks_;
+        if (!first_mismatch_.empty())
+            return;
+
         const int truth = material_from_scratch(pos);
-        if (acc_ != truth && first_mismatch_.empty())
+        if (acc_ != truth) {
             first_mismatch_ = std::string(when) + ": incremental material is " +
                               std::to_string(acc_) + " but the board says " +
                               std::to_string(truth);
+            return;
+        }
+
+        const FeatureSet truth_features = features_from_scratch(pos);
+        if (features_ != truth_features) {
+            const FeatureSet wrong = features_ ^ truth_features;
+            std::size_t first = 0;
+            while (first < wrong.size() && !wrong.test(first))
+                ++first;
+            first_mismatch_ = std::string(when) + ": incremental feature set differs from the board in " +
+                              std::to_string(wrong.count()) + " features, first at index " +
+                              std::to_string(first) + " (square " + std::to_string(first % 64) + ")";
+        }
     }
 
     int acc_ = 0;
-    std::vector<int> stack_;
+    FeatureSet features_;
+    std::vector<Frame> stack_;
+    std::function<void(long)> on_push_;
     long pushes_ = 0, pops_ = 0, refreshes_ = 0, checks_ = 0, unbalanced_pops_ = 0;
     std::string first_mismatch_;
 };
@@ -217,6 +288,116 @@ TEST_F(IncrementalEvalTest, TheSyncCheckActuallyDetectsDesynchronisation) {
     ASSERT_NE(probe, nullptr);
     EXPECT_FALSE(probe->first_mismatch().empty())
         << "an evaluator that ignores the delta went undetected, so the check above proves nothing";
+}
+
+// Material is invariant under piece movement, so a check that only compared
+// material would accept an evaluator that got every square wrong -- which is
+// exactly the failure that breaks a network. This proves the feature-set half
+// of the oracle is the part doing that work, by moving pieces to the wrong
+// squares while keeping material exactly right.
+TEST_F(IncrementalEvalTest, TheSyncCheckDetectsCorrectMaterialOnWrongSquares) {
+    class WrongSquares : public CheckedIncrementalMaterial {
+      public:
+        void push(const position& pos, const FeatureDelta& d) override {
+            FeatureDelta mangled = d;
+            // Mirror every square. Piece counts, and so material, are
+            // untouched; every feature index is wrong.
+            for (int i = 0; i < mangled.n && i < FeatureDelta::max_events; ++i)
+                mangled.events[static_cast<std::size_t>(i)].sq =
+                    Square(63 - static_cast<int>(mangled.events[static_cast<std::size_t>(i)].sq));
+            CheckedIncrementalMaterial::push(pos, mangled);
+        }
+    };
+
+    SearchEngine engine;
+    engine.set_threads(1);
+
+    WrongSquares* probe = nullptr;
+    engine.set_evaluator_factory([&probe](Searchthread&) {
+        auto e = std::make_unique<WrongSquares>();
+        probe = e.get();
+        return e;
+    });
+
+    std::istringstream ss("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+    position p(ss);
+
+    SearchLimits lims;
+    lims.depth = 5;
+    engine.start(p, lims, /*silent=*/true);
+    engine.wait();
+
+    ASSERT_NE(probe, nullptr);
+    EXPECT_FALSE(probe->first_mismatch().empty())
+        << "features on the wrong squares went undetected, so the check only proves material";
+}
+
+// A search that is cut off mid-tree still unwinds through undo_move, so the
+// hooks must come back balanced. If they did not, the next search would start
+// from a stack that still held frames from the abandoned one.
+TEST_F(IncrementalEvalTest, AnAbortedSearchStillUnwindsTheEvaluatorStack) {
+    SearchEngine engine;
+    engine.set_threads(1);
+
+    CheckedIncrementalMaterial* probe = nullptr;
+    engine.set_evaluator_factory([&probe](Searchthread&) {
+        auto e = std::make_unique<CheckedIncrementalMaterial>();
+        probe = e.get();
+        return e;
+    });
+
+    std::istringstream ss("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1");
+    position p(ss);
+
+    ASSERT_NE(probe, nullptr);
+    probe->set_on_push([&engine](long n) {
+        if (n == 5000)
+            engine.stop();
+    });
+
+    SearchLimits lims;
+    lims.depth = 30; // deep enough that it cannot finish before the abort
+    engine.start(p, lims, /*silent=*/true);
+    engine.wait();
+
+    EXPECT_GE(probe->pushes(), 5000) << "the search stopped before the abort was triggered";
+    EXPECT_LT(probe->pushes(), 500000) << "the search ran to completion instead of being aborted";
+    EXPECT_EQ(probe->pushes(), probe->pops())
+        << "an aborted search left " << (probe->pushes() - probe->pops())
+        << " moves pushed but never popped";
+    EXPECT_EQ(probe->depth(), 0u) << "the evaluator stack was not fully unwound after an abort";
+    EXPECT_TRUE(probe->first_mismatch().empty()) << probe->first_mismatch();
+}
+
+// One engine searching two unrelated positions is the normal case in a game,
+// and the jump between them has no delta. Without a refresh the second search
+// would start from the first position's state.
+TEST_F(IncrementalEvalTest, ASecondUnrelatedRootIsRefreshedNotContinued) {
+    SearchEngine engine;
+    engine.set_threads(1);
+
+    CheckedIncrementalMaterial* probe = nullptr;
+    engine.set_evaluator_factory([&probe](Searchthread&) {
+        auto e = std::make_unique<CheckedIncrementalMaterial>();
+        probe = e.get();
+        return e;
+    });
+    ASSERT_NE(probe, nullptr);
+
+    SearchLimits lims;
+    lims.depth = 6;
+
+    for (const char* fen : {"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+                            "8/2k5/8/8/8/5Q2/8/4K3 w - - 0 1"}) {
+        std::istringstream ss(fen);
+        position p(ss);
+        engine.start(p, lims, /*silent=*/true);
+        engine.wait();
+        EXPECT_TRUE(probe->first_mismatch().empty()) << "in " << fen << "\n"
+                                                     << probe->first_mismatch();
+    }
+
+    EXPECT_GE(probe->refreshes(), 2) << "the second root reused the first root's state";
 }
 
 // Installing an evaluator must not be a one-way door, and it must survive the


### PR DESCRIPTION
Steps 3 and 4 of [`docs/nnue-integration.md`](../blob/main/docs/nnue-integration.md), done together because step 3 alone has no way to prove it works. Follows #116, which made the board able to report what changed.

### The hooks

`IEvaluator` gains `push`, `pop` and `refresh`. `push` receives the position after a move and the features it changed. `refresh` exists because the board also changes by *jumps* — setting up a position, or the root arriving at the start of a search — and there is no delta to follow across those. Nothing refreshed at the root before this, which would have left an accumulator a whole game out of date with every evaluation after it silently wrong.

**The hooks are free when unwanted.** An unconditional virtual call on every `do_move` is an indirect branch the compiler cannot inline away, taken millions of times a second in exchange for an empty body. Evaluators declare `wants_deltas()` once and `Searchthread` caches it, so the HCE pays a predicted branch and nothing else. Bench is **697583 nodes** — unchanged.

Move-making in the search now goes through four helpers instead of touching `position` directly, so a future call site cannot make a move without telling the evaluator. Null moves push an *empty* delta rather than being skipped, keeping the evaluator's stack depth equal to the search's; the interface says explicitly that an empty delta does not mean nothing changed, since side to move did.

### The seam

Which evaluator a thread gets is now a rule the engine can reapply — `SearchEngine::EvaluatorFactory` — rather than something a caller pushes in once, because `Threadpool::init()` destroys and recreates `Searchthread` objects on every `Threads` change and anything installed by hand would silently revert. This is how NNUE will arrive, and how the test below substitutes an instrumented evaluator without the engine knowing.

### The proof (step 4)

A test evaluator maintains material *and the exact set of active (colour, piece, square) features* through the seam, and checks both against the board at every push and every evaluate. **The real search drives it** — pruning, reductions, re-searches, null moves and quiescence all make and unmake moves, and a hand walk over legal moves would miss the asymmetric paths.

Material alone would have been a weak oracle: it is invariant under piece *movement*, so it would accept an evaluator that dropped every quiet move or got every square wrong — precisely what breaks a network. Hence the feature set, which is the shape an NNUE input layer is indexed by.

Four negative controls, each required to be caught:
- an evaluator that ignores the delta entirely;
- one that mirrors every square, keeping material exactly right while making every feature index wrong;
- an aborted search (stopped from inside the evaluator mid-tree) must still unwind the stack — it does, exactly balanced, `depth() == 0`;
- two unrelated roots on one engine must refresh rather than continue.

### Review

A rubber-duck review of the first commit found one blocking issue, fixed in the second: `set_evaluator_factory` destroyed an evaluator a search thread could be calling into. It now settles the engine first, the same stop-then-wait the UCI layer does for `position`.

### Numbers

Bench 697583 (identical). 171/171 tests pass, 165 before.

nps cost is still unmeasured — the box is saturated by an SPRT and wall-clock has ~15% variance there; `perf` is blocked and valgrind unavailable. The identical bench bounds the behavioural risk at zero regardless.