### PR TITLE
docs: trim the README and correct documentation drift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ b/
 # Measurement output: logs, PGNs and optimiser state. Machine-specific and
 # large; results that matter belong in docs, not in the tree.
 testruns/
+
+# Python bytecode from scripts/
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -13,88 +13,45 @@ a hand-written evaluation function.
 
 ## Strength
 
-Estimated **~2503 Elo** (CCRL Blitz scale, 95% CI ±55), measured 14 August 2026.
+Estimated **~2503 Elo** on the CCRL 40/40 scale (95% CI ±55), measured
+14 August 2026.
 
 | Date | Rating | 95% CI | Games | Notes |
 |------|--------|--------|-------|-------|
-| 2026-08-14 | **2503** | ±55 | 240 | Correction history, mobility counts captures, storm advancement. Self-play said +52; the gauntlet did not see it — see below |
-| 2026-08-14 | 2523 | ±53 | 240 | Eval coverage batch: connected pawns, queen mobility, tactical motifs, rook files, outposts, passer rank coverage, backward pawns |
-| 2026-08-13 | 2473 | ±60 | 224 | Correctness batch: zobrist/material keys, phase interpolation, aspiration window, king safety |
-| (earlier) | 2413 | ±82 | 150 | Prior baseline, same anchors and hardware |
+| 2026-08-14 | **2503** | ±55 | 240 | Correction history, mobility counts captures, storm advancement |
+| 2026-08-14 | 2523 | ±53 | 240 | Evaluation coverage batch |
+| 2026-08-13 | 2473 | ±60 | 224 | Correctness batch |
+| (earlier) | 2413 | ±82 | 150 | Prior baseline |
 
-The last two rows are the honest limit of this method. Between them the engine
-gained a measured +30.6 ± 12, +16.7 ± 11 and +4.9 ± 14 in self-play SPRTs
-against its own previous revision, and the gauntlet reports 2523 then 2503 —
-a change of the opposite sign, comfortably inside either interval. Both things
-can be true, and at least one certainly is:
+Read this as "somewhere around 2500 since 13 August" rather than as a trajectory.
+Three things limit it, and they are worth stating plainly:
 
+- **240 games cannot resolve 50 Elo.** The interval is ±55, so two runs differing
+  by 20 are one run.
 - **Self-play overstates field Elo.** A change is measured against an opponent
-  that shares every one of its blind spots, so an improvement that only matters
-  in positions both sides misplay collects points that no external opponent
-  will concede. This is a well-known effect and there is no reason to think
-  this engine is exempt.
-- **240 games cannot resolve 50 Elo.** The interval is ±55. Two runs that
-  differ by 20 are one run.
+  that shares all of its blind spots, so gains confined to positions both sides
+  misplay do not transfer to the field.
+- **The anchors disagree with each other** by more than the stated interval: this
+  run implies 2536 from Fruit and 2448 from Glaurung, and the previous run
+  implied 2491 and 2561 — the same two engines, opposite directions. A fit
+  assuming a single strength scale is being asked to reconcile a non-transitive
+  matchup, so the real uncertainty is wider than the statistical one.
 
-The two anchors also disagree with each other by more than the stated interval:
-this run implies 2536 from Fruit and 2448 from Glaurung, and the previous run
-implied 2491 and 2561 — the same two engines, opposite directions. A fit that
-assumes a single strength scale is being asked to reconcile a non-transitive
-matchup, so the true uncertainty is wider than the statistical one.
+The per-change SPRTs are the trustworthy measurements; this table is a periodic
+check that the engine has not drifted away from the field.
 
-Read the table as "somewhere around 2500 since 13 August" and not as a
-trajectory. The SPRT numbers are the trustworthy measurements of individual
-changes; this table is a periodic sanity check that the engine has not drifted
-away from the field.
+These rows were measured against Fruit 2.1 and Glaurung 2.2 alone, both ~200
+points above the engine, where a fit is extrapolating rather than interpolating.
+Three bracketing anchors have since been added — Zurichess Fribourg (2412),
+Arasan 12.2 (2505) and Phalanx XXIV (2521) — so later rows will be more reliable
+but not directly comparable to these.
 
