### PR TITLE
fix: make the shared node counters race-free

### DIFF
--- a/include/havoc/position.hpp
+++ b/include/havoc/position.hpp
@@ -3,6 +3,7 @@
 #include "havoc/bitboard.hpp"
 #include "havoc/feature_delta.hpp"
 #include "havoc/magics.hpp"
+#include "havoc/single_writer_counter.hpp"
 #include "havoc/types.hpp"
 #include "havoc/utils.hpp"
 #include "havoc/zobrist.hpp"
@@ -104,8 +105,10 @@ class position {
     std::vector<info> history_;
     info ifo{};
     piece_data pcs;
-    U64 nodes_searched = 0;
-    U64 qnodes_searched = 0;
+    // Incremented only by the thread that owns this position, but summed by
+    // every thread for the node limit and by the UCI loop for live nps.
+    single_writer_counter nodes_searched;
+    single_writer_counter qnodes_searched;
 
   public:
     position() { history_.reserve(1024); }
@@ -233,12 +236,12 @@ class position {
     [[nodiscard]] bool is_cap_promotion(const Movetype& mt);
     [[nodiscard]] bool is_promotion(const U8& mt);
 
-    [[nodiscard]] inline U64 nodes() const { return nodes_searched; }
-    [[nodiscard]] inline U64 qnodes() const { return qnodes_searched; }
-    inline void set_nodes_searched(U64 n) { nodes_searched = n; }
-    inline void set_qnodes_searched(U64 qn) { qnodes_searched = qn; }
-    inline void adjust_nodes(const U64& dn) { nodes_searched += dn; }
-    inline void adjust_qnodes(const U64& dn) { qnodes_searched += dn; }
+    [[nodiscard]] inline U64 nodes() const { return nodes_searched.get(); }
+    [[nodiscard]] inline U64 qnodes() const { return qnodes_searched.get(); }
+    inline void set_nodes_searched(U64 n) { nodes_searched.set(n); }
+    inline void set_qnodes_searched(U64 qn) { qnodes_searched.set(qn); }
+    inline void adjust_nodes(const U64& dn) { nodes_searched.add(dn); }
+    inline void adjust_qnodes(const U64& dn) { qnodes_searched.add(dn); }
 
     template <Color c, Piece p> [[nodiscard]] inline U64 get_pieces() const {
         return pcs.bitmap[c][p];

--- a/include/havoc/single_writer_counter.hpp
+++ b/include/havoc/single_writer_counter.hpp
@@ -21,8 +21,11 @@ namespace havoc {
 /// x86: tens of cycles, on a line other threads are reading, in the hottest
 /// loop in the engine. With a single writer no atomic RMW is needed -- nothing
 /// else can change the value between the load and the store -- so `add()` is a
-/// deliberately separate relaxed load and relaxed store, which is a pair of
-/// plain MOVs.
+/// deliberately separate relaxed load and relaxed store, which on x86-64 is a
+/// pair of plain MOVs. That last part is target-specific: the language does not
+/// promise std::atomic<U64> is lock-free, and on a target where it is not, this
+/// would put a mutex in the hot path. The static_assert below refuses to build
+/// there rather than silently going slow.
 ///
 /// What readers get is *a* value the counter held at some point. A sum across
 /// threads is not a consistent snapshot of anything. Both consumers only need
@@ -32,6 +35,9 @@ namespace havoc {
 /// Copy and move are value copies rather than the deleted ones std::atomic
 /// would otherwise impose on every enclosing class.
 class single_writer_counter {
+    static_assert(std::atomic<U64>::is_always_lock_free,
+                  "single_writer_counter would take a lock in the search's hottest loop");
+
   public:
     single_writer_counter() = default;
     ~single_writer_counter() = default;

--- a/include/havoc/single_writer_counter.hpp
+++ b/include/havoc/single_writer_counter.hpp
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "havoc/types.hpp"
+
+#include <atomic>
+
+namespace havoc {
+
+/// A counter written by exactly one thread and read by many.
+///
+/// The search's node counters live on each thread's own position and are only
+/// ever incremented by that thread, but they are summed *from other threads*:
+/// by the node-limit check, which every thread evaluates over every thread's
+/// count, and by the UCI loop reporting live nps while the search runs. Reading
+/// a plain U64 that another thread is writing is a data race, and therefore
+/// undefined behaviour, however benign the generated code happens to look --
+/// the compiler is entitled to assume nobody else touches the object.
+///
+/// Relaxed atomics fix that for free, but only if the increment is written
+/// carefully. `fetch_add` is a read-modify-write and lowers to a LOCK XADD on
+/// x86: tens of cycles, on a line other threads are reading, in the hottest
+/// loop in the engine. With a single writer no atomic RMW is needed -- nothing
+/// else can change the value between the load and the store -- so `add()` is a
+/// deliberately separate relaxed load and relaxed store, which is a pair of
+/// plain MOVs.
+///
+/// What readers get is *a* value the counter held at some point. A sum across
+/// threads is not a consistent snapshot of anything. Both consumers only need
+/// an approximation, so that is fine; do not build an exactness requirement on
+/// top of this type.
+///
+/// Copy and move are value copies rather than the deleted ones std::atomic
+/// would otherwise impose on every enclosing class.
+class single_writer_counter {
+  public:
+    single_writer_counter() = default;
+    ~single_writer_counter() = default;
+    single_writer_counter(const single_writer_counter& o) noexcept { set(o.get()); }
+    single_writer_counter(single_writer_counter&& o) noexcept { set(o.get()); }
+    single_writer_counter& operator=(const single_writer_counter& o) noexcept {
+        set(o.get());
+        return *this;
+    }
+    single_writer_counter& operator=(single_writer_counter&& o) noexcept {
+        set(o.get());
+        return *this;
+    }
+
+    /// Assignment from a raw count, so the type drops into existing code.
+    single_writer_counter& operator=(U64 n) noexcept {
+        set(n);
+        return *this;
+    }
+
+    [[nodiscard]] U64 get() const noexcept { return v_.load(std::memory_order_relaxed); }
+    void set(U64 n) noexcept { v_.store(n, std::memory_order_relaxed); }
+    void add(U64 dn) noexcept { set(get() + dn); }
+
+    /// Only the owning thread may call this.
+    single_writer_counter& operator++() noexcept {
+        add(1);
+        return *this;
+    }
+
+  private:
+    std::atomic<U64> v_{0};
+};
+
+} // namespace havoc

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1071,8 +1071,8 @@ void position::set_piece(char p, const Square& s) {
 void position::clear() {
     pcs.clear();
     history_.clear();
-    nodes_searched = 0;
-    qnodes_searched = 0;
+    nodes_searched.set(0);
+    qnodes_searched.set(0);
     ifo = {};
 }
 


### PR DESCRIPTION
Second item of #127. Follows #128.

## The race

Each thread increments the node counters on its own `position`, so they look thread-local. They are not: they are read across threads in two places.

- `SearchEngine::total_nodes()` (`src/search.cpp`) loops over **all** threads summing `t->nodes() + t->qnodes()`, and the node-limit check calls it from **every** thread (`src/search.cpp:676`).
- `readout_pv` sums them at `src/search.cpp:1648`, and the UCI loop reports live nps while helpers are still running.

Reading a plain `U64` that another thread is writing is a data race, and so undefined behaviour, whatever the generated code happens to look like.

## Confirmed by ThreadSanitizer, and confirmed fixed

Not taken on faith — measured both ways, same binary settings, same workload:

| Threads | Depth | `main` | this branch |
|---|---|---|---|
| 2 | 6 | **2 races** | 0 |
| 2 | 8 | **2 races** | 0 |
| 4 | 6 | **5 races** | 0 |
| 4 | 8 | **4 races** | 0 |

The report on `main` names exactly the predicted pair:

```
WARNING: ThreadSanitizer: data race
  Read of size 8 at ... by thread T4:
    #0 havoc::position::nodes() const   include/havoc/position.hpp:236
    #1 havoc::SearchEngine::readout_pv  src/search.cpp:1648
  Previous write of size 8 ... :
    #0 havoc::position::do_move         src/position.cpp:415   (++nodes_searched)
```

(If you reproduce this: TSan aborts with `unexpected memory mapping` on current kernels unless you disable ASLR — run it under `setarch $(uname -m) -R`.)

## The fix, and why it is not `fetch_add`

New `single_writer_counter`: a relaxed `std::atomic<U64>` whose `add()` is a **separate relaxed load and relaxed store**, not `fetch_add`.

`fetch_add` is a read-modify-write and lowers to `LOCK XADD` on x86 — tens of cycles, on a line other threads are reading, inside `do_move`, which is the hottest loop in the engine. There is exactly one writer per counter, so no atomic RMW is needed: nothing else can change the value between the load and the store. The type's name states that precondition rather than leaving it in a comment somewhere.

Copy and move are value copies, because `std::atomic` is neither copyable nor movable and would otherwise delete `position`'s move operations.

Readers get *a* value the counter held at some point; a cross-thread sum is not a coherent snapshot. Both consumers only need an approximation. Totals collected after `wait()` are exact, via the thread pool's own synchronisation.

## Cost: none

- Bench **byte-identical** at 694503.
- `objdump -d | grep -c "lock "` is **6 before and 6 after** — direct evidence no atomic RMW crept in.
- Interleaved nps A/B: base 1808978 / 1821704 / 1768877, candidate 1787904 / 1825645 / 1822661.
- 175/175 tests pass.

## From review

Added `static_assert(std::atomic<U64>::is_always_lock_free)`. The header claimed relaxed load/store is a pair of plain MOVs; that is true on x86-64 but the language does not promise it, and on a target where the type is not lock-free this would put a **mutex** in the hot path. Better to fail the build than to silently go slow.

Review also confirmed the single-writer precondition holds today: counters are reset only after `wait()`, per-thread positions are copied before helpers launch, and no live-search path assigns to a position.

## Remaining

Only the TSan CI job is left on #127; sending that separately, since this PR is what makes such a job green.