### PR TITLE
feat: add razoring

### DIFF
--- a/docs/revisit-after-tuning.md
+++ b/docs/revisit-after-tuning.md
@@ -30,8 +30,31 @@ course.
 | King safety constants (`pawnless_flank_penalty`, `king_storm_penalty`, `king_shelter`) | `fix/king-safety-untunable` | These were literals in the evaluation and are now parameters at exactly the values they had, so nothing about them was ever measured. `king_shelter` in particular spent its life halved by integer division, which means the array's tuned history was fit against a truncated version of itself; treat its current values as arbitrary. The storm penalty ignores how far advanced the storming pawns are, which is the signal that actually matters -- worth adding once the flat version has been fit. |
 | `eval_threats` weights (`threat_by_pawn`, `threat_weak_pawn`, `queen_pin_*`, `discovered_check_bonus`, `restriction_weight`, `skewer_bonus`) | `fix/threat-weights-untunable` | An entire evaluation component that was frozen at unmeasured literals. `restriction_weight` is the one to watch: it multiplies a difference of attacked-square counts that can reach several dozen, so it is the highest-leverage single number in the file and a fit may want it well below 1, which the integer type cannot express. If the fit pushes it to zero, the term probably needs a divisor or the counts need scaling down. |
 | ProbCut (`probcut_min_depth`, `probcut_margin`, `probcut_depth_reduction`) | `feat/probcut` | Search parameters, so SPSA rather than Texel. Measured node-neutral on bench (1884909 -> 1871476) with a 61% cutoff rate on entry, which says the technique works but that the verification search costs about what it saves at these settings. The margin and the reduction are the two knobs that decide whether it pays; if SPSA cannot find a profitable setting, the honest conclusion is that haVoc's tree is too shallow at fixed depth for ProbCut to earn its keep. |
+| Razoring (`razor_max_depth`, `razor_base`, `razor_margin`) | `feat/razoring` | Landed measuring **-0.7 +/- 9.3 over 3000 games** -- flat, not a gain. Kept on the ProbCut precedent: it is a search parameter, so SPSA rather than Texel, and its value is entirely a function of its margins. Instrumentation says there is room: the quiescence verification succeeds **94-99% of the time at every margin tried**, so razoring is nowhere near the point where it starts being wrong, which means the current settings are too timid rather than too bold. But the aggressive direction is not free either -- firing 4x more often grew the bench tree ~50%, monotonically. If SPSA cannot find a setting that beats flat, remove it; a technique that cannot earn its keep should not stay for the sake of completeness. **Do not tune this on bench node count** -- see the warning below. |
 | King zone open files (`king_open_file_penalty`, `king_semi_open_file_penalty`) | `integration/ordering-shelter` | Landed on a batched SPRT that measured +3.8 +/- 25.9 over 460 games, which is a statement about the batch and not about these two numbers. Both defaults are guesses. They also overlap the shelter term, which already charges for a missing pawn in front of the king: an open file beside the king implies no shelter pawn on it, so some of this penalty is being paid twice. Check whether the fit drives one of the two toward zero, which is what collinearity looks like. |
 | Threat-escape move ordering | `integration/ordering-shelter` | Not a weight but an ordering rule: moves of the piece the null-move threat lands on are lifted by `kCounterMoveBonus`, a fixed eighth of the history range. That constant was picked for the countermove term and reused here without measurement. It is an SPSA candidate rather than a Texel one. |
+
+## Why bench node count cannot tune a pruning heuristic
+
+Razoring made this concrete and it generalises to every forward-pruning
+parameter here. Measured over the bench suite with firing counters:
+
+| razor setting | times fired | bench nodes vs 694503 |
+| --- | --- | --- |
+| base 800 | 179 | **+16%** |
+| base 500 | 1669 | +7% |
+| base 300 | 2441 | -1% |
+| base 1000 | 39 | **-5%** |
+
+Firing 179 times made the tree 16% *bigger*; firing 39 times made it 5%
+smaller. The relationship is neither monotonic nor causal in the way it looks:
+an early return changes what lands in the transposition table, which changes
+move ordering at every node that later probes it, and the tree reorganises. The
+node count is a chaotic function of the parameter, not a measure of efficiency.
+
+The same caution applies to reading bench as evidence a pruning change "works".
+It is a reliable *identity* check -- an unchanged bench means an unchanged tree
+-- and an unreliable *quality* check. Only games decide these.
 
 ## Evaluation defaults introduced with no evidence behind them
 

