### PR TITLE
fix: bound the SMP start-depth stagger, plus first thread-scaling profile

### DIFF
--- a/docs/thread-scaling.md
+++ b/docs/thread-scaling.md
@@ -1,19 +1,18 @@
-# Thread scaling: measured
+# Thread scaling: preliminary profiling
 
 Roadmap Tier 1 item 2 (`docs/neural-direction.md` §10) asks for nps *and*
 strength to be measured against thread count "before assuming it scales". This
-is that measurement. The short version is that it does not scale: **16 threads
-buy about seven tenths of a ply over one thread**, and past 16 threads the
-engine gets weaker.
+is a first pass at that. It is **profiling, not a verdict**: the sample is small
+relative to the effects, and the confounds listed at the bottom are not yet
+controlled. Nothing here establishes that Lazy SMP is implemented incorrectly.
 
 Machine: i9-13900KS, 8 P-cores (16 hardware threads) + 16 E-cores, 24 cores /
-32 threads total, 93 GB RAM. All runs `-DHAVOC_NATIVE=ON`, Hash 1024 MB.
+32 threads total. All runs `-DHAVOC_NATIVE=ON`, Hash 1024 MB.
 
 ## Depth reached at fixed time
 
-The measurement that matters, because it is what a game actually rewards. 14
-positions spanning openings, middlegames and endgames, `go movetime 1500`, 2
-repetitions, mean of the deepest completed iteration.
+14 positions spanning openings, middlegames and endgames, `go movetime 1500`,
+2 repetitions, mean of the deepest completed iteration. Stagger span 4.
 
 | threads | mean depth | gain over 1 thread |
 | --- | --- | --- |
@@ -21,73 +20,101 @@ repetitions, mean of the deepest completed iteration.
 | 2 | 20.821 | +0.11 |
 | 4 | 21.286 | +0.57 |
 | 8 | 21.357 | +0.64 |
-| 16 | **21.429** | **+0.71** |
+| 16 | 21.429 | +0.71 |
 | 24 | 21.286 | +0.57 |
 | 32 | 21.107 | +0.39 |
 
-Scaling peaks at 16 threads and then goes backwards. Thirty-two threads is
-worse than eight.
+Read this as a shape, not as seven reliable numbers: independent repetitions of
+the same configuration differed by up to 0.25 ply, which is comparable to most
+of the differences in the table. The shape that does survive that spread is
+that the curve flattens early and does not keep climbing.
 
 ## Raw throughput
-
-Raw nps scales roughly as expected, which is the important part of the
-diagnosis: the threads really are running and really are searching.
 
 | threads | nps | vs 1 thread |
 | --- | --- | --- |
 | 1 | 1.74 M | 1.0x |
-| 2 | 3.35 M | 1.9x |
-| 4 | 6.15 M | 3.5x |
 | 8 | 10.8 M | 6.2x |
 | 16 | 17.0 M | 9.8x |
 | 24 | 19.2 M | 11.0x |
 | 32 | 16.5 M | 9.5x |
 
-## The gap is the finding
+**Aggregate nps is not parallel speedup and must not be read as one.** Sixteen
+threads duplicating each other's work produce excellent aggregate nps and no
+depth at all. The number is here only to establish that the threads are running
+and doing work, not to quantify what that work is worth.
 
-Eleven times the nodes per second converts into +0.7 ply. The parallel work is
-being done and then wasted: it is not reaching the thread whose result is
-returned. The transposition table *is* shared (a single `tt_` on
-`SearchEngine`), so the sharing mechanism exists; what has not been established
-is whether helper output survives in it under 16-32 threads of write pressure,
-or whether the aspiration and staggering interact so that helpers spend their
-time on iterations nobody consumes. That investigation is filed separately.
+## What is and is not established
 
