### PR TITLE
docs: the 'better-conditioned history table' prescription is measured and negative

### DIFF
--- a/docs/revisit-after-tuning.md
+++ b/docs/revisit-after-tuning.md
@@ -389,6 +389,55 @@ have now been measured. If quiet history is to drive pruning here it needs a
 better-conditioned table first -- the current one is keyed on (colour, from,
 to) with no piece identity -- not a different threshold.
 
+## Conditioning the quiet history table on the moving piece: measured, negative
+
+The section above ends by saying the prerequisite for any rule reading the
+negative half of quiet history is a better-conditioned table, "the current one
+is keyed on (colour, from, to) with no piece identity". That prescription has
+now been tested directly, and it does not hold. Every way of putting the piece
+into the key made move ordering worse.
+
+All figures are bench nodes at the same depth, lower is better, against a
+baseline of 694503.
+
+| keying | bench | vs baseline |
+| --- | --- | --- |
+| `[colour][from][to]` (current) | 694503 | -- |
+| `[colour][piece][to]` | 771931 | +11.1% |
+| `[colour][piece][from][to]` | 963945 | +38.8% |
+| `[colour][from][to]` + summed `[colour][piece][to]` plane | 814764 | +17.3% |
+| ...same, piece plane at quarter weight | 909552 | +31.0% |
+
+The runs went through a single `history_slot()` accessor, and a control that
+routed the *original* key through that same new plumbing reproduced 694503
+byte for byte. So the plumbing is not what moved these numbers.
+
+**Why adding the piece hurts.** Within any one position the from-square already
+determines the piece, so the piece is only new information across positions --
+where sliding lines are shared and d1-d4 might be a queen in one game and a
+rook in the next. That is a real but small gain in resolution, and it is bought
+by splitting every counter six ways. The table then needs roughly six times the
+samples to reach the same confidence, and quiet history is already sparse: a
+cutoff node has tried a mean of 0.34 quiets before it cuts. Dilution dominates
+resolution. Dropping the from-square instead (`[piece][to]`) avoids the
+dilution but throws away the finer move identity, and also loses: it is close
+to an unconditioned marginal of what continuation history already stores.
+
+**A caution on these numbers.** Bench node count is chaotic with respect to
+ordering and pruning changes -- small parameter moves swing it 20%, and the
+quarter-weight row above is *worse* than the full-weight row, which a smooth
+signal would not do. No single row here should be read as a precise effect
+size. What is solid is the pattern: four independent variants, none of them
+within reach of baseline, against a control that reproduced it exactly. None
+of them earned an SPRT.
+
+**Conclusion.** (colour, from, to) is not an oversight, it is a reasonable
+optimum for a table this sparse, and "condition it better" is not the
+unexplored lever the previous section assumed. If the negative half of quiet
+history is ever to drive pruning, the constraint to attack is the *sparsity* --
+how few samples each slot gets -- not the key. Nothing here changes the
+standing advice that the thresholds themselves stay dead.
+
 ## Why Texel tuning never produced anything
 
 Three independent defects, stacked. Any one alone would have been enough to


### PR DESCRIPTION
Tier 0, documentation only, no code change.

`docs/revisit-after-tuning.md` ended its quiet-history analysis by naming a prerequisite: any rule reading the negative half of the table needs a better-conditioned table first, because the current key is (colour, from, to) with no piece identity. That was the one direction the document left open, so I tested it.

It fails. Bench nodes, lower is better, baseline 694503:

| keying | bench | vs baseline |
| --- | --- | --- |
| `[colour][from][to]` (current) | 694503 | -- |
| `[colour][piece][to]` | 771931 | +11.1% |
| `[colour][piece][from][to]` | 963945 | +38.8% |
| `[colour][from][to]` + summed `[colour][piece][to]` | 814764 | +17.3% |
| ...same, piece plane at quarter weight | 909552 | +31.0% |

Everything ran through a single `history_slot()` accessor, and a **control that routed the original key through that same new plumbing reproduced 694503 exactly** -- so the plumbing is not what moved these numbers.

The mechanism is straightforward in hindsight: within a single position the from-square already determines the piece, so piece identity is only new information *across* positions. That is a small gain in resolution bought by splitting every counter six ways, and quiet history is already sparse (a cutoff node has tried a mean of 0.34 quiets before it cuts). Dilution beats resolution.

I have also written down a caution that applies beyond this experiment: bench node count is chaotic with respect to ordering and pruning changes. The quarter-weight row is worse than the full-weight row, which a smooth signal would not do. No row is a precise effect size; the pattern across four variants is the result, and none of them came close enough to baseline to deserve an SPRT.

The experimental code is reverted; bench is back to 694503 and the tree is clean. The takeaway recorded for the next session is that the constraint worth attacking is the **sparsity** of quiet history, not its key.