### PR TITLE
ci: run searches under ThreadSanitizer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,3 +120,47 @@ jobs:
       - name: Fuzz UCI (ASan + UBSan)
         if: matrix.os == 'ubuntu-latest' && matrix.compiler == 'gcc'
         run: ./scripts/testing/fuzz-uci.sh build-debug/havoc 7
+
+  # ThreadSanitizer needs its own build: it cannot be combined with ASan, and
+  # the job above is already the long pole, so this runs in parallel instead of
+  # being bolted onto it.
+  #
+  # Nothing else in CI can catch a data race. The unit tests drive the engine
+  # through its C++ interface on one thread, so the shared transposition table,
+  # the cross-thread node counters and the stop flag are never contended. Both
+  # races found so far were invisible to the entire rest of the suite.
+  thread-sanitizer:
+    runs-on: ubuntu-latest
+    name: ubuntu-latest / tsan
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install GCC 13
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-13 g++-13
+
+      # RelWithDebInfo, not Debug: TSan is slow enough on its own, and the line
+      # numbers in a race report are what matter, not the optimisation level.
+      # Tests are off because this job runs searches, not the test suite.
+      - name: Configure TSan
+        env:
+          CC: gcc-13
+          CXX: g++-13
+        run: >
+          cmake -B build-tsan
+          -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          -DHAVOC_NATIVE=OFF
+          -DHAVOC_WERROR=ON
+          -DCMAKE_CXX_FLAGS=-fsanitize=thread
+          -DCMAKE_EXE_LINKER_FLAGS=-fsanitize=thread
+
+      - name: Build TSan
+        run: cmake --build build-tsan --parallel
+
+      # "quick" keeps this to three searches, ~30s on a 4-core runner. The
+      # heavier thread counts in "full" are for running locally on a machine
+      # that actually has the cores to contend with.
+      - name: Search under TSan
+        run: ./scripts/testing/tsan-search.sh build-tsan/havoc quick

--- a/scripts/testing/README.md
+++ b/scripts/testing/README.md
@@ -237,3 +237,29 @@ scripts/testing/tactics.sh ./build/havoc 3000
 
 Ten positions with forced best moves. A coarse smoke test for search sanity, not
 a strength measure — it is far too small to resolve Elo.
+
+## Correctness scripts
+
+Two scripts in this directory check things a match cannot. Neither measures
+strength; both are pass/fail, and both exist because the unit tests structurally
+cannot reach what they cover.
+
+| script | what it covers | why the test suite misses it |
+| --- | --- | --- |
+| `fuzz-uci.sh` | malformed UCI input | the tests drive the C++ interface, never the UCI parser |
+| `tsan-search.sh` | data races between search threads | the tests are single-threaded, so nothing is ever contended |
+
+Both run in CI on every PR. Run them locally against the matching sanitizer
+build before proposing anything that touches parsing or threading:
+
+```sh
+cmake -B build-tsan -DCMAKE_BUILD_TYPE=RelWithDebInfo -DHAVOC_NATIVE=OFF \
+      -DCMAKE_CXX_FLAGS=-fsanitize=thread -DCMAKE_EXE_LINKER_FLAGS=-fsanitize=thread
+cmake --build build-tsan --parallel
+scripts/testing/tsan-search.sh build-tsan/havoc full
+```
+
+`full` adds deeper and more heavily threaded searches than CI runs, which is
+worth doing on a machine with the cores to contend with. If TSan aborts with
+`unexpected memory mapping`, that is the known ASLR conflict on current kernels;
+the script already reruns itself under `setarch -R` to avoid it.