-Time-to-depth at fixed depth was also measured and is extremely noisy -- 16
-threads gave 4.49x in one run and 3.35x in another -- because time-to-depth
-under Lazy SMP is a max over randomised threads. Depth-at-fixed-time over many
-positions is the more stable statistic and is what the table above reports.
+Established:
 
-## What this changes
+- The curve flattens by 4 to 8 threads and does not improve past 16.
+- 32 threads is not better than 16 on this machine.
 
-- **Do not use search threads to scale datagen.** N independent single-threaded
-  processes scale linearly; N search threads deliver +0.7 ply at N=16. Datagen
-  throughput should come from parallel games, not parallel search.
-- **The useful range today is 4 to 16 threads**, and most of even that is won
-  by 4.
-- Any future SMP work should be judged against the depth-at-fixed-time table
-  above, not against nps, which looks healthy and is measuring the wrong thing.
+Not established, and specifically **not** claimed:
 
-## The stagger bug fixed alongside this measurement
+- That helper threads "contribute nothing". They do not need to finish an
+  iteration to be useful; the transposition-table entries they write during an
+  unfinished iteration are exactly how Lazy SMP transmits work. Their results
+  are also consumed directly at `src/search.cpp` in the collection loop after
+  `wait_finished()`.
+- That the observed gain is abnormal. There is no universal expected ply gain
+  for a correct Lazy SMP; it depends on the effective branching factor, the
+  same-depth speedup, and how much duplicated work the threads do. Deriving the
+  engine's own single-thread node growth per ply, and comparing that against
+  measured same-depth speedup, is the prerequisite for calling any number
+  disappointing. That has not been done.
+
+Time-to-depth at fixed depth was also measured and is too noisy to use: 16
+threads gave 4.49x in one run and 3.35x in another, because time-to-depth under
+Lazy SMP is a max over randomised threads.
+
+## Confounds not yet controlled
+
+- **Hybrid cores.** The 13900KS mixes P-cores, E-cores and SMT siblings. The
+  24-to-32 regression may be SMT or scheduler placement rather than anything in
+  the search. Experiments should be pinned to core classes before concluding.
+- **Sample size.** 14 positions repeated twice is not 28 independent samples.
+  Detecting 0.2 ply reliably needs on the order of 50-200 independent paired
+  positions; detecting 0.1 ply, several hundred.
+- **No interleaving.** Configurations were run in blocks, so thermal and
+  frequency drift is aliased onto the thread count.
+- **TT pressure.** A 1 GB table under 32 threads of random access was not
+  varied, and `hashfull` and miss rates were not recorded.
+
+## Practical guidance for now
+
+- **Do not assume search threads scale datagen.** N independent single-threaded
+  processes scale linearly and are the safe way to fill a datagen corpus; that
+  is unaffected by anything in this document.
+- The useful range measured here is 4 to 16 threads, and most of it is already
+  won by 4.
+- Judge future SMP work against depth-at-fixed-time with a properly powered
+  sample, not against aggregate nps.
+
+## The stagger bug fixed alongside this profiling
 
 Helper threads began iterative deepening at `1 + thread_id`, unbounded. A
 time-based search passes `MAX_PLY` (64) as its target, so on a 32-thread search
 the upper half of the threads began with a first iteration of depth 17 to 32
-with no iterative-deepening warmup behind it. Those are searches no move's time
-budget can finish, so those cores produced nothing but transposition-table
-traffic.
+with no iterative-deepening warmup behind it. Whatever those searches are
+worth, they are not what the stagger was meant to produce.
 
 The offset now wraps modulo `smp_stagger_span` (default 4), so every helper
-starts somewhere it can actually reach while still not walking an identical
-path to its neighbours.
-
-Measured, 14 positions, `go movetime 1500`, 2 repetitions, mean depth:
+starts somewhere it can reach while still not walking an identical path to its
+neighbours.
 
 | threads | unbounded (old) | span 2 | span 4 | span 8 |
 | --- | --- | --- | --- | --- |
 | 16 | 21.286 | 21.393 | 21.250 | 21.286 |
 | 32 | 20.536 | 21.071 | 20.857 | 20.893 |
 
