### PR TITLE
docs: record that a deliberate history extension is flat

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -128,6 +128,23 @@ which is the question the check exists to answer.
 ### Did not work
 
 - **Texel tuning.** Covered in section 5 — do not retry it.
+- **Extending PV moves with strong history in LMR.** This one arrived by
+  accident: an unsigned underflow was extending strong-history PV moves by a ply,
+  unchosen and unmeasured, and #123 removed it. Removing it cost ~1.5% more nodes
+  to the same bench, which raised the obvious question of whether the accident
+  had been carrying Elo. Reimplemented deliberately in signed arithmetic and
+  measured properly. The reproduction was verified faithful before the match:
+  bench came back at exactly the pre-#123 figure (684468) and the per-move node
+  vector over a nine-move game was byte-identical to #121. **−6.6 ± 9.1 over the
+  full 3000 games, LOS 7.7%.** Flat. The extension buys 1.5% fewer nodes and no
+  strength, so it is not worth carrying as deliberate complexity, and #123 was
+  right to remove it.
+
+  Read the partials as a lesson rather than as data: this run sat at **−44 at 223
+  games, −31 at 343, −27 at 970**, and finished at −6.6. Three consecutive
+  readings said "clearly harmful" and every one of them was noise. That is the
+  fourth time a partial reading in this project has pointed somewhere the
+  finished run did not go.
 - **Moving `moves_left` off 25.** The sudden-death divisor in the time budget
   (`our_time / moves_left + inc * 0.9`) is the single largest lever in a formula
   that is worth +35–42 Elo, and 25 was never measured — it was assumed. Swept as


### PR DESCRIPTION
Closes the regression hunt's last open hypothesis.

#123 removed an unsigned underflow that had been extending strong-history PV moves by a ply — accidental, never chosen, never measured. Removing it cost **~1.5% more nodes** for the same bench, so it was worth asking whether the accident had been carrying Elo.

Reimplemented deliberately in signed arithmetic and measured. The reproduction was verified faithful *before* the match, which matters because otherwise the result describes something else:

- bench returned **exactly** the pre-#123 figure (684468);
- the per-move node vector over a nine-move game was **byte-identical** to #121.

**Result: −6.6 ± 9.1 over the full 3000 games, LOS 7.7%.** Flat. Not worth carrying as deliberate complexity for 1.5% fewer nodes and no strength — #123 stands, and the branch is deleted rather than merged.

### The partials are the more useful finding

This run read **−44 at 223 games, −31 at 343, −27 at 970**, and finished at **−6.6**. Three consecutive readings said "clearly harmful" and all three were noise. I reported the −27 as probably real; it was not. That is the fourth time in this project a partial reading has pointed somewhere the finished run did not go, so it is recorded next to the result.

It also dissolves a contradiction that had been open for a while: −44 was irreconcilable with #121-vs-#120 being dead even over 3262 games and with run B's −1.3 ± 9.0. At −6.6, all three agree.

Docs only.