--- a/scripts/testing/tsan-search.sh
+++ b/scripts/testing/tsan-search.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# usage: tsan-search.sh <engine> [quick|full]
+#
+# Runs multi-threaded searches under ThreadSanitizer and fails if any of them
+# reports a data race.
+#
+# The unit tests cannot find these. They drive the engine through its C++
+# interface, largely on one thread, so the interesting concurrency -- N search
+# threads sharing a transposition table, summing each other's node counters,
+# and racing to set the stop flag -- never runs. Every race this script has
+# caught so far was invisible to the whole rest of the suite.
+#
+# Build it with:
+#   cmake -B build-tsan -DCMAKE_BUILD_TYPE=RelWithDebInfo -DHAVOC_NATIVE=OFF \
+#         -DCMAKE_CXX_FLAGS=-fsanitize=thread \
+#         -DCMAKE_EXE_LINKER_FLAGS=-fsanitize=thread
+#   scripts/testing/tsan-search.sh build-tsan/havoc
+#
+# RelWithDebInfo rather than Debug on purpose: TSan is slow enough already, and
+# a Debug build makes these searches take long enough that nobody runs them.
+#
+# Exits non-zero if TSan reports anything.
+
+set -u
+ENG="${1:?engine binary}"
+MODE="${2:-quick}"
+FAILURES=0
+CASES=0
+
+if [[ ! -x "$ENG" ]]; then
+    echo "not an executable: $ENG" >&2
+    exit 1
+fi
+
+# TSan aborts at startup with "FATAL: unexpected memory mapping" on kernels
+# that hand out more address-space randomisation than its shadow mapping can
+# cope with, which includes current Ubuntu. Running with randomisation off is
+# the documented workaround and does not weaken the checking.
+SETARCH=(setarch "$(uname -m)" -R)
+if ! "${SETARCH[@]}" true 2>/dev/null; then
+    SETARCH=()
+    echo "note: setarch -R unavailable, running with ASLR on" >&2
+fi
+
+# halt_on_error=0 so one race does not hide the rest; exitcode=0 so that the
+# engine's own exit status stays readable and the race count below is what
+# decides the result.
+export TSAN_OPTIONS="halt_on_error=0 exitcode=0 history_size=2 ${TSAN_OPTIONS:-}"
+
+# A search only runs while stdin is open: "go" followed immediately by "quit"
+# aborts it, which would make this script pass by not searching at all. Hold
+# stdin open with a sleep, and check afterwards that a bestmove came back.
+run_case() {
+    local label="$1" threads="$2" go="$3" wait_s="$4"
+    CASES=$((CASES + 1))
+    local log out races
+    log=$(mktemp)
+    out=$( (printf 'uci\nsetoption name Threads value %s\nisready\nposition startpos\n%s\n' \
+                "$threads" "$go"; sleep "$wait_s") \
+           | timeout 900 "${SETARCH[@]}" "$ENG" 2>"$log" )
+
+    races=$(grep -c 'WARNING: ThreadSanitizer' "$log")
+    if ! grep -q '^bestmove' <<<"$out"; then
+        echo "FAIL  $label -- no bestmove; the search did not run, so this proves nothing"
+        FAILURES=$((FAILURES + 1))
+    elif [[ "$races" -gt 0 ]]; then
+        echo "FAIL  $label -- $races data race(s)"
+        grep -A 6 'WARNING: ThreadSanitizer' "$log" | head -40
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "ok    $label"
+    fi
+    rm -f "$log"
+}
+
+echo "ThreadSanitizer search check: $ENG ($MODE)"
+
+# Fixed depth and time-managed searches take different paths -- the second one
+# is what exercises the stop flag and the time checks -- so both are covered.
+run_case "depth 8, 2 threads"      2  "go depth 8"        3
+run_case "depth 8, 4 threads"      4  "go depth 8"        3
+run_case "movetime 2000, 4 threads" 4 "go movetime 2000"  5
+
+if [[ "$MODE" == "full" ]]; then
+    run_case "depth 12, 4 threads"      4  "go depth 12"      10
+    run_case "movetime 2000, 8 threads" 8  "go movetime 2000" 6
+    run_case "movetime 1500, 16 threads" 16 "go movetime 1500" 6
+fi
+
+echo "$CASES case(s), $FAILURES failure(s)"
+[[ "$FAILURES" -eq 0 ]]


### PR DESCRIPTION
Last item of #127. Follows #128 and #129.

## Why

Nothing in CI could catch a data race. The unit tests drive the engine through its C++ interface on a single thread, so the shared transposition table, the cross-thread node counters and the stop flag are never contended. The two races fixed in #128 and #129 were invisible to the entire rest of the suite — 175 passing tests, four green platforms, ASan, UBSan and the UCI fuzzer all had nothing to say about undefined behaviour sitting in `do_move`.

That is a poor way to find out. This adds the check that would have caught them.

## What it does

`scripts/testing/tsan-search.sh` runs searches under TSan and fails on any report. It covers **fixed-depth and time-managed** searches at several thread counts, because those take different paths — the time-managed one is what exercises the stop flag and the time checks.

It also **fails if no `bestmove` comes back**. A search that never ran would otherwise pass silently, and that is not hypothetical: piping `quit` alongside `go` makes the engine abort the search and return immediately, which is exactly the shape of mistake that turns a green check into decoration. The script holds stdin open and then checks it actually got an answer.

`quick` (3 searches, ~30s) runs in CI; `full` (6, up to 16 threads and depth 12) is for running locally on a machine with the cores to contend with.

## Verified in both directions

A gate nobody has seen fail is not a gate:

| build | result |
|---|---|
| the commit before #129 | **exit 1** — names `position::nodes()` (position.hpp:236, via `readout_pv`) racing `do_move` (position.cpp:415) |
| current `main` | exit 0 |

Also confirmed the exact configure and build lines in the workflow work locally with `-DHAVOC_WERROR=ON`, producing no warnings, and that `full` is clean on main at up to 16 threads and depth 12.

## Notes

- Runs as **its own job**. TSan cannot be combined with the ASan build, and the existing Linux job is already the long pole, so this runs in parallel rather than being bolted on.
- `RelWithDebInfo`, not `Debug`. TSan is slow enough already, and what matters in a race report is the line numbers, not the optimisation level.
- TSan aborts at startup with `FATAL: unexpected memory mapping` on current kernels, including Ubuntu's, because of how much address-space randomisation they hand out. The script runs under `setarch -R`, the documented workaround, and degrades gracefully with a note if `setarch` is missing.
- `scripts/testing/README.md` gains a short section covering this and `fuzz-uci.sh` together, since neither measures strength and both were undocumented there.

Closes #127.