-Neutral at 16 threads, worth about half a ply at 32. This is a robustness fix
-that removes a pathology rather than a source of Elo, and it is bench-identical
-because thread 0 is unaffected either way.
+At 16 threads the spans are indistinguishable, including from the old
+behaviour. At 32 threads every bounded span beats unbounded, by +0.32 ply for
+the shipped default and +0.54 for span 2. The span itself is therefore a
+heuristic: what the data supports is that *some* bound beats none at 32
+threads, not that 4 is the best value. Span 2 won this table but by too little
+to justify shipping it on this evidence.
+
+This is a robustness fix that removes a pathology, not a source of Elo. It is
+bench-identical because thread 0 is unaffected either way.

--- a/docs/thread-scaling.md
+++ b/docs/thread-scaling.md
@@ -1,0 +1,93 @@
+# Thread scaling: measured
+
+Roadmap Tier 1 item 2 (`docs/neural-direction.md` §10) asks for nps *and*
+strength to be measured against thread count "before assuming it scales". This
+is that measurement. The short version is that it does not scale: **16 threads
+buy about seven tenths of a ply over one thread**, and past 16 threads the
+engine gets weaker.
+
+Machine: i9-13900KS, 8 P-cores (16 hardware threads) + 16 E-cores, 24 cores /
+32 threads total, 93 GB RAM. All runs `-DHAVOC_NATIVE=ON`, Hash 1024 MB.
+
+## Depth reached at fixed time
+
+The measurement that matters, because it is what a game actually rewards. 14
+positions spanning openings, middlegames and endgames, `go movetime 1500`, 2
+repetitions, mean of the deepest completed iteration.
+
+| threads | mean depth | gain over 1 thread |
+| --- | --- | --- |
+| 1 | 20.714 | -- |
+| 2 | 20.821 | +0.11 |
+| 4 | 21.286 | +0.57 |
+| 8 | 21.357 | +0.64 |
+| 16 | **21.429** | **+0.71** |
+| 24 | 21.286 | +0.57 |
+| 32 | 21.107 | +0.39 |
+
+Scaling peaks at 16 threads and then goes backwards. Thirty-two threads is
+worse than eight.
+
+## Raw throughput
+
+Raw nps scales roughly as expected, which is the important part of the
+diagnosis: the threads really are running and really are searching.
+
+| threads | nps | vs 1 thread |
+| --- | --- | --- |
+| 1 | 1.74 M | 1.0x |
+| 2 | 3.35 M | 1.9x |
+| 4 | 6.15 M | 3.5x |
+| 8 | 10.8 M | 6.2x |
+| 16 | 17.0 M | 9.8x |
+| 24 | 19.2 M | 11.0x |
+| 32 | 16.5 M | 9.5x |
+
+## The gap is the finding
+
+Eleven times the nodes per second converts into +0.7 ply. The parallel work is
+being done and then wasted: it is not reaching the thread whose result is
+returned. The transposition table *is* shared (a single `tt_` on
+`SearchEngine`), so the sharing mechanism exists; what has not been established
+is whether helper output survives in it under 16-32 threads of write pressure,
+or whether the aspiration and staggering interact so that helpers spend their
+time on iterations nobody consumes. That investigation is filed separately.
+
+Time-to-depth at fixed depth was also measured and is extremely noisy -- 16
+threads gave 4.49x in one run and 3.35x in another -- because time-to-depth
+under Lazy SMP is a max over randomised threads. Depth-at-fixed-time over many
+positions is the more stable statistic and is what the table above reports.
+
+## What this changes
+
+- **Do not use search threads to scale datagen.** N independent single-threaded
+  processes scale linearly; N search threads deliver +0.7 ply at N=16. Datagen
+  throughput should come from parallel games, not parallel search.
+- **The useful range today is 4 to 16 threads**, and most of even that is won
+  by 4.
+- Any future SMP work should be judged against the depth-at-fixed-time table
+  above, not against nps, which looks healthy and is measuring the wrong thing.
+
+## The stagger bug fixed alongside this measurement
+
+Helper threads began iterative deepening at `1 + thread_id`, unbounded. A
+time-based search passes `MAX_PLY` (64) as its target, so on a 32-thread search
+the upper half of the threads began with a first iteration of depth 17 to 32
+with no iterative-deepening warmup behind it. Those are searches no move's time
+budget can finish, so those cores produced nothing but transposition-table
+traffic.
+
+The offset now wraps modulo `smp_stagger_span` (default 4), so every helper
+starts somewhere it can actually reach while still not walking an identical
+path to its neighbours.
+
+Measured, 14 positions, `go movetime 1500`, 2 repetitions, mean depth:
+
+| threads | unbounded (old) | span 2 | span 4 | span 8 |
+| --- | --- | --- | --- | --- |
+| 16 | 21.286 | 21.393 | 21.250 | 21.286 |
+| 32 | 20.536 | 21.071 | 20.857 | 20.893 |
+
+Neutral at 16 threads, worth about half a ply at 32. This is a robustness fix
+that removes a pathology rather than a source of Elo, and it is bench-identical
+because thread 0 is unaffected either way.