-### Method
-
-The rating is a maximum-likelihood fit of the standard logistic Elo model. The
-opponents' ratings are held fixed at their published values and haVoc's rating
-is the value of `r` solving
-
-```
-sum_i N_i * E(r - R_i) = sum_i S_i        where  E(d) = 1 / (1 + 10^(-d/400))
-```
-
-Draws score a half point, which is what the Elo model assumes; no separate draw
-parameter is fitted.
-
-- **Anchors.** Fruit 2.1 (2694) and Glaurung 2.2 (2793), CCRL 40/15 single-CPU
-  64-bit entries, list dated 7 August 2026. Both have very large CCRL sample
-  sizes and decades of scrutiny, so their published ratings carry small error
-  bars. Obscure hobby engines were tried as anchors and discarded: two of them
-  produced implied ratings 223 points apart for the same candidate, which is
-  what a lumpy evaluation surface and a thinly-played published rating do to a
-  fit that assumes a single strength scale.
-
-  Both anchors sit ~200 points *above* haVoc, where it scores about 22%. A
-  score that lopsided carries little information per game, and with no anchor
-  below the engine the fit is extrapolating rather than interpolating — which
-  is a large part of why two anchors can disagree by 90 points. Three
-  bracketing anchors have since been added for future runs: Zurichess Fribourg
-  (2412), Arasan 12.2 (2505) and Phalanx XXIV (2521). Rows above this note were
-  measured against the original two only, so they remain mutually comparable
-  but are not comparable to later rows.
-- **Conditions.** 20+0.2 on one thread with a 64 MB hash, `OwnBook=false` and
-  `Ponder=false` forced on every engine, from a fixed opening book with colours
-  reversed on each pair. All engines run on the same machine at the same time
-  control.
-- **Caveats.** This is an *estimate on the CCRL scale*, not a CCRL rating: it
-  comes from a two-opponent gauntlet on one machine, not from CCRL's own pool.
-  The confidence interval is statistical only and does not cover anchor error
-  or the non-transitivity of engine matchups. Treat the trend across rows as
-  more meaningful than any single absolute figure. Consecutive rows here have
-  overlapping intervals, so a single step is suggestive rather than proven;
-  the rows are directly comparable because the anchors, hardware, book and time
-  control are held fixed across them.
-
-Every change that could plausibly affect playing strength is gated behind a
-self-play SPRT against the previous revision before it is merged.
-
-The scripts that produce every number in this section live in
-[`scripts/testing/`](scripts/testing/README.md), together with the opening book
-and the rules for choosing anchors.
+The method is a maximum-likelihood fit of the logistic Elo model with opponent
+ratings held fixed at their published CCRL 40/40 values, at 20+0.2 on one
+thread with `OwnBook` and `Ponder` forced off. It is an estimate *on* the CCRL
+scale, not a CCRL rating. The scripts, the
+opening book and the rules for choosing anchors are in
+[`scripts/testing/`](scripts/testing/README.md).
 
 To reproduce a rating from a gauntlet PGN:
 
@@ -192,11 +149,12 @@ The main heuristics in use are:
 - Transposition table with 4-entry clusters, XOR key verification, and
   depth/age-based replacement
 - Late move reductions, adjusted by history score and node type
-- Null move pruning
-- Reverse futility pruning
+- Null move pruning, reverse futility pruning, and ProbCut
 - Singular extensions
 - Internal iterative reductions
-- Killer moves, butterfly history, and countermoves for move ordering
+- Killer moves, countermoves, butterfly history, capture history, and
+  continuation history for move ordering
+- Correction history on the static evaluation
 - Quiescence search with delta pruning and static exchange evaluation
 
 Multi-threaded search is Lazy SMP: each thread runs an independent search over a
@@ -217,7 +175,7 @@ implementation covers:
 
 ## Development
 
