### PR TITLE
test: promote the two build-comparison diagnostics into the repo

### DIFF
--- a/scripts/testing/README.md
+++ b/scripts/testing/README.md
@@ -81,8 +81,36 @@ gain in batches where the effect is large enough to see.
 ### Tier 0 — no match at all
 
 Docs, tests, CI, refactors, and any change whose bench node count is
-byte-identical. An identical bench is a *stronger* proof of inertness than any
-match could provide, and it is free. Do not spend games on it.
+byte-identical. An identical bench is strong evidence of inertness and it is
+free. Do not spend games on it.
+
+**Bench alone is not enough for a behavioural claim.** It searches fixed
+positions at fixed depth and carries no state between them: every position gets
+a fresh table and fresh history. Anything that only shows up once the engine has
+accumulated state — move-ordering history, correction history, transposition
+entries surviving into the next search — is invisible to it. Two builds can
+print the same bench number and search different trees in a game.
+
+Two scripts cover what bench cannot:
+
+```sh
+scripts/testing/seq-nodes.py <binary-a> <binary-b>      # state carried across moves
+scripts/testing/time-profile.py <wtime> <winc> <bin>... # behaviour under a clock
+```
+
+`seq-nodes.py` issues one `ucinewgame` and walks a real game, so state carries
+forward as it does in play, and compares per-move node vectors. Identical
+vectors are strong evidence of identity; a mismatch is conclusive. It exits
+non-zero on disagreement, so it can gate a match.
+
+`time-profile.py` plays with an actual clock and records per-move think time and
+depth. Both bench and `seq-nodes.py` use fixed depth and are therefore blind to
+time management, which is worth +35–42 Elo here and is exactly the kind of thing
+that regresses unnoticed.
+
+Use `seq-nodes.py` to confirm a *reimplementation* reproduces the original
+before spending games on it. That check is the difference between a match that
+answers the question asked and one that silently answers a different one.
 
 ### Tier A — sanity check, cap 1200 games, ~20 min
 