--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -470,6 +470,15 @@ struct parameters {
     int lmr_min_depth = 3;          // late move reductions minimum depth
     // lmr_hist_bad is dead for the same reason as history_prune_margin above,
     // and under the same measurements -- do not retune it in isolation.
+    // Helper threads start their iterative deepening a few iterations apart so
+    // they do not all walk the identical path. The offset must wrap: it used to
+    // be the raw thread id, so thread N began at depth N+1, and a time-based
+    // search passes MAX_PLY (64) as the target. On a 32-thread search that gave
+    // the upper half of the threads a first iteration of depth 17 to 32 with no
+    // iterative-deepening warmup behind it -- searches no move's time budget
+    // can finish, so those cores contributed nothing but TT traffic.
+    int smp_stagger_span = 4;       // helper start depths wrap modulo this
+
     int lmr_hist_bad = 2000;        // reduce one extra ply below -this
     int lmr_hist_good = 4000;       // reduce one less ply above this
     int best_move_bonus = 2;        // best-move history bonus, times depth

--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -477,6 +477,17 @@ struct parameters {
     // the upper half of the threads a first iteration of depth 17 to 32 with no
     // iterative-deepening warmup behind it -- searches no move's time budget
     // can finish, so those cores contributed nothing but TT traffic.
+    //
+    // Deliberately *not* registered with the tuner. It only changes behaviour
+    // with helper threads running, and the tuner drives a single-threaded
+    // search, so SPSA would perturb it against an identically zero gradient --
+    // which is exactly what EverySearchParameterReachesTheSearch asserts
+    // cannot happen. Registering it fails that test, correctly.
+    //
+    // The span itself is a heuristic, not a measured optimum: the differences
+    // between spans of 2, 4 and 8 in the table in docs/thread-scaling.md are
+    // smaller than the run-to-run spread of the measurement that produced
+    // them. What is measured is that *some* bound beats none at 32 threads.
     int smp_stagger_span = 4;       // helper start depths wrap modulo this
 
     int lmr_hist_bad = 2000;        // reduce one extra ply below -this

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -514,7 +514,12 @@ void SearchEngine::iterative_deepening(position& p, U16 depth, bool silent, int 
     Move prev_best{};
     int stable_iterations = 0;
 
-    for (unsigned id = 1 + static_cast<unsigned>(thread_id); id <= depth; ++id) {
+    // See parameters.hpp: the stagger wraps so that no helper begins at a depth
+    // it cannot reach. A span of 1 disables staggering entirely.
+    const unsigned span = static_cast<unsigned>(std::max(1, params_.smp_stagger_span));
+    const unsigned stagger = static_cast<unsigned>(thread_id) % span;
+
+    for (unsigned id = 1 + stagger; id <= depth; ++id) {
         if (signals_.stop.load())
             break;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -295,8 +295,9 @@ void SearchEngine::start(position& p, const SearchLimits& lims, bool silent) {
         search_threads_.wait_finished();
         signals_.stop = true;
 
-        // Collect results. Helper threads all search to different depths, so
-        // their root scores are not directly comparable: a shallow thread can
+        // Collect results. Helper threads start at staggered depths and stop
+        // wherever the clock caught them, so their root scores are not
+        // directly comparable: a shallow thread can
         // easily return a higher score than a deeper, more reliable one. Prefer
         // the thread that finished the deepest iteration, breaking ties on
         // score, and prefer a proven shorter mate over any of that.


### PR DESCRIPTION
## The bug

`SearchEngine::iterative_deepening` started helper thread N at depth N+1, unbounded:

    for (unsigned id = 1 + static_cast<unsigned>(thread_id); id <= depth; ++id) {

A time-based `go` passes `MAX_PLY` (64) as the target depth, so on a 32-thread search the upper half of the threads began with a **first** iteration of depth 17 to 32, with no iterative-deepening warmup behind it. Whatever those searches are worth, they are not what a stagger is meant to produce.

The offset now wraps modulo `smp_stagger_span` (default 4).

## Measured

14 positions, `go movetime 1500`, 2 reps, mean deepest completed iteration:

| threads | unbounded (old) | span 2 | span 4 | span 8 |
| --- | --- | --- | --- | --- |
| 16 | 21.286 | 21.393 | 21.250 | 21.286 |
| 32 | 20.536 | 21.071 | 20.857 | 20.893 |

Indistinguishable at 16 threads; at 32 every bounded span beats unbounded, by +0.32 ply for the shipped default. What the data supports is that *some* bound beats none at 32 threads — **not** that 4 is optimal. Span 2 won the table but by too little to ship on. The header comment says so explicitly.

Bench is byte-identical at 694503 (thread 0 is unaffected either way) and 175/175 tests pass.

## Also: `docs/thread-scaling.md`

The profiling Tier 1 item 2 of `docs/neural-direction.md` asks for. The curve flattens by 4–8 threads and does not improve past 16; 32 threads is not better than 16 on this box.

I want to be explicit that this is **profiling, not a verdict**. My first draft claimed this proved Lazy SMP was broken; a review pushed back and was right:

- Aggregate nps is not parallel speedup — 16 threads duplicating work give great nps and no depth. It is reported only to show the threads are running.
- Helpers do not need to *finish* an iteration to contribute; TT entries written mid-iteration are the transmission mechanism. And their results *are* consumed, in the collection loop after `wait_finished()`.
- There is no universal expected ply gain for correct Lazy SMP, so +0.71 ply at 16 threads cannot be called abnormal without first deriving this engine's own node growth per ply.
- Repeat runs of one configuration varied by up to 0.25 ply — comparable to most differences in the table. 14 positions × 2 reps is not 28 independent samples.

The document now lists its confounds (hybrid P/E/SMT cores, sample size, no interleaving, unvaried TT pressure) rather than concluding past them.

The one piece of practical guidance that is safe: **do not scale datagen with search threads** — N independent single-threaded processes scale linearly.

## Note on the tuner

I initially registered `smp_stagger_span` with the SPSA tuner for reproducibility. That fails `EverySearchParameterReachesTheSearch`, correctly: the parameter is inert in a single-threaded search, so the tuner would perturb it against a zero gradient. It stays unregistered, and the header now records why.

## Follow-up

Review surfaced a genuine correctness bug in the TT that is a better scaling suspect than anything here; filed separately.