--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -423,6 +423,9 @@ struct parameters {
     // machinery can reach them; search.cpp reads them through params_.
     int rfp_max_depth = 6;          // reverse futility only below this depth
     int rfp_margin = 80;            // ...and only if eval - margin*depth >= beta
+    int razor_max_depth = 3;        // razoring only below this depth
+    int razor_base = 300;           // ...and only if eval + base + margin*depth <= alpha
+    int razor_margin = 400;
     int nmp_min_depth = 3;          // null move needs at least this much depth
     int nmp_base_r = 3;             // base null-move reduction
     int nmp_depth_div = 6;          // extra reduction of depth/this

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -396,6 +396,9 @@ std::vector<std::pair<std::string, int*>> parameters::all_params(TuneStage stage
         // worth. They are tuned by SPSA against game results.
         result.emplace_back("rfp_max_depth", &rfp_max_depth);
         result.emplace_back("rfp_margin", &rfp_margin);
+        result.emplace_back("razor_max_depth", &razor_max_depth);
+        result.emplace_back("razor_base", &razor_base);
+        result.emplace_back("razor_margin", &razor_margin);
         result.emplace_back("nmp_min_depth", &nmp_min_depth);
         result.emplace_back("nmp_base_r", &nmp_base_r);
         result.emplace_back("nmp_depth_div", &nmp_depth_div);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -904,6 +904,27 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
     const bool forward_prune = (!in_check && !pvNode && !stack->null_search && !singular_search &&
                                 std::abs(alpha - beta) == 1 && hasStaticValue);
 
+    // Razoring: the mirror of reverse futility. If the static eval is so far
+    // below alpha that a margin cannot plausibly bridge it, spend a quiescence
+    // search instead of a full-width one. The quiescence result is what decides:
+    // only if it *also* fails low do we return, so a position saved by a capture
+    // or a check evasion still gets searched properly. That verification is what
+    // separates razoring from simply pruning the node, which would be unsound.
+    //
+    // qsearch is handed *this* node's stack frame, not `stack + 1`, because it
+    // searches the same position and must therefore sit at the same ply. That
+    // makes the placement load-bearing: qsearch clobbers `threat_move` and
+    // `curr_move` on the frame it is given, and both are re-initialised below
+    // before anything reads them (`curr_move` at the null-move guard,
+    // `threat_move` by the null search itself). Moving this block after either
+    // of those would corrupt the node.
+    if (forward_prune && depth <= params_.razor_max_depth &&
+        static_eval_val + params_.razor_base + params_.razor_margin * depth <= alpha &&
+        std::abs(alpha) < score::kMateMaxPly) {
+        const int razor_score = qsearch<non_pv>(pos, alpha - 1, alpha, 0, stack, thread_id);
+        if (razor_score < alpha) return razor_score;
+    }
+
     // Null move pruning
     bool null_move_allowed =
         (pos.to_move() == white ? pos.non_pawn_material<white>() : pos.non_pawn_material<black>());


### PR DESCRIPTION
The README listed razoring as implemented and it was not. This adds it.

**Measured: −0.7 ± 9.3 Elo over the full 3000 games, LOS 44.2%.** Flat. This is not a strength claim — see "why merge it then" below.

### What it does

At low depth, when the static eval sits so far below alpha that the margin cannot plausibly be bridged, spend a quiescence search instead of a full-width one. The node only returns if qsearch **also** fails low, so a position rescued by a capture or a check evasion still gets searched properly. That verification is what separates razoring from simply pruning the node, which would be unsound.

One subtlety worth flagging for review: qsearch is handed **this node's own stack frame**, not `stack + 1`, because it searches the same position and must sit at the same ply. That makes the placement load-bearing — qsearch clobbers `threat_move` and `curr_move` on the frame it is given, and both are re-initialised further down before anything reads them. Moving the block past either would corrupt the node silently. The comment says so.

Margins are registered parameters so SPSA can reach them, not literals.

### Chosen by instrumentation, not by eye

I added firing counters and measured before trusting anything:

- The quiescence verification succeeds **94–99% of the time at every margin tried**, so it is almost never wasted work — and the current settings are too *timid* rather than too bold.
- A quadratic margin (my first attempt) **never fired above depth 1**. That is not razoring. Switched to linear, which fires at all three depths.

### Bench node count cannot tune this

Worth reading even if you skip the rest:

| razor setting | times fired | bench vs 694503 |
| --- | --- | --- |
| base 800 | 179 | **+16%** |
| base 300 | 2441 | −1% |
| base 1000 | 39 | **−5%** |

179 firings made the tree 16% *bigger*; 39 firings made it 5% smaller. Non-monotonic and not causal — an early return changes what lands in the TT, which changes move ordering everywhere that later probes it, and the tree reorganises. I started tuning on bench and had to throw that work out. It is now documented in `revisit-after-tuning.md` so nobody repeats it: bench is a reliable *identity* check and an unreliable *quality* check.

### Why merge something that measured flat

Same precedent as ProbCut, which also landed node-neutral: it is a search parameter, so SPSA rather than Texel, and its value is entirely a function of its margins — which are now reachable by the tuner, and would not be if this were deleted. The doc entry carries an explicit instruction to **remove it if SPSA cannot beat flat**, rather than letting it sit forever for the sake of completeness.

175 tests pass. Bench 686052.