### PR TITLE
release: bump version to 2.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.20)
 
 project(haVoc
-    VERSION 2.1.0
+    VERSION 2.2.0
     DESCRIPTION "A modern UCI chess engine"
     HOMEPAGE_URL "https://github.com/mjglatzmaier/haVoc"
     LANGUAGES CXX

--- a/include/havoc/version.hpp
+++ b/include/havoc/version.hpp
@@ -10,7 +10,7 @@ namespace havoc {
 inline constexpr int VERSION_MAJOR = 2;
 inline constexpr int VERSION_MINOR = 1;
 inline constexpr int VERSION_PATCH = 0;
-inline constexpr std::string_view VERSION_STRING = "2.1.0";
+inline constexpr std::string_view VERSION_STRING = "2.2.0";
 inline constexpr std::string_view ENGINE_NAME = "haVoc";
 inline constexpr std::string_view ENGINE_AUTHOR = "M.Glatzmaier";
 


### PR DESCRIPTION
Version bump only, ahead of tagging v2.2.0.

Bench **694503**, 175 tests passing.

The release does not claim a strength gain — measured against v2.1.0 it is **−6.3 ± 4.8 Elo** over 11000 games, and the release notes say so up front. It earns its tag on four real data races (TT entries, node counters, per-thread history, per-thread seldepth), a rating that is now anchored from both sides at **~2580** rather than extrapolated from two anchors above the engine, and a script that rebuilds all five anchors reproducibly.