### PR TITLE
fix: make transposition table entries atomic

### DIFF
--- a/include/havoc/tt.hpp
+++ b/include/havoc/tt.hpp
@@ -3,6 +3,7 @@
 /// @file tt.hpp
 /// @brief Transposition table with XOR-based entry encoding.
 
+#include <atomic>
 #include "havoc/types.hpp"
 
 #include <cstring>
@@ -56,27 +57,49 @@ inline void prefetch(const void* addr) {
 //
 // pkey = zobrist_key ^ dkey   (Hyatt's XOR trick)
 
+// Both halves are atomic because every search thread reads and writes them
+// concurrently. The XOR trick below detects a *torn* pair, which is a
+// different problem: it is a semantic check on the values, and it does nothing
+// about the fact that concurrent non-atomic access is a data race and so
+// undefined behaviour. Without the atomics the compiler is entitled to assume
+// no other thread touches these words, and may reload or split the accesses.
+//
+// The ordering is relaxed throughout. Nothing here publishes any other memory,
+// so there is nothing to synchronise-with; the entry is self-describing and
+// the XOR check validates it. On x86-64 a relaxed 64-bit load or store is a
+// plain mov, so this costs nothing at the instruction level.
 struct entry {
-    U64 pkey = 0;
-    U64 dkey = 0;
+    std::atomic<U64> pkey{0};
+    std::atomic<U64> dkey{0};
 
-    [[nodiscard]] bool empty() const { return pkey == 0 && dkey == 0; }
+    [[nodiscard]] U64 pk() const { return pkey.load(std::memory_order_relaxed); }
+    [[nodiscard]] U64 dk() const { return dkey.load(std::memory_order_relaxed); }
 
-    void encode(U8 depth, U8 bound, U8 age, const Move& m, int16_t score) {
-        dkey = 0;
-        dkey |= U64(m.f);
-        dkey |= U64(m.t) << 8;
-        dkey |= U64(m.type) << 16;
-        dkey |= U64(bound & 0xF) << 26;
-        dkey |= U64(depth) << 30;
-        dkey |= U64(score < 0 ? -score : score) << 38;
-        dkey |= U64(score < 0 ? 1ULL : 0ULL) << 54;
-        dkey |= U64(age) << 55;
+    /// Callers must load each half exactly once and work from the locals, or
+    /// the validation and the decode can see different writes.
+    void put(U64 p, U64 d) {
+        dkey.store(d, std::memory_order_relaxed);
+        pkey.store(p, std::memory_order_relaxed);
     }
 
-    [[nodiscard]] U8 depth() const { return U8((dkey >> 30) & 0xFF); }
-    [[nodiscard]] U8 bound() const { return U8((dkey >> 26) & 0xF); }
-    [[nodiscard]] U8 age() const { return U8((dkey >> 55) & 0xFF); }
+    [[nodiscard]] bool empty() const { return pk() == 0 && dk() == 0; }
+
+    [[nodiscard]] static U64 encode(U8 depth, U8 bound, U8 age, const Move& m, int16_t score) {
+        U64 d = 0;
+        d |= U64(m.f);
+        d |= U64(m.t) << 8;
+        d |= U64(m.type) << 16;
+        d |= U64(bound & 0xF) << 26;
+        d |= U64(depth) << 30;
+        d |= U64(score < 0 ? -score : score) << 38;
+        d |= U64(score < 0 ? 1ULL : 0ULL) << 54;
+        d |= U64(age) << 55;
+        return d;
+    }
+
+    [[nodiscard]] U8 depth() const { return U8((dk() >> 30) & 0xFF); }
+    [[nodiscard]] U8 bound() const { return U8((dk() >> 26) & 0xF); }
+    [[nodiscard]] U8 age() const { return U8((dk() >> 55) & 0xFF); }
 };
 
 // ─── Decoded hash data ──────────────────────────────────────────────────────

--- a/include/havoc/tt.hpp
+++ b/include/havoc/tt.hpp
@@ -58,10 +58,17 @@ inline void prefetch(const void* addr) {
 // pkey = zobrist_key ^ dkey   (Hyatt's XOR trick)
 
 // Both halves are atomic because every search thread reads and writes them
-// concurrently. The XOR trick below detects a *torn* pair, which is a
-// different problem: it is a semantic check on the values, and it does nothing
-// about the fact that concurrent non-atomic access is a data race and so
-// undefined behaviour. Without the atomics the compiler is entitled to assume
+// concurrently. The XOR trick below is a *probabilistic* check on the values
+// and does nothing about the fact that concurrent non-atomic access is a data
+// race and so undefined behaviour.
+//
+// Probabilistic is the right word and the guarantee is weaker than it looks.
+// If a slot goes from (Ka^Da, Da) to (Kb^Db, Db), a reader can observe the
+// mixed pair (Ka^Da, Db), which validates cleanly for the phantom key
+// Ka^Da^Db. Nothing here rules that out; it is merely very unlikely, and a
+// bogus hit is caught downstream because the move is legality-checked against
+// the probing thread's own position. A real guarantee would need a sequence
+// counter, a lock, or a 128-bit atomic entry. Without the atomics the compiler is entitled to assume
 // no other thread touches these words, and may reload or split the accesses.
 //
 // The ordering is relaxed throughout. Nothing here publishes any other memory,
@@ -77,6 +84,11 @@ struct entry {
 
     /// Callers must load each half exactly once and work from the locals, or
     /// the validation and the decode can see different writes.
+    ///
+    /// dkey is stored first so that pkey acts as the commit word. Probes load
+    /// pkey first for the same reason: a reader that sees a new pkey has
+    /// necessarily already been able to see the new dkey, so the (new pkey,
+    /// stale dkey) interleaving cannot arise.
     void put(U64 p, U64 d) {
         dkey.store(d, std::memory_order_relaxed);
         pkey.store(p, std::memory_order_relaxed);

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -75,8 +75,9 @@ bool hash_table::fetch(U64 key, hash_data& e) {
     prefetch(stored);
 
     for (unsigned i = 0; i < cluster_size; ++i, ++stored) {
+        const U64 p = stored->pk();
         const U64 d = stored->dk();
-        if ((stored->pk() ^ d) == key) {
+        if ((p ^ d) == key) {
             e.decode(d);
 
             // An entry that is still being hit is still useful, but eviction
@@ -106,6 +107,12 @@ void hash_table::save(U64 key, U8 depth, U8 bound, const Move& m, int16_t score,
     entry* const first = first_entry(key);
     entry* replace = nullptr;
     bool same_key = false;
+    // The dkey validated by the probe below. Re-reading the slot after
+    // validating it reopens the window this function just closed: another
+    // thread can replace the entry in between, and we would then preserve a
+    // move belonging to a different position, or refuse the save on some other
+    // entry's depth.
+    U64 same_dkey = 0;
 
     for (unsigned i = 0; i < cluster_size; ++i) {
         entry* e = first + i;
@@ -113,9 +120,12 @@ void hash_table::save(U64 key, U8 depth, U8 bound, const Move& m, int16_t score,
             replace = e;
             break;
         }
-        if ((e->pk() ^ e->dk()) == key) {
+        const U64 p = e->pk();
+        const U64 d = e->dk();
+        if ((p ^ d) == key) {
             replace = e;
             same_key = true;
+            same_dkey = d;
             break;
         }
     }
@@ -139,7 +149,7 @@ void hash_table::save(U64 key, U8 depth, U8 bound, const Move& m, int16_t score,
     Move best = m;
     if (same_key) {
         hash_data existing;
-        existing.decode(replace->dk());
+        existing.decode(same_dkey);
 
         // Keep a much deeper result from this same search unless the new one is
         // exact, which is always worth having.

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -63,7 +63,11 @@ void hash_table::clear() {
     // zero default initialiser, so the two are equivalent here, but the type is
     // not trivially default-constructible and memset on it is what -Wclass-memaccess
     // objects to. GCC still lowers this to a memset.
-    std::fill_n(entries_.get(), cluster_count_, hash_cluster{});
+    // Cannot fill with a copy: std::atomic is neither copyable nor assignable.
+    // Relaxed stores are correct here -- clear() runs with no search in flight.
+    for (size_t i = 0; i < cluster_count_; ++i)
+        for (auto& e : entries_[i].cluster_entries)
+            e.put(0, 0);
 }
 
 bool hash_table::fetch(U64 key, hash_data& e) {
@@ -71,8 +75,9 @@ bool hash_table::fetch(U64 key, hash_data& e) {
     prefetch(stored);
 
     for (unsigned i = 0; i < cluster_size; ++i, ++stored) {
-        if ((stored->pkey ^ stored->dkey) == key) {
-            e.decode(stored->dkey);
+        const U64 d = stored->dk();
+        if ((stored->pk() ^ d) == key) {
+            e.decode(d);
 
             // An entry that is still being hit is still useful, but eviction
             // scores it by when it was *written*, not by when it was last
@@ -86,10 +91,8 @@ bool hash_table::fetch(U64 key, hash_data& e) {
             // bits 55-62 of dkey, so it can be rewritten in place; pkey has to
             // be re-derived from the key so the XOR validation still holds.
             if (e.age != generation_) {
-                const U64 refreshed =
-                    (stored->dkey & ~(0xFFULL << 55)) | (U64(generation_) << 55);
-                stored->dkey = refreshed;
-                stored->pkey = key ^ refreshed;
+                const U64 refreshed = (d & ~(0xFFULL << 55)) | (U64(generation_) << 55);
+                stored->put(key ^ refreshed, refreshed);
                 e.age = generation_;
             }
             return true;
@@ -110,7 +113,7 @@ void hash_table::save(U64 key, U8 depth, U8 bound, const Move& m, int16_t score,
             replace = e;
             break;
         }
-        if ((e->pkey ^ e->dkey) == key) {
+        if ((e->pk() ^ e->dk()) == key) {
             replace = e;
             same_key = true;
             break;
@@ -136,7 +139,7 @@ void hash_table::save(U64 key, U8 depth, U8 bound, const Move& m, int16_t score,
     Move best = m;
     if (same_key) {
         hash_data existing;
-        existing.decode(replace->dkey);
+        existing.decode(replace->dk());
 
         // Keep a much deeper result from this same search unless the new one is
         // exact, which is always worth having.
@@ -149,8 +152,8 @@ void hash_table::save(U64 key, U8 depth, U8 bound, const Move& m, int16_t score,
             best = existing.move;
     }
 
-    replace->encode(depth, bound, generation_, best, score);
-    replace->pkey = key ^ replace->dkey;
+    const U64 d = entry::encode(depth, bound, generation_, best, score);
+    replace->put(key ^ d, d);
 }
 
 int hash_table::hashfull() const {


### PR DESCRIPTION
Closes the first item of #127.

## The race

`entry::pkey` and `entry::dkey` were plain `U64`, concurrently read and written by every search thread in `fetch()` and `save()`. That is a data race and therefore undefined behaviour — independent of how benign the generated code looks, because the compiler is entitled to assume no other thread touches those words and may reload or split the accesses.

Hyatt's XOR trick does not address this. It is a check on the *values*; the language-level race underneath is a separate problem.

Both halves are now `std::atomic<U64>` accessed exclusively with `memory_order_relaxed`. Nothing here publishes any other memory — the entry is self-describing, and the `Move` that comes out of it is decoded by value and checked for legality against the probing thread's own position — so there is nothing to synchronise-with. On x86-64 a relaxed 64-bit load or store is a plain `mov`.

## Cost: none

- Bench **byte-identical** at 694503.
- Interleaved single-thread nps A/B, three pairs: base 1776019 / 1776651 / 1810042, candidate 1821690 / 1813570 / 1815904.
- 16-thread mean depth at `go movetime 1500`, 14 positions × 2 reps: base 21.321, candidate 21.500. My measured noise band for that statistic is ~0.25 ply, so I read this as **no regression**, not as an improvement.
- 175/175 tests pass.

## From review

- `save()` validated a slot and then **re-read** `dkey` to decode it, reopening the window the load-once rule exists to close. The validated word is now carried in a local. Without this, a concurrent replacement could make `save()` preserve a move from a different position, or refuse a save based on another entry's depth.
- Probes now load `pkey` **before** `dkey`. `put()` stores `dkey` first, so `pkey` is the commit word; loading it first makes the (new pkey, stale dkey) interleaving unreachable.
- I had claimed the XOR check detects torn pairs. It does not, quite: a slot going from `(Ka^Da, Da)` to `(Kb^Db, Db)` can be read as the mixed pair `(Ka^Da, Db)`, which validates for the phantom key `Ka^Da^Db`. Very unlikely, not impossible; the downstream legality check is what actually saves us. The comment now says so rather than promising a guarantee the scheme cannot make.

## Not done here

Issue #127 also proposed making the generation refresh conditional. **It already is** (`if (e.age != generation_)`), so that item was wrong; I have corrected the issue. The remaining open items there are the shared node counters and a TSan CI job.

This does **not** claim to fix the flat scaling curve in `docs/thread-scaling.md`. Relaxed atomics compile to the same instructions, so the coherence traffic is unchanged. This is a correctness fix.