### PR TITLE
fix: stop LMR quietly extending PV moves with strong history

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1267,9 +1267,17 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
                 // site applied the same idea twice, reducing non-PV moves by 2
                 // plies more than PV moves instead of 1.
 
-                // Reduce less for moves with good history
-                if (hist > params_.lmr_hist_good)
-                    R = std::max(0u, R - 1);
+                // Reduce less for moves with good history.
+                // R is unsigned and reduction() returns 0 for PV nodes at low
+                // depth and move count (bitboards::reductions[1][..] is built
+                // as 0 whenever the log product is below 1.0), so the previous
+                // std::max(0u, R - 1) wrapped to UINT_MAX rather than clamping:
+                // R - 1 underflows first, and the max then sees a huge value.
+                // static_cast<int>(R) is -1 from there, so LMR became
+                // newdepth + 1 and the move was quietly *extended* a ply
+                // instead of reduced one less.
+                if (hist > params_.lmr_hist_good && R > 0)
+                    --R;
 
                 // Don't reduce into qsearch
                 LMR = std::max(1, newdepth - static_cast<int>(R));


### PR DESCRIPTION
## The bug

`src/search.cpp`, inside the LMR block:

    unsigned R = reduction(pvNode, improving, depth, moves_searched);
    ...
    if (hist > params_.lmr_hist_good)
        R = std::max(0u, R - 1);      // intended: reduce one ply less

`R` is **unsigned**, so this does not clamp. `R - 1` underflows to `UINT_MAX` *before* `std::max` runs; the max then sees a huge value and keeps it. `static_cast<int>(R)` is `-1` from there, so

    LMR = std::max(1, newdepth - static_cast<int>(R));

becomes `newdepth + 1`. The move is **extended** a ply instead of being reduced one ply less.

## It is reachable

`reduction()` genuinely returns 0. `src/bitboard.cpp` builds the PV half of the table as

    reductions[1][0][sd][mc] = big_r >= 1.0 ? big_r + 0.5 : 0;

so any PV node whose `log(depth) * log(movecount)` falls below the cutoff has `R == 0`. (The non-PV half is `reductions[1][..] + 1`, so it is always at least 1 — this only bites on PV nodes.)

Bench confirms it fires: **684468 -> 694503** once fixed.

## The fix

    if (hist > params_.lmr_hist_good && R > 0)
        --R;

## Note on the node count

Fixing this *raises* bench nodes by 1.5%, i.e. the accidental extension was net node-saving on the bench suite. I am still treating it as a bug rather than a feature: the surrounding code, the comment, and the variable name all say "reduce less", never "extend", and an extension that happens only when an unsigned counter wraps is not a design.

If the SPRT comes back negative, that is a genuinely interesting result — it would say a *deliberate* extension for strong-history PV moves is worth having, which is then a real feature to implement and document rather than an accident to preserve.

## Testing

- 175/175 tests pass.
- Tier A SPRT per `scripts/testing/README.md`, results to follow in a comment.

## Review

Found by a rubber-duck review of an unrelated (and subsequently abandoned) change to `lmr_hist_bad` / `lmr_hist_good`. That calibration attempt was dropped because `docs/revisit-after-tuning.md` already records three measured, all-negative experiments in exactly that direction; see the closing comment on #122. This underflow is the one real defect that came out of it.