### PR TITLE
docs: record the measurements at the dead history parameters

### DIFF
--- a/docs/revisit-after-tuning.md
+++ b/docs/revisit-after-tuning.md
@@ -362,6 +362,24 @@ collapses from 8164 to 709. The positive signal that quiet ordering actually
 depends on is destroyed, and a move is punished for having been tried in a
 line that failed low for reasons having nothing to do with that move.
 
+**Later corroboration.** The history-pruning site was instrumented directly
+over a full bench: `seen=61534 fire=0 min=-193`. It is reached sixty-one
+thousand times and prunes nothing, and the most negative score ever seen there
+is -193 against a depth-1 threshold of -4096. This measures the rule rather
+than the table and reaches the same conclusion.
+
+That re-derivation cost a session's work because nothing at the parameter
+definitions pointed here. The constants in `parameters.hpp` now carry the
+measurements and a pointer to this section. If you are reading this because you
+just discovered these thresholds are unreachable: that is the documented
+finding, not a new one, and both repair directions are already measured.
+
+One real defect did come out of that pass. `lmr_hist_good` was applied as
+`R = std::max(0u, R - 1)` with `R` unsigned, so when `reduction()` returned 0 --
+which it does for PV nodes at low depth and move count -- `R - 1` wrapped to
+`UINT_MAX` before the max ran, and the move was extended a ply instead of
+reduced one ply less. Fixed in #123, `+11.4 +/- 14.6` over 1124 games.
+
 **Conclusion.** The cutoff path already does the conventional thing -- bonus to
 the move that cut, malus to the quiets tried before it. The fail-low malus is
 not conventional and should stay off. The two thresholds reading the negative

--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -433,6 +433,17 @@ struct parameters {
     int fp_base = 100;              // ...prune when eval + base + margin*depth <= alpha
     int fp_margin = 90;
     int history_prune_depth = 3;    // history pruning only below this depth
+    // DEAD RULE -- DO NOT RETUNE. See docs/revisit-after-tuning.md, "The quiet
+    // history table cannot support the rules that read it". This margin sits
+    // far outside the range the butterfly table reaches, so the rule never
+    // fires: instrumenting a full bench gives 61534 evaluations of the site and
+    // 0 firings, with an observed minimum of -193 against a depth-1 threshold
+    // of -4096. Retargeting it onto the observed percentiles has been measured
+    // twice (-21.6 +/- 21.6 and -29.7 +/- 28.3) and developing the negative
+    // half of the table to meet it once (-67.4 +/- 29.3). Both directions are
+    // measured, so SPSA cannot rescue it either. The prerequisite is a
+    // better-conditioned table -- the key carries no piece identity -- not a
+    // different number here.
     int history_prune_margin = 4096; // ...and only below -margin*depth
     int see_prune_depth = 1;        // negative-SEE capture pruning depth
     int see_quiet_prune_depth = 5; // quiet moves losing material pruned below this depth
@@ -457,6 +468,8 @@ struct parameters {
     int probcut_margin = 180;       // probcut beta = beta + this
     int probcut_depth_reduction = 4; // verification search depth = depth - this
     int lmr_min_depth = 3;          // late move reductions minimum depth
+    // lmr_hist_bad is dead for the same reason as history_prune_margin above,
+    // and under the same measurements -- do not retune it in isolation.
     int lmr_hist_bad = 2000;        // reduce one extra ply below -this
     int lmr_hist_good = 4000;       // reduce one less ply above this
     int best_move_bonus = 2;        // best-move history bonus, times depth


### PR DESCRIPTION
Tier 0 (comment and documentation only, bench unchanged at 694503).

I lost a session's work rediscovering something the repository already knew: `lmr_hist_bad` and `history_prune_margin` sit outside the range the butterfly history table reaches, so neither rule can fire. `docs/revisit-after-tuning.md` had already measured both ways of repairing that and found both negative (-21.6, -29.7, -67.4 Elo), and concluded the thresholds should be treated as dead code rather than parameters awaiting a fit.

Nothing at the parameter definitions said so, so the natural move on discovering the unreachability is to retune them -- which is exactly the measured-negative path.

This puts the evidence where someone will trip over it:

- `include/havoc/parameters.hpp` -- both constants now carry the measured results and a pointer to the section, marked DO NOT RETUNE.
- `docs/revisit-after-tuning.md` -- adds the direct instrumentation of the pruning site (`seen=61534 fire=0 min=-193`, i.e. reached 61534 times per bench and prunes nothing), a note that a rediscovery already happened once, and the `lmr_hist_good` unsigned-underflow defect fixed in #123.

The one thing that is *not* closed off is the document's actual recommendation: the table is keyed on (colour, from, to) with no piece identity, and a better-conditioned table is the prerequisite for any rule reading its negative half.