-Run the test suite (133 tests, including perft against the five standard
+Run the test suite (175 tests, including perft against the five standard
 positions from the Chess Programming Wiki):
 
 ```sh
@@ -238,37 +196,32 @@ Windows: [ci.yml](https://github.com/mjglatzmaier/haVoc/actions/workflows/ci.yml
 
 ## Current state and known gaps
 
-Being honest about where things stand:
+- **The evaluation is hand-set, and Texel tuning is not the way out of that.** A
+  parameter's gradient is independent of its current value, so the fit is
+  unmoved by better starting points, and the error is dominated by material
+  while the quiet filter discards exactly the positions where tactical terms
+  fire. The fit it converges to measured +1.4 ± 19.9 Elo over 781 games. Useful
+  for material and piece-square tables, and little else.
+- **The search is capped at 64 plies** (`MAX_PLY`). Search and quiescence stop
+  cleanly at the bound, but the cap is low: ten seconds already reaches ply 29.
+- **Several depth-indexed constants are calibrated to a bug that no longer
+  exists.** The reduction and futility formulas, null-move reduction and
+  reverse-futility margins were tuned while the depth counter ran at roughly
+  twice the real remaining depth, and none has been retuned since.
+- **The transposition key mixes in the fifty-move and half-move counters**,
+  which blocks transpositions between identical positions reached at different
+  plies. That looks like a mistake, but removing it measured ~20% more nodes, so
+  it stays until something better replaces it.
+- **Syzygy probing and Polyglot books are stubs**, although both options are
+  advertised and parsed.
+- **The search is not saturated:** 29% of positions change their preferred move
+  at depth 8, and 12% are still changing at depth 12, so nodes remain valuable.
 
-- The evaluation terms are largely hand-set. Texel tuning infrastructure exists,
-  and has been shown *not* to be the answer: a parameter's gradient is
-  independent of its current value, so the fit is unmoved by better starting
-  points, and the error is dominated by material while the quiet filter discards
-  the positions where tactical terms fire. The fit it converges to measured
-  +1.4 ± 19.9 Elo over 781 games. Use it for material and piece-square tables
-  only — see [`docs/roadmap.md`](docs/roadmap.md).
-- The search is capped at 64 plies (`MAX_PLY`). Search and quiescence now stop
-  cleanly at that bound rather than running past the end of the search stack,
-  but the cap itself is low: a ten-second search already reaches ply 29, and a
-  forty-second one reaches ply 40.
-- Several depth-indexed constants (reduction and futility formulas, null-move
-  reduction, razoring and reverse-futility margins) were tuned when a bug made
-  the depth counter run at roughly twice the real remaining depth. They are all
-  now operating at a different point than the one they were chosen for, and
-  none of them has been retuned since.
-- The transposition key deliberately mixes in the fifty-move and half-move
-  counters, which blocks transpositions between identical positions reached at
-  different plies. This looks wrong and was measured: removing it costs about
-  20% more nodes, so it stays until something better replaces it.
-- Syzygy tablebase probing and Polyglot opening books are stubs.
-- Search is not saturated: 29% of positions change their preferred move at depth
-  8 and 12% are still changing at depth 12, so nodes remain genuinely valuable
-  and the search margins are the most promising thing left to tune.
-
-Possible future work, in rough order of interest: SPSA over the search margins,
-move ordering, replacing the hand-written evaluation with a learned one, Syzygy
-probing, and Chess960 support. [`docs/roadmap.md`](docs/roadmap.md) has the
-reasoning, the negative results, and the things not to retry.
+The direction from here is a learned, CPU-side evaluation rather than further
+hand-tuning. The reasoning, the alternatives that were ruled out and the
+measured dead ends are in
+[`docs/neural-direction.md`](docs/neural-direction.md) and
+[`docs/roadmap.md`](docs/roadmap.md).
 
 ## License
 

--- a/scripts/rate.py
+++ b/scripts/rate.py
@@ -14,8 +14,8 @@ import re
 import sys
 from collections import defaultdict
 
-# CCRL 40/15 ratings, single-CPU 64-bit entries, list dated 7 August 2026,
-# taken from computerchess.org.uk/ccrl/4040/rating_list_all.html.
+# CCRL 40/40 ratings ("all engines" list), single-CPU 64-bit entries, list
+# dated 7 August 2026, from computerchess.org.uk/ccrl/4040/rating_list_all.html.
 #
 # Only fruit and glaurung should normally be used as anchors -- pass
 # `--only fruit,glaurung`. Both have very large CCRL sample sizes, so their
@@ -26,7 +26,7 @@ from collections import defaultdict
 # evaluation surface and a thinly-played published rating do to a fit that
 # assumes a single strength scale.
 #
-# Fairy-Max is deliberately absent: it does not appear on the 40/15 list at
+# Fairy-Max is deliberately absent: it does not appear on the 40/40 list at
 # all, so the 1975 figure used in earlier sessions was never sourced. It can
 # still be played for interest, it just cannot anchor anything.
 ANCHORS = {
@@ -159,7 +159,7 @@ def main():
     se_elo = se_score / slope if slope > 0 else float("inf")
     print(f"\ntotal {s_tot:.1f} / {n_tot}")
     print(f"haVoc estimated rating: {r:.0f}  (+/- {1.96*se_elo:.0f}, 95%)")
-    print("anchored on CCRL Blitz; same hardware and time control for all "
+    print("anchored on CCRL 40/40; same hardware and time control for all "
           "engines")
 
 


### PR DESCRIPTION
The README had grown to 275 lines, with the Strength section alone taking 90 of them and duplicating what `scripts/testing/README.md` already documents in more depth. This collapses it to 226 lines: the results table, the three caveats that actually limit the number, and a pointer to the test docs.

While checking each claim against the source rather than assuming, several were wrong:

| Claim | Reality |
|---|---|
| Search list omits ProbCut | 17 references in `src/search.cpp` |
| Search list omits correction history | implemented, 5 references |
| Search list omits capture history | implemented (#121) |
| "razoring margins" listed as tuned | razoring does not exist in the engine |
| "133 tests" | 175 |
| rating on "CCRL Blitz" scale | anchors are CCRL 40/40 |

The last one was a three-way inconsistency: the README headline said *CCRL Blitz*, `rate.py`'s provenance comment said *CCRL 40/15*, and `rate.py`'s printed output said *CCRL Blitz* — all for one set of numbers whose source URL is the **40/40** list, and which match `anchor_rating.py`'s 40/40 table exactly. All three now say 40/40.

Note that the earlier ratings were fitted against Fruit and Glaurung alone, both ~200 Elo *above* the engine, so the fit was extrapolating. The README now says so, and notes that the three bracketing anchors added since make later measurements more reliable but not comparable to these rows.

The forward-looking section listed SPSA over search margins and a learned evaluation as equal options; `docs/neural-direction.md` has since settled that, so it points there.

Documentation and one output string only — no engine code, bench unchanged.