--- a/scripts/testing/seq-nodes.py
+++ b/scripts/testing/seq-nodes.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Compare two builds for behavioural identity across a sequence of positions.
+
+Why this exists
+---------------
+`bench` is the usual identity check, and it is not sufficient. It searches a
+fixed list of positions at fixed depth, and it carries no state between them:
+every position gets a fresh table and fresh history. So `bench` is blind to any
+change that only shows up once the engine has accumulated state -- move-ordering
+history, correction history, transposition entries surviving into the next
+search. Two builds can print the same bench number and search different trees in
+an actual game.
+
+This drives one `ucinewgame` and then walks a real game, feeding successive
+`position startpos moves ...` and searching each. State carries forward exactly
+as it does in play, and the per-move node counts are recorded.
+
+Identical per-move vectors across two builds is strong evidence they are the
+same engine. It is not proof -- node counts can collide -- but a change that
+alters search behaviour and leaves this vector untouched is rare enough that a
+match is worth trusting. A *mismatch* is conclusive: they differ.
+
+This was written to verify that a reimplementation of an accidental LMR
+extension actually reproduced the original before spending 3000 games measuring
+it. That check is the difference between a match that answers the question asked
+and one that answers a different question silently.
+
+Usage:
+    seq-nodes.py <binary> [<binary> ...] [--depth N]
+
+Exits non-zero if the binaries disagree, so it can gate a match.
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+
+# A quiet Ruy Lopez, chosen because nothing forcing happens: the engine has to
+# actually search rather than following a forced sequence, so history and
+# ordering state get exercised.
+MOVES = ["e2e4", "e7e5", "g1f3", "b8c6", "f1b5", "a7a6", "b5a4", "g8f6",
+         "e1g1", "f8e7", "f1e1", "b7b5", "a4b3", "d7d6", "c2c3", "e8g8"]
+
+
+def node_vector(binary, depth):
+    """Search every second position of the game, returning per-move node counts."""
+    p = subprocess.Popen([binary], stdin=subprocess.PIPE,
+                         stdout=subprocess.PIPE, text=True)
+
+    def send(line):
+        p.stdin.write(line + "\n")
+        p.stdin.flush()
+
+    def search():
+        send(f"go depth {depth}")
+        nodes = 0
+        while True:
+            line = p.stdout.readline()
+            if not line:
+                raise RuntimeError(f"{binary} exited mid-search")
+            m = re.search(r" nodes (\d+)", line)
+            if m:
+                nodes = int(m.group(1))
+            if line.startswith("bestmove"):
+                return nodes
+
+    send("uci")
+    # One thread: helper threads make node counts nondeterministic, which would
+    # destroy the comparison this script exists to make.
+    send("setoption name Threads value 1")
+    send("isready")
+    while not p.stdout.readline().startswith("readyok"):
+        pass
+    send("ucinewgame")
+
+    counts = []
+    for i in range(0, len(MOVES) + 1, 2):
+        played = " ".join(MOVES[:i])
+        send(f"position startpos moves {played}" if i else "position startpos")
+        counts.append(search())
+
+    send("quit")
+    p.wait(timeout=10)
+    return counts
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("binaries", nargs="+")
+    ap.add_argument("--depth", type=int, default=11)
+    args = ap.parse_args()
+
+    results = {}
+    for b in args.binaries:
+        counts = node_vector(b, args.depth)
+        results[b] = counts
+        print(f"{b:40s} total={sum(counts):>9d}  {counts}")
+
+    if len(results) < 2:
+        return 0
+
+    vectors = list(results.values())
+    if all(v == vectors[0] for v in vectors):
+        print("\nidentical: same per-move node vector on every build")
+        return 0
+
+    print("\nDIFFER: these builds do not search the same tree")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/testing/time-profile.py
+++ b/scripts/testing/time-profile.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Compare time-managed behaviour between builds.
+
+bench is fixed-depth and seq.py used `go depth`, so both are blind to how much
+time the engine decides to spend. Two builds can be byte-identical at fixed
+depth and still play differently under a clock. This drives a real game with a
+real time control and records, per move, how long the engine actually thought
+and how deep it got.
+"""
+import subprocess, sys, time, re
+
+MOVES = ["e2e4","e7e5","g1f3","b8c6","f1b5","a7a6","b5a4","g8f6","e1g1","f8e7",
+         "f1e1","b7b5","a4b3","d7d6","c2c3","e8g8"]
+
+def run(binary, wtime, winc):
+    p = subprocess.Popen([binary], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                         text=True, bufsize=1)
+    def send(s):
+        p.stdin.write(s + "\n"); p.stdin.flush()
+    send("uci")
+    while "uciok" not in p.stdout.readline():
+        pass
+    send("setoption name Threads value 1")
+    send("setoption name Hash value 64")
+    send("isready")
+    while "readyok" not in p.stdout.readline():
+        pass
+    send("ucinewgame")
+    send("isready")
+    while "readyok" not in p.stdout.readline():
+        pass
+
+    out = []
+    for i in range(0, len(MOVES), 2):
+        moves = " ".join(MOVES[:i])
+        send(f"position startpos moves {moves}" if moves else "position startpos")
+        t0 = time.time()
+        send(f"go wtime {wtime} btime {wtime} winc {winc} binc {winc}")
+        depth = nodes = 0
+        while True:
+            line = p.stdout.readline()
+            if not line:
+                break
+            if line.startswith("info"):
+                m = re.search(r"\bdepth (\d+)", line)
+                if m:
+                    depth = max(depth, int(m.group(1)))
+                m = re.search(r"\bnodes (\d+)", line)
+                if m:
+                    nodes = int(m.group(1))
+            if line.startswith("bestmove"):
+                break
+        out.append((round((time.time() - t0) * 1000), depth, nodes))
+    send("quit")
+    p.wait(timeout=10)
+    return out
+
+if __name__ == "__main__":
+    wtime, winc = int(sys.argv[1]), int(sys.argv[2])
+    builds = sys.argv[3:]
+    res = {}
+    for b in builds:
+        res[b] = run(b, wtime, winc)
+    print(f"tc: wtime={wtime} winc={winc}")
+    for b in builds:
+        tot_t = sum(r[0] for r in res[b])
+        tot_n = sum(r[2] for r in res[b])
+        print(f"\n{b}\n  total_ms={tot_t} total_nodes={tot_n}")
+        print("  " + " ".join(f"{r[0]}ms/d{r[1]}" for r in res[b]))


### PR DESCRIPTION
Both scripts were written during the regression hunt and both lived only in `/tmp` — the same way the rating anchors were lost to a reboot.

### Why bench is not enough

`bench` searches fixed positions at fixed depth and **carries no state between them**: every position gets a fresh table and fresh history. So it is blind to anything that only appears once the engine has accumulated state — move-ordering history, correction history, TT entries surviving into the next search. Two builds can print the same bench number and search different trees in a game.

### `seq-nodes.py`

Issues one `ucinewgame` and walks a real game, feeding successive `position startpos moves ...`, so state carries forward as it does in play. Compares per-move node vectors across builds.

Identical vectors are strong evidence of identity; a **mismatch is conclusive**. Exits non-zero on disagreement so it can gate a match. Verified both directions:

```
/tmp/b-rel/havoc        total=845945  [97828, 113681, 95003, ...]
/tmp/b-tb-cand/havoc    total=845945  [97828, 113681, 95003, ...]
identical: same per-move node vector on every build          -> exit 0

/tmp/b-121/havoc        total=799889  [97849, 124073, 97445, ...]
DIFFER: these builds do not search the same tree             -> exit 1
```

This is what confirmed the deliberate history-extension reimplementation actually reproduced the accidental one before 3000 games were spent on it (#134). That check is the difference between a match that answers the question asked and one that silently answers a different one.

### `time-profile.py`

Covers the other blind spot: bench and `seq-nodes.py` both use **fixed depth**, so neither can see time management — worth +35–42 Elo here, and exactly the kind of thing that regresses unnoticed. Plays with a real clock and records per-move think time and depth.

Tier 0 in the testing README now says all of this, rather than claiming an identical bench is proof of inertness.

Tooling and docs only; no engine code.