### PR TITLE
feat: order captures by what they took, not just what it was worth

### DIFF
--- a/include/havoc/move_order.hpp
+++ b/include/havoc/move_order.hpp
@@ -71,16 +71,56 @@ struct SearchNode {
 /// move ordering pipeline or grow without bound over a long search.
 constexpr int kMaxHistory = 16384;
 
-/// Capture scores combine the exchange value with a history term. The two live
-/// on very different scales -- SEE spans roughly +/-910 while history saturates
-/// at +/-kMaxHistory -- so the exchange value is scaled up before they are
-/// added. This keeps the sign of the capture score equal to the sign of the SEE
-/// value, which is what separates the good-capture phase from the bad-capture
-/// phase, and leaves history to break ties between captures of equal value.
-/// 4096 is the smallest power of two for which the narrowest gap between two
-/// distinct exchange values (15, a bishop for a knight) outweighs the full
-/// history range.
-constexpr int kCaptureSeeScale = 4096;
+/// Capture scores combine the exchange value with history terms. The exchange
+/// value is scaled up by this first, so that it is the primary sort key and
+/// history only breaks ties between captures it scores identically.
+///
+/// How large this has to be is not a matter of taste, and the reasoning that
+/// used to sit here was wrong. It claimed the narrowest gap between two
+/// distinct exchange values was 15, a bishop taken for a knight, and sized the
+/// scale against that. But 15 is the narrowest gap between two *piece values*,
+/// not between two exchange results: see() returns sums and differences of the
+/// material values, so the achievable results are spaced by their greatest
+/// common divisor. With the current numbers (100, 300, 315, 480, 910) that is
+/// 5, and SEE really does return both 115 and 120 in ordinary positions. The
+/// values are tunable, so a tuner is free to make the spacing 1.
+///
+/// Sizing the scale against any particular set of material values is therefore
+/// the wrong move. Instead the history terms are clamped into strictly less
+/// than half a step (kCaptureTieRoom below), which makes the ordering
+/// lexicographic: exchange value first, history second, for any material
+/// values and however the history tables are later rescaled.
+constexpr int kCaptureSeeScale = 1 << 16;
+
+/// Room reserved inside one exchange-value step for history to order captures
+/// that SEE cannot tell apart. Strictly less than half a step, so that two
+/// tie-breaks pulling in opposite directions still cannot span a whole step
+/// and swap two captures of different exchange value.
+constexpr int kCaptureTieRoom = kCaptureSeeScale / 2 - 1;
+
+static_assert(2 * kCaptureTieRoom < kCaptureSeeScale,
+              "history can reorder captures across distinct exchange values");
+
+/// Offset added to every capture whose exchange value is non-negative.
+///
+/// The capture list is split into a good-capture phase and a bad-capture phase
+/// by chunking it at score 0, so the *sign* of a capture's score decides which
+/// side of the killers it is tried on. That split is meant to be a statement
+/// about the exchange -- "this wins material" -- and nothing else. Once history
+/// terms are added to the capture score, an even exchange with a poor record
+/// would silently fall through to the bad-capture phase, which is a change to
+/// the search's shape smuggled in under a change to its ordering.
+///
+/// This offset keeps the two questions separate: SEE alone decides the phase,
+/// history only orders moves within it. It is larger than the whole tie-break
+/// range, so no history value can carry a capture across the boundary in
+/// either direction.
+constexpr int kGoodCaptureBase = 1 << 20;
+
+static_assert(kGoodCaptureBase > kCaptureTieRoom,
+              "history can carry a non-losing capture into the bad-capture phase");
+static_assert(kCaptureSeeScale > kCaptureTieRoom,
+              "history can carry a losing capture into the good-capture phase");
 
 /// Sentinel meaning "no cutoff" when splitting a scored move list into chunks.
 /// It has to sit below every score a scoring function can produce, so it cannot
@@ -141,6 +181,41 @@ struct Movehistory {
     /// the weights set through `set_continuation_weights`.
     int continuation_score(const position& p, const Move& m, const SearchNode* stack) const;
 
+    /// ─── Capture history ────────────────────────────────────────────────
+    ///
+    /// Captures are ordered by their exchange value, which answers "what does
+    /// this win or lose in the ensuing sequence" and nothing else. It cannot
+    /// separate two captures worth the same material, and there are usually
+    /// several: every recapture on the same square, every piece that can take
+    /// the same hanging knight. Nor does it know that in this structure the
+    /// exchange sacrifice on f6 is the move and the equal-looking trade on d5
+    /// never is -- SEE is a property of a square, not of a position.
+    ///
+    /// Capture history supplies what SEE cannot: a record of which captures
+    /// actually produced cutoffs, keyed on the piece that moved, where it
+    /// landed, and what it took. That triple is the smallest key that
+    /// distinguishes the cases SEE conflates, and it is what makes "a rook
+    /// taking a pawn on h7" a different proposition from "a bishop taking a
+    /// pawn on h7".
+    ///
+    /// The score is bounded by kMaxHistory, so it can reorder captures within
+    /// an exchange value but never across kGoodCaptureBase.
+
+    /// Ordering bonus for capture `m`, which must be a capture in `p`.
+    /// `p` is the position before `m` is played, so the captured piece is
+    /// still standing on the destination square.
+    [[nodiscard]] int capture_score(const position& p, const Move& m) const;
+
+    /// Rewards `best` if it is a capture and penalises every other capture in
+    /// `captures` that was tried and did not cut. Called at a fail-high: when
+    /// the cutoff came from a quiet, `best` is simply not a capture and every
+    /// capture tried is penalised, which is the correct lesson.
+    ///
+    /// `p` must be the position at that node with every searched move undone,
+    /// so that piece_on identifies both the moving and the captured piece.
+    void update_capture(const position& p, const Move& best, int bonus,
+                        const std::vector<Move>& captures);
+
     /// ─── Correction history ─────────────────────────────────────────────
     ///
     /// The static evaluation is not a neutral estimator: it is wrong in ways
@@ -192,7 +267,17 @@ struct Movehistory {
     const int* continuation_slot(int plane, const SearchNode* stack, Color c, Piece moved,
                                  const Move& m) const;
 
+    /// Resolves the (color, moved, to, captured) slot for `m`, or nullptr if
+    /// `m` is not a capture or either piece cannot be identified in `p`.
+    const int* capture_slot(const position& p, const Move& m) const;
+    int* capture_slot(const position& p, const Move& m);
+
     std::array<std::array<std::array<int, squares>, squares>, colors> history_;
+    /// Indexed by [color][moved piece][destination][captured piece]. 18 KB,
+    /// small enough to stay resident, so it is held inline rather than behind
+    /// the indirection the continuation tables need.
+    std::array<std::array<std::array<std::array<int, pieces>, squares>, pieces>, colors>
+        capture_history_{};
     /// Indexed by [side to move][pawn key]. Two colours because the same pawn
     /// structure is a different proposition depending on whose move it is.
     std::array<std::array<int, kCorrSize>, colors> corrections_{};

--- a/include/havoc/move_order.hpp
+++ b/include/havoc/move_order.hpp
@@ -144,6 +144,18 @@ inline void apply_history_bonus(int& h, int bonus) {
     h += bonus - h * std::abs(bonus) / kMaxHistory;
 }
 
+static_assert(kMaxHistory <= std::numeric_limits<int16_t>::max(),
+              "capture history values must fit the narrow type they are stored in");
+
+/// Narrow overload for tables held as int16_t to keep their cache footprint
+/// down. The arithmetic is done at full width and the result is bounded by
+/// kMaxHistory, which the assertion above pins inside the narrow range.
+inline void apply_history_bonus(int16_t& h, int bonus) {
+    int wide = h;
+    apply_history_bonus(wide, bonus);
+    h = static_cast<int16_t>(wide);
+}
+
 struct Movehistory {
     Movehistory();
     Movehistory& operator=(const Movehistory& mh);
@@ -269,14 +281,29 @@ struct Movehistory {
 
     /// Resolves the (color, moved, to, captured) slot for `m`, or nullptr if
     /// `m` is not a capture or either piece cannot be identified in `p`.
-    const int* capture_slot(const position& p, const Move& m) const;
-    int* capture_slot(const position& p, const Move& m);
+    const int16_t* capture_slot(const position& p, const Move& m) const;
+    int16_t* capture_slot(const position& p, const Move& m);
 
     std::array<std::array<std::array<int, squares>, squares>, colors> history_;
-    /// Indexed by [color][moved piece][destination][captured piece]. 18 KB,
-    /// small enough to stay resident, so it is held inline rather than behind
-    /// the indirection the continuation tables need.
-    std::array<std::array<std::array<std::array<int, pieces>, squares>, pieces>, colors>
+    /// Indexed by [color][destination][moved piece][captured piece].
+    ///
+    /// Both the element type and the index order are chosen for the cache
+    /// rather than for looks, because this table is read in qsearch, which
+    /// previously touched no history table at all. Adding an 18 KB random
+    /// access stream to the hottest loop in the engine cost 2.55% nps, which
+    /// was more than the better ordering was winning back.
+    ///
+    /// int16_t halves the footprint to 9 KB, which is free: values are bounded
+    /// by kMaxHistory, asserted below to fit.
+    ///
+    /// Keying on the destination *before* the moving piece matters more. The
+    /// captures being scored at one node are not scattered uniformly -- they
+    /// pile up on a handful of contested squares, because every recapture in a
+    /// sequence lands on the same square. Putting the destination outermost
+    /// puts all 36 (mover, victim) combinations for one square in 72
+    /// contiguous bytes, so scoring an entire recapture fight touches one or
+    /// two cache lines instead of one per capture.
+    std::array<std::array<std::array<std::array<int16_t, pieces>, pieces>, squares>, colors>
         capture_history_{};
     /// Indexed by [side to move][pawn key]. Two colours because the same pawn
     /// structure is a different proposition depending on whose move it is.

--- a/include/havoc/types.hpp
+++ b/include/havoc/types.hpp
@@ -41,6 +41,17 @@ enum Movetype {
     no_type
 };
 
+/// True if a move of type `mt` removes an enemy piece from the board.
+///
+/// Capture-promotions count: they take a piece as well as making one, so any
+/// table keyed on what was taken has to see them. The `capture_promotion` and
+/// `pseudo_legal` entries above are classification tags the generator uses
+/// internally, not types a made move carries, so they are deliberately absent.
+constexpr bool is_capture(Movetype mt) {
+    return mt == capture || mt == ep || mt == capture_promotion_q ||
+           mt == capture_promotion_r || mt == capture_promotion_b || mt == capture_promotion_n;
+}
+
 /// Piece types (pawn=0 .. king=5).
 enum Piece { pawn, knight, bishop, rook, queen, king, pieces, no_piece };
 

--- a/scripts/testing/README.md
+++ b/scripts/testing/README.md
@@ -53,13 +53,76 @@ verify the round-trip reproduces the default bench node count exactly before
 trusting it**. `havoc_texel` embeds compiled-in defaults, so it must be rebuilt
 after any `parameters.hpp` change or it silently dumps stale values.
 
-### Accumulated-drift check
+## How many games to spend
+
+The hard constraint is precision per unit time, and it is worse than intuition
+suggests. Measured on the 24-core box at `10+0.1` with `CONC=30`, roughly 55
+games/minute, at the draw rate this book produces:
+
+| games | 95% CI | wall clock |
+|---|---|---|
+| 1000 | ±16.0 Elo | 18 min |
+| 2000 | ±11.3 Elo | 36 min |
+| 3000 | ±9.2 Elo | 55 min |
+| 4000 | ±8.0 Elo | 73 min |
+| 8000 | ±5.7 Elo | 2 h 25 |
+| 16000 | ±4.0 Elo | 4 h 51 |
+
+Read the last two rows carefully. **An 8000-game run resolves ±5.7 Elo.** A
+change genuinely worth +3 Elo needs 30–60k games — twelve to twenty-four hours
+— before a single test can distinguish it from nothing. So running every
+candidate to 8000 games is not merely expensive, it does not answer the
+question either. It buys a number that still contains zero.
+
+The way out is not more games per change. It is to stop asking each change to
+prove its own gain, and instead ask each change not to do damage, then measure
+gain in batches where the effect is large enough to see.
+
+### Tier 0 — no match at all
+
+Docs, tests, CI, refactors, and any change whose bench node count is
+byte-identical. An identical bench is a *stronger* proof of inertness than any
+match could provide, and it is free. Do not spend games on it.
+
+### Tier A — sanity check, cap 1200 games, ~20 min
+
+Every functional PR. `elo0=-10 elo1=0`, a non-regression test. It is not
+trying to prove the change is good; it is trying to catch the change being
+bad, which is a much cheaper question.
+
+- LLR crosses the upper bound → merge.
+- LLR crosses the lower bound → do not merge; investigate.
+- Cap reached undecided → merge only if the point estimate is ≥ −8 Elo **and**
+  there is independent evidence: fewer bench nodes, a mechanism that explains
+  the gain, and a clean review.
+
+That last clause is what makes the tier safe, and it is a real gate. A change
+with no evidence beyond "it measured neutral" should be parked as an issue, not
+merged. Tier A cannot tell those two cases apart, so the judgement has to come
+from somewhere else.
+
+### Tier B — cumulative measurement, 3000 games, ~55 min, every 7–10 PRs
+
+Current `main` against the previous Tier B tag. This is the number to report as
+progress; no Tier A result should ever be quoted as an Elo gain.
 
 Individually a change can measure neutral — say −5 ± 25 — and still be merged
-under the structural-change policy. Ten such merges can hide a real regression
-that no single SPRT was ever powered to see. Periodically SPRT current `main`
-against a snapshot from 5–10 PRs back: the accumulated delta is larger, so it
-resolves faster and in one direction.
+under the rules above. Ten such merges can hide a real regression that no
+single run was ever powered to see. Batching fixes that: eight PRs worth +3
+each is +24 Elo, which 3000 games resolves comfortably, and it resolves in one
+direction rather than as a scatter of overlapping intervals.
+
+### Tier C — 8000+ games
+
+Release candidates, or one specific change that has to be banked as a known
+quantity. Rare, and scheduled deliberately rather than reached by default.
+
+### Standing rule
+
+One machine-occupying job at a time. A second match, a build, or a datagen run
+sharing the box does not just slow an SPRT down — the test is a *timing*
+measurement at a fixed time control, so competing load corrupts the result
+rather than merely delaying it.
 
 ## Parameter optimisation
 

--- a/src/move_order.cpp
+++ b/src/move_order.cpp
@@ -98,7 +98,7 @@ void Movehistory::malus_continuation(const position& p, const SearchNode* stack,
 
 // ─── Capture history ────────────────────────────────────────────────────────
 
-const int* Movehistory::capture_slot(const position& p, const Move& m) const {
+const int16_t* Movehistory::capture_slot(const position& p, const Move& m) const {
     const auto mt = static_cast<Movetype>(m.type);
     if (!is_capture(mt))
         return nullptr;
@@ -110,27 +110,27 @@ const int* Movehistory::capture_slot(const position& p, const Move& m) const {
     if (taken == no_piece || moved == no_piece)
         return nullptr;
 
-    return &capture_history_[p.to_move()][moved][m.t][taken];
+    return &capture_history_[p.to_move()][m.t][moved][taken];
 }
 
-int* Movehistory::capture_slot(const position& p, const Move& m) {
-    return const_cast<int*>(static_cast<const Movehistory*>(this)->capture_slot(p, m));
+int16_t* Movehistory::capture_slot(const position& p, const Move& m) {
+    return const_cast<int16_t*>(static_cast<const Movehistory*>(this)->capture_slot(p, m));
 }
 
 int Movehistory::capture_score(const position& p, const Move& m) const {
-    const int* h = capture_slot(p, m);
+    const int16_t* h = capture_slot(p, m);
     return h ? *h : 0;
 }
 
 void Movehistory::update_capture(const position& p, const Move& best, int bonus,
                                  const std::vector<Move>& captures) {
-    if (int* h = capture_slot(p, best))
+    if (int16_t* h = capture_slot(p, best))
         apply_history_bonus(*h, bonus);
 
     for (const auto& c : captures) {
         if (c == best)
             continue;
-        if (int* h = capture_slot(p, c))
+        if (int16_t* h = capture_slot(p, c))
             apply_history_bonus(*h, -bonus);
     }
 }
@@ -188,9 +188,9 @@ void Movehistory::clear() {
         std::fill(c.begin(), c.end(), 0);
 
     for (auto& color : capture_history_)
-        for (auto& moved : color)
-            for (auto& to : moved)
-                std::fill(to.begin(), to.end(), 0);
+        for (auto& to : color)
+            for (auto& moved : to)
+                std::fill(moved.begin(), moved.end(), 0);
 }
 
 void Movehistory::update_correction(Color c, U64 pawnkey, int depth, int diff) {

--- a/src/move_order.cpp
+++ b/src/move_order.cpp
@@ -20,6 +20,7 @@ Movehistory& Movehistory::operator=(const Movehistory& mh) {
     // eval-versus-search bias while appearing to preserve the history.
     corrections_ = mh.corrections_;
     countermoves = mh.countermoves;
+    capture_history_ = mh.capture_history_;
     *continuation_ = *mh.continuation_;
     cont_pct1_ = mh.cont_pct1_;
     cont_pct2_ = mh.cont_pct2_;
@@ -95,6 +96,45 @@ void Movehistory::malus_continuation(const position& p, const SearchNode* stack,
                 apply_history_bonus(*h, -bonus);
 }
 
+// ─── Capture history ────────────────────────────────────────────────────────
+
+const int* Movehistory::capture_slot(const position& p, const Move& m) const {
+    const auto mt = static_cast<Movetype>(m.type);
+    if (!is_capture(mt))
+        return nullptr;
+
+    // En passant is the one capture whose victim is not standing on the
+    // destination square, and it is always a pawn.
+    const Piece taken = mt == ep ? pawn : p.piece_on(static_cast<Square>(m.t));
+    const Piece moved = p.piece_on(static_cast<Square>(m.f));
+    if (taken == no_piece || moved == no_piece)
+        return nullptr;
+
+    return &capture_history_[p.to_move()][moved][m.t][taken];
+}
+
+int* Movehistory::capture_slot(const position& p, const Move& m) {
+    return const_cast<int*>(static_cast<const Movehistory*>(this)->capture_slot(p, m));
+}
+
+int Movehistory::capture_score(const position& p, const Move& m) const {
+    const int* h = capture_slot(p, m);
+    return h ? *h : 0;
+}
+
+void Movehistory::update_capture(const position& p, const Move& best, int bonus,
+                                 const std::vector<Move>& captures) {
+    if (int* h = capture_slot(p, best))
+        apply_history_bonus(*h, bonus);
+
+    for (const auto& c : captures) {
+        if (c == best)
+            continue;
+        if (int* h = capture_slot(p, c))
+            apply_history_bonus(*h, -bonus);
+    }
+}
+
 void Movehistory::update(const Color& c, const Move& m, const Move& previous, int bonus,
                          int16_t eval, const std::vector<Move>& quiets, Move* killers) {
     if (m.type == static_cast<U8>(Movetype::quiet)) {
@@ -146,6 +186,11 @@ void Movehistory::clear() {
 
     for (auto& c : corrections_)
         std::fill(c.begin(), c.end(), 0);
+
+    for (auto& color : capture_history_)
+        for (auto& moved : color)
+            for (auto& to : moved)
+                std::fill(to.begin(), to.end(), 0);
 }
 
 void Movehistory::update_correction(Color c, U64 pawnkey, int depth, int diff) {
@@ -190,14 +235,22 @@ int Movehistory::score(const Move& m, const Color& c, const Move& previous, cons
 
 int score_captures(const position& p, const Move& m, const Move& /*prev*/,
                    const Move& /*followup*/, const Move& /*threat*/, SearchNode* stack,
-                   const Movehistory* /*hist*/) {
-    return p.see(m) * kCaptureSeeScale + stack->best_move_history()[p.to_move()][m.f][m.t];
+                   const Movehistory* hist) {
+    const int see = p.see(m);
+    int tie = stack->best_move_history()[p.to_move()][m.f][m.t];
+    if (hist)
+        tie += hist->capture_score(p, m);
+    return (see >= 0 ? kGoodCaptureBase : 0) + see * kCaptureSeeScale +
+           std::clamp(tie, -kCaptureTieRoom, kCaptureTieRoom);
 }
 
 int score_qcaptures(const position& p, const Move& m, const Move& /*prev*/,
                     const Move& /*followup*/, const Move& /*threat*/, SearchNode* /*stack*/,
-                    const Movehistory* /*hist*/) {
-    return p.see(m);
+                    const Movehistory* hist) {
+    const int see = p.see(m);
+    const int tie = hist ? hist->capture_score(p, m) : 0;
+    return (see >= 0 ? kGoodCaptureBase : 0) + see * kCaptureSeeScale +
+           std::clamp(tie, -kCaptureTieRoom, kCaptureTieRoom);
 }
 
 int score_quiets(const position& p, const Move& m, const Move& prev, const Move& followup,
@@ -447,11 +500,7 @@ void QMoveorder::next_phase() {
 }
 
 bool QMoveorder::valid_qmove(const Move& m) const {
-    return m_incheck || m.type == static_cast<U8>(capture) || m.type == static_cast<U8>(ep) ||
-           m.type == static_cast<U8>(capture_promotion_q) ||
-           m.type == static_cast<U8>(capture_promotion_r) ||
-           m.type == static_cast<U8>(capture_promotion_b) ||
-           m.type == static_cast<U8>(capture_promotion_n);
+    return m_incheck || is_capture(static_cast<Movetype>(m.type));
 }
 
 } // namespace havoc

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -687,6 +687,7 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
 
     bool in_check = pos.in_check();
     std::vector<Move> quiets;
+    std::vector<Move> captures;
     stack->in_check = in_check;
     stack->ply = (stack - 1)->ply + 1;
 
@@ -794,6 +795,40 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
                                     history_bonus(depth), static_cast<int16_t>(ttvalue), quiets,
                                     stack->killers);
                     thread_history(thread_id).update_continuation(pos, stack, ttm, history_bonus(depth), quiets);
+                    // The capture table, unlike the quiet ones above, is only
+                    // allowed to learn here from a genuine fail-high. The
+                    // asymmetry is not an oversight and it is not small: with
+                    // this update unrestricted, bench goes 684468 -> 947351,
+                    // a 38% larger tree.
+                    //
+                    // The reason the quiet update survives an upper-bound
+                    // entry is that it is competing against other quiets that
+                    // are also unproven, and being the best move known for the
+                    // position is real evidence even when it failed low. A
+                    // capture is not in that situation. Its ordering is
+                    // anchored to the exchange value, so the history term only
+                    // ever has to answer the much narrower question of which
+                    // of several equally-valued captures actually works -- and
+                    // a move that failed low is evidence against, not for.
+                    //
+                    // The one-sidedness makes it worse. `captures` is
+                    // necessarily empty at a node that never ran a move loop,
+                    // so there is no malus to balance the bonus: every capture
+                    // that reaches the TT is rewarded and nothing is ever
+                    // penalised, and the entry saturates at kMaxHistory.
+                    //
+                    // bound_low is deliberately the only bound accepted, and
+                    // widening it to bound_exact was tried and rejected: bench
+                    // 684468 -> 718833. An exact entry means the score fell
+                    // strictly inside the window at the node that stored it,
+                    // so its move was the best of an all or PV node -- it is
+                    // the best move known, which is not the same claim as
+                    // having refuted anything. bound_low is the only bound
+                    // that means a move actually caused a cutoff, and that is
+                    // the only evidence this table wants.
+                    if (e.bound == bound_low && ttvalue >= beta)
+                        thread_history(thread_id).update_capture(pos, ttm, history_bonus(depth),
+                                                                 captures);
                     return ttvalue;
                 }
             }
@@ -947,10 +982,7 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
                 continue;
             // skipQuiets still lets the hash move and the killers through, and
             // those are usually quiet, so the capture test cannot be skipped.
-            const bool pc_is_capture = (pc_move.type == static_cast<U8>(capture)) ||
-                                       (pc_move.type == static_cast<U8>(ep)) ||
-                                       pos.is_cap_promotion(static_cast<Movetype>(pc_move.type));
-            if (!pc_is_capture || !pos.is_legal(pc_move))
+            if (!is_capture(static_cast<Movetype>(pc_move.type)) || !pos.is_legal(pc_move))
                 continue;
             if (pos.see(pc_move) < see_threshold)
                 continue;
@@ -1263,6 +1295,8 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
 
         if (move.type == static_cast<U8>(Movetype::quiet))
             quiets.emplace_back(move);
+        else if (is_capture(static_cast<Movetype>(move.type)))
+            captures.emplace_back(move);
 
         undo_move(pos, move, thread_id);
 
@@ -1299,6 +1333,8 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
                                 history_bonus(depth), static_cast<int16_t>(bestScore), quiets,
                                 stack->killers);
                 thread_history(thread_id).update_continuation(pos, stack, best_move, history_bonus(depth), quiets);
+                thread_history(thread_id).update_capture(pos, best_move, history_bonus(depth),
+                                                         captures);
                 break;
             }
 
@@ -1361,10 +1397,7 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
     // that the evaluation was too high, and a fail-high only the reverse. A
     // capture or a check makes the difference tactical rather than a property
     // of the structure, which is what this table is keyed on.
-    const bool best_is_capture =
-        (best_move.type == static_cast<U8>(capture)) ||
-        (best_move.type == static_cast<U8>(ep)) ||
-        pos.is_cap_promotion(static_cast<Movetype>(best_move.type));
+    const bool best_is_capture = is_capture(static_cast<Movetype>(best_move.type));
 
     if (!in_check && !singular_search && corrected_static_eval != score::kNegInf &&
         !best_is_capture && std::abs(bestScore) < score::kMate - 100 &&

--- a/tests/test_search.cpp
+++ b/tests/test_search.cpp
@@ -11,6 +11,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <numeric>
 #include <random>
 #include <sstream>
 #include <vector>
@@ -283,24 +284,52 @@ TEST_F(SearchTest, HistoryScoresStayBounded) {
 }
 
 // The good/bad capture split is create_chunk(score::kDraw), i.e. the sign of the
-// capture score. Capture scores are see * kCaptureSeeScale + history, so the
-// scale factor has to be large enough that a saturated history score can never
-// flip that sign, or a losing capture with a good history is searched in the
-// good-capture phase and a winning capture with a poor history is deferred.
+// capture score, and within each chunk the order is the score. So the scoring
+// function has to guarantee two separate things: that history never flips the
+// sign, and that history never reorders two captures of different exchange
+// value.
+//
+// This test used to assert both against a claim that the narrowest gap between
+// distinct exchange values is 15, a bishop taken for a knight. That claim is
+// false. 15 is the narrowest gap between two piece *values*; see() returns sums
+// and differences of those values, so its results are spaced by their greatest
+// common divisor, which is 5 today (115 and 120 are both reachable) and can be
+// 1 once a tuner has moved them. The old assertions passed while the invariant
+// they were written to protect was broken.
+//
+// The fix was structural rather than numeric, so the test is too: history is
+// clamped into strictly less than half an exchange step, which makes the
+// ordering lexicographic for any spacing at all.
 TEST_F(SearchTest, CaptureOrderingIsDominatedBySee) {
-    // The narrowest gap between two distinct exchange values: a bishop (315)
-    // taken for a knight (300).
-    constexpr int smallest_see = 15;
+    // Two tie-breaks pulling in opposite directions must not span a full step,
+    // whatever the material values are. This is the property that replaces the
+    // old "narrowest gap is 15" argument.
+    EXPECT_LT(2 * kCaptureTieRoom, kCaptureSeeScale)
+        << "history can reorder two captures whose exchange values differ by one step";
 
-    EXPECT_GT(smallest_see * kCaptureSeeScale, kMaxHistory)
-        << "a saturated history score can flip the sign of a winning capture";
+    // The material values are tunable, so assert the property directly against
+    // their greatest common divisor rather than against a hardcoded gap.
+    const auto vals = position::see_values();
+    int spacing = 0;
+    for (int i = 0; i < 5; ++i)
+        spacing = std::gcd(spacing, vals[static_cast<std::size_t>(i)]);
+    ASSERT_GT(spacing, 0);
+    EXPECT_GE(spacing * kCaptureSeeScale, 2 * kCaptureTieRoom + 1)
+        << "with these material values history can cross an exchange step";
 
-    EXPECT_GT(smallest_see * kCaptureSeeScale, 2 * kMaxHistory)
-        << "history can reorder two captures of different exchange value";
+    // Neither side of the phase boundary can be crossed. A non-losing capture
+    // keeps a positive score even with the worst tie-break, and a losing one
+    // keeps a negative score even with the best.
+    EXPECT_GT(kGoodCaptureBase - kCaptureTieRoom, 0)
+        << "a non-losing capture can be pushed into the bad-capture phase";
+    EXPECT_LT(-kCaptureSeeScale + kCaptureTieRoom, 0)
+        << "a losing capture can be pushed into the good-capture phase";
 
-    // No overflow for the largest value see() can return.
-    constexpr int max_see = 2000;
-    EXPECT_LT(static_cast<long long>(max_see) * kCaptureSeeScale + kMaxHistory,
+    // No overflow for the largest value see() can return, with generous room
+    // for tuned material values.
+    constexpr int max_see = 20000;
+    EXPECT_LT(static_cast<long long>(max_see) * kCaptureSeeScale + kGoodCaptureBase +
+                  kCaptureTieRoom,
               static_cast<long long>(std::numeric_limits<int>::max()));
 }
 
@@ -364,6 +393,151 @@ TEST_F(SearchTest, MoveOrderYieldsEveryLegalMove) {
 // stack - 1 and stack - 2. Only the search guarantees those frames exist; the
 // first version of this code walked back and crashed here, on a four-element
 // stack, which is exactly the kind of caller that must keep working.
+// Captures are ordered by their exchange value, which is a property of a
+// square and a pair of piece values -- it cannot tell two captures worth the
+// same material apart. Capture history exists to break exactly those ties, so
+// the whole point of it is the key: the mover, where it landed, and what it
+// took. If any one of the three is missing, evidence about one capture leaks
+// onto a different one that SEE already scores identically, which is worse
+// than having no table at all.
+TEST_F(SearchTest, CaptureHistoryIsKeyedOnMoverDestinationAndVictim) {
+    // A rook and a bishop that can both take the same pawn on d5, so the only
+    // thing separating the two captures is the piece making them. SEE scores
+    // them identically; this table must not.
+    auto pawn_pos = make_pos("4k3/8/8/3p4/8/8/B7/3RK3 w - - 0 1");
+    ASSERT_EQ(pawn_pos.piece_on(D5), pawn);
+
+    Move rook_takes;
+    rook_takes.set(D1, D5, capture);
+    Move bishop_takes;
+    bishop_takes.set(A2, D5, capture);
+    ASSERT_TRUE(pawn_pos.is_legal(rook_takes));
+    ASSERT_TRUE(pawn_pos.is_legal(bishop_takes));
+
+    Movehistory hist;
+    ASSERT_EQ(hist.capture_score(pawn_pos, rook_takes), 0) << "table did not start empty";
+
+    std::vector<Move> none;
+    hist.update_capture(pawn_pos, rook_takes, kMaxHistory / 4, none);
+
+    EXPECT_GT(hist.capture_score(pawn_pos, rook_takes), 0)
+        << "the capture that cut gained nothing";
+    EXPECT_EQ(hist.capture_score(pawn_pos, bishop_takes), 0)
+        << "evidence about the rook's capture leaked onto the bishop's; the "
+           "mover is not part of the key";
+
+    // Same mover, same destination, different victim: a knight on d5 instead
+    // of a pawn. Nothing learned above applies to it.
+    auto knight_pos = make_pos("4k3/8/8/3n4/8/8/B7/3RK3 w - - 0 1");
+    ASSERT_EQ(knight_pos.piece_on(D5), knight);
+    Move rook_takes_knight;
+    rook_takes_knight.set(D1, D5, capture);
+    EXPECT_EQ(hist.capture_score(knight_pos, rook_takes_knight), 0)
+        << "evidence about taking a pawn leaked onto taking a knight; the "
+           "victim is not part of the key";
+
+    // Same mover, same victim, different destination.
+    auto elsewhere = make_pos("4k3/8/8/8/4R1p1/8/B7/4K3 w - - 0 1");
+    ASSERT_EQ(elsewhere.piece_on(G4), pawn);
+    Move rook_takes_g4;
+    rook_takes_g4.set(E4, G4, capture);
+    ASSERT_TRUE(elsewhere.is_legal(rook_takes_g4));
+    EXPECT_EQ(hist.capture_score(elsewhere, rook_takes_g4), 0)
+        << "evidence about a capture on d5 leaked onto one on g4; the "
+           "destination is not part of the key";
+}
+
+// En passant is the one capture whose victim is not standing on the square the
+// capturing piece lands on. Reading piece_on(to) would find an empty square and
+// key the move as a non-capture, silently dropping every en passant from the
+// table -- a bug that no test comparing scores of ordinary captures can see.
+TEST_F(SearchTest, CaptureHistoryScoresEnPassantAsTakingAPawn) {
+    auto pos = make_pos("4k3/8/8/3pP3/8/8/8/4K3 w - d6 0 1");
+    ASSERT_EQ(pos.piece_on(D6), no_piece) << "the ep destination must be empty";
+    ASSERT_EQ(pos.piece_on(D5), pawn) << "the ep victim stands beside, not on, the target";
+
+    Move ep_capture;
+    ep_capture.set(E5, D6, ep);
+    ASSERT_TRUE(pos.is_legal(ep_capture));
+
+    Movehistory hist;
+    std::vector<Move> none;
+    hist.update_capture(pos, ep_capture, kMaxHistory / 4, none);
+    EXPECT_GT(hist.capture_score(pos, ep_capture), 0)
+        << "en passant was not recorded; its victim is not on the destination";
+
+    // It must be filed as taking a pawn, which is what an ordinary pawn
+    // capture landing on d6 would also be.
+    auto ordinary = make_pos("4k3/8/3p4/4P3/8/8/8/4K3 w - - 0 1");
+    ASSERT_EQ(ordinary.piece_on(D6), pawn);
+    Move pawn_takes;
+    pawn_takes.set(E5, D6, capture);
+    ASSERT_TRUE(ordinary.is_legal(pawn_takes));
+    EXPECT_EQ(hist.capture_score(ordinary, pawn_takes), hist.capture_score(pos, ep_capture))
+        << "en passant is a pawn taking a pawn and must share that slot";
+}
+
+// A quiet move has no victim, so there is no slot for it. update_capture is
+// called at every fail-high, and most cutoffs come from quiets, so this is the
+// common case rather than an edge one: it must do nothing at all rather than
+// index the table with no_piece.
+TEST_F(SearchTest, CaptureHistoryIgnoresQuietMovesAndPenalisesTheOnesThatFailed) {
+    auto pos = make_pos("4k3/8/8/3p4/8/8/B7/3RK3 w - - 0 1");
+
+    Move quiet_move;
+    quiet_move.set(D1, D2, quiet);
+    ASSERT_TRUE(pos.is_legal(quiet_move));
+
+    Move rook_takes;
+    rook_takes.set(D1, D5, capture);
+    Move bishop_takes;
+    bishop_takes.set(A2, D5, capture);
+
+    Movehistory hist;
+    EXPECT_EQ(hist.capture_score(pos, quiet_move), 0) << "a quiet move has no capture slot";
+
+    // The cutoff came from a quiet, and both captures were tried and failed.
+    // Both must be penalised, and the quiet must still leave the table alone.
+    std::vector<Move> tried{rook_takes, bishop_takes};
+    hist.update_capture(pos, quiet_move, kMaxHistory / 4, tried);
+
+    EXPECT_EQ(hist.capture_score(pos, quiet_move), 0)
+        << "a quiet cutoff wrote into the capture table";
+    EXPECT_LT(hist.capture_score(pos, rook_takes), 0) << "a capture that failed was not penalised";
+    EXPECT_LT(hist.capture_score(pos, bishop_takes), 0)
+        << "a capture that failed was not penalised";
+
+    // The move that cut is never its own counter-example.
+    Movehistory hist2;
+    std::vector<Move> tried2{rook_takes, bishop_takes};
+    hist2.update_capture(pos, rook_takes, kMaxHistory / 4, tried2);
+    EXPECT_GT(hist2.capture_score(pos, rook_takes), 0)
+        << "the cutoff move penalised itself out of the bonus it had just earned";
+    EXPECT_LT(hist2.capture_score(pos, bishop_takes), 0);
+}
+
+// Movehistory's copy assignment is what carries the tables across a Threads
+// change, and it has already silently dropped one member: corrections_ was
+// left out, so a copy preserved the history while discarding the accumulated
+// eval bias. Nothing failed, node counts just drifted. Every table added since
+// needs its own guard, because the failure mode is invisible.
+TEST_F(SearchTest, CopyingHistoryCarriesTheCaptureTable) {
+    auto pos = make_pos("4k3/8/8/3p4/8/8/B7/3RK3 w - - 0 1");
+    Move rook_takes;
+    rook_takes.set(D1, D5, capture);
+
+    Movehistory a;
+    std::vector<Move> none;
+    a.update_capture(pos, rook_takes, kMaxHistory / 4, none);
+    const int expected = a.capture_score(pos, rook_takes);
+    ASSERT_GT(expected, 0) << "nothing was written; the test would compare zeroes";
+
+    Movehistory b;
+    b = a;
+    EXPECT_EQ(b.capture_score(pos, rook_takes), expected)
+        << "copy assignment dropped the capture table";
+}
+
 TEST_F(SearchTest, ContinuationHistoryIsKeyedOnThePredecessor) {
     std::istringstream fen("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1");
     position pos(fen);


### PR DESCRIPTION
Captures were ordered by exchange value alone. SEE answers "what does this win or lose in the ensuing sequence" and nothing else, so it cannot separate two captures worth the same material — and there are usually several: every recapture on a square, every piece that can take the same hanging knight. It is also a property of a square rather than of a position, so it cannot know that in this structure the exchange sacrifice is the move and the equal-looking trade never is.

This adds a capture history table keyed on **(colour, moving piece, destination, captured piece)** — the smallest key that distinguishes the cases SEE conflates — and reads it in both the main search and qsearch.

**Bench 697583 → 684468**, a 1.9% smaller tree at fixed depth, nps unchanged (1795947 vs 1850284, inside the ~3% run-to-run spread). SPRT running.

## Two findings worth more than the feature

**1. The capture table must only learn from moves that actually caused a cutoff.**

Mirroring the quiet-history update at the TT cutoff cost **38% more nodes** (947351). The quiet update there is deliberately unrestricted and documented as load-bearing — restricting it costs 40% more nodes — but the two cases are not alike. A quiet competes against other unproven quiets, where "best move known for this position" is real evidence even from an upper-bound entry. A capture is anchored to its exchange value, so history only has to answer the much narrower question of which equally-valued capture works, and there a move that failed low is evidence *against*. It is also one-sided: `captures` is necessarily empty at a node that never ran a move loop, so nothing is ever penalised and entries saturate.

Restricting to `bound_low` fixes it. Widening to `bound_exact` was tried and **rejected at 718833** — an exact entry means the score fell inside the window at the storing node, so its move was the best of an all/PV node, which is not the same claim as having refuted something.

**2. The invariant this file documented was not true.**

`move_order.hpp` claimed the narrowest gap between two distinct exchange values was 15 (a bishop for a knight) and sized `kCaptureSeeScale` against it. But 15 is the narrowest gap between two piece *values*. `see()` returns sums and differences of those values, so its results are spaced by their **greatest common divisor** — 5 with the current numbers, and 1 once a tuner moves them. SEE really does return both 115 and 120 in ordinary positions.

So the invariant was already broken before this PR: history could reorder captures across exchange values, and a SEE −5 capture could reach the good-capture phase. Rather than pick a bigger number, history is now clamped into strictly less than half an exchange step, making the ordering lexicographic for *any* material values. Backed by `static_assert`s and a test that derives the spacing from `position::see_values()` instead of hardcoding it.

## Also

- `kGoodCaptureBase` keeps SEE alone deciding the good/bad phase split, so history orders only *within* a phase. Verified a provable no-op on its own (bench byte-identical).
- New `constexpr bool is_capture(Movetype)` replaces three hand-rolled capture tests.
- 5 new tests: the key triple (mover / destination / victim each proven load-bearing), en passant filed as taking a pawn despite its victim not being on the destination square, quiet moves leaving the table alone, the cutoff move not penalising itself, and copy assignment carrying the new table — the bug that already silently dropped `corrections_` once.
- Negative controls run: removing the en-passant case and dropping the victim from the key each fail the new tests.

175/175 tests pass. Reviewed by rubber-duck, which caught both blocking issues above.