### PR TITLE
feat: extend singular moves by two plies when they are singular by a wide margin

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -124,10 +124,32 @@ which is the question the check exists to answer.
   `--decisions` (what actually changes a move) each settled questions that had
   been circular. When stuck, the fastest route has consistently been to build the
   measurement rather than reason harder.
+- **Double singular extensions.** When the hash move beats the singular beta by
+  a wide margin it is extended two plies instead of one. Measured **+10.0 ± 6.4
+  Elo over 6000 games** (3.1σ), from two independent 3000-game SPRTs: +7.2 ±
+  8.9 against pre-razoring main and +13.0 ± 9.1 against main with razoring,
+  combined by inverse-variance weighting. The baselines differ, but razoring
+  itself measured flat (−0.7 ± 9.3), so they are statistically equivalent.
+  Notably **tree-neutral** — the bench node count barely moves — so this buys
+  strength by spending the same effort in better places, not by spending more.
+  The *negative* extension that usually ships alongside it was tried and
+  discarded: see below.
 
 ### Did not work
 
 - **Texel tuning.** Covered in section 5 — do not retry it.
+- **Negative singular extensions.** The standard companion to the double
+  extension: when the hash move fails the singular test badly, search it a ply
+  *shallower* to spend less on a node that looks unpromising. Here it grew the
+  bench tree by **35%**, which is the opposite of the entire point. The reason
+  is mechanical: searching the hash move shallower stops it producing the
+  cutoff, so the node goes on to search every alternative at full depth. It
+  was removed and the double extension shipped alone. A comment in
+  `src/search.cpp` records this so it is not retried blind.
+
+  Anyone reattempting it must know that
+  `extensions = std::max(givesCheck ? 1 : 0, singular_ext)` **silently swallows
+  a negative extension**, so the first attempt will appear to do nothing.
 - **Extending PV moves with strong history in LMR.** This one arrived by
   accident: an unsigned underflow was extending strong-history PV moves by a ply,
   unchosen and unmeasured, and #123 removed it. Removing it cost ~1.5% more nodes

--- a/include/havoc/move_order.hpp
+++ b/include/havoc/move_order.hpp
@@ -37,6 +37,11 @@ struct SearchNode {
     Move excluded_move;
     Move* pv = nullptr;
     int sel_depth = 0;
+    /// How many double extensions are already on the path to this node. A
+    /// doubly-extended move gives its child more depth than the parent spent,
+    /// so without a cap a chain of them can grow the tree without bound. This
+    /// counter is inherited, not reset per node.
+    int double_extensions = 0;
     std::unique_ptr<BestMoveHistory> bmh;
     Move killers[4];
     int16_t static_eval = score::kNegInf;

--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -421,6 +421,8 @@ struct parameters {
     // position is worth. They can only be tuned against game results, which
     // is what SPSA is for. They live here so the tuner and the ParamFile
     // machinery can reach them; search.cpp reads them through params_.
+    int double_ext_margin = 24;     // singular by more than this extends twice
+    int max_double_ext = 6;         // ...but at most this many times on a path
     int rfp_max_depth = 6;          // reverse futility only below this depth
     int rfp_margin = 80;            // ...and only if eval - margin*depth >= beta
     int razor_max_depth = 3;        // razoring only below this depth

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -394,6 +394,8 @@ std::vector<std::pair<std::string, int*>> parameters::all_params(TuneStage stage
         // -- a Texel gradient over these is identically zero, because they
         // change which nodes the search visits rather than what a position is
         // worth. They are tuned by SPSA against game results.
+        result.emplace_back("double_ext_margin", &double_ext_margin);
+        result.emplace_back("max_double_ext", &max_double_ext);
         result.emplace_back("rfp_max_depth", &rfp_max_depth);
         result.emplace_back("rfp_margin", &rfp_margin);
         result.emplace_back("razor_max_depth", &razor_max_depth);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1186,9 +1186,27 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
 
             if (singular_score < singular_beta) {
                 singular_ext = 1;
+                // Double extension: how far the alternatives fell short says
+                // *how* singular the move is, and a move that is singular by a
+                // wide margin is usually the only thing holding the position
+                // together. Restricted to non-PV nodes and capped along the
+                // path, because a doubly-extended move hands its child more
+                // depth than this node spent -- a chain of them grows the tree
+                // without bound, which is the standard way this technique goes
+                // wrong.
+                if (!pvNode && singular_score < singular_beta - params_.double_ext_margin &&
+                    stack->double_extensions < params_.max_double_ext) {
+                    singular_ext = 2;
+                }
             } else if (singular_beta >= beta) {
                 return singular_beta; // Multi-cut
             }
+            // A negative extension for the non-singular `ttvalue >= beta` case
+            // was tried here and removed: it grew the bench tree 35%, which
+            // defeats the point of a technique whose whole purpose is to spend
+            // less. Searching the hash move a ply shallower stops it producing
+            // the cutoff, so the node goes on to search everything else at full
+            // depth. See docs/roadmap.md.
         }
 
         stack->push_context(pos.piece_on(static_cast<Square>(move.f)), move.t);
@@ -1196,7 +1214,12 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
         stack->curr_move = move;
 
         bool givesCheck = pos.in_check();
-        int extensions = std::max(givesCheck ? 1 : 0, singular_ext);
+        // A negative singular extension has to survive this: taking std::max
+        // against the check extension would silently swallow it.
+        int extensions = singular_ext < 0 ? singular_ext
+                                          : std::max(givesCheck ? 1 : 0, singular_ext);
+        (stack + 1)->double_extensions =
+            stack->double_extensions + (singular_ext == 2 ? 1 : 0);
         // Extra reductions beyond the one ply every move already consumes.
         int reductions_val = 0;
 


### PR DESCRIPTION
## What

When the hash move beats the singular beta by a wide margin, extend it by two plies instead of one. Capped per branch by an inherited `double_extensions` counter on `SearchNode`, so a chain of double extensions cannot run away.

## The measurement

Two independent 3000-game SPRTs at 10+0.1, bounds -0.5/+0.5, both run to full length so neither estimate is biased by early stopping:

| run | baseline | result |
|---|---|---|
| 1 | main before razoring | +7.2 ± 8.9, LOS 94.2% |
| 2 | main with razoring (`df4a0f9`) | **+13.0 ± 9.1, LOS 99.7%** |
| combined | inverse-variance, 6000 games | **+10.0 ± 6.4 (3.1σ)** |

**The honest caveat:** the two runs do not share a baseline. Razoring landed between them. Razoring itself measured flat (-0.7 ± 9.3, LOS 44.2%), so the two baselines are statistically equivalent and combining them is defensible — but they are not the same binary, and that is worth saying out loud rather than presenting 6000 games as if they were one experiment.

Run 1 alone would not have justified merging. LOS 94.2% is below this project's empirical false-positive line: a control run here between *behaviourally identical* builds once returned -8.0 at LOS 4.2%, so ~2σ excursions demonstrably happen on this harness. That is exactly why the confirmation run was required, and it is why the result is reported at 6000 games rather than 3000.

## Why this is worth having

It is **tree-neutral**. The bench node count barely moves, so this is not buying strength by spending more effort — it is spending the same effort in better places. That is a much more durable kind of gain than one that shows up as a bigger tree.

## What was tried and removed

The negative singular extension, which normally ships alongside this, is **not** here. Isolated, it grew the bench tree by 35% — the opposite of its entire purpose. The mechanism: searching the hash move a ply shallower stops it producing the cutoff, so the node goes on to search every alternative at full depth. It is recorded in `docs/roadmap.md` with its mechanism, along with the detail that `extensions = std::max(givesCheck ? 1 : 0, singular_ext)` silently swallows a negative extension, so a future attempt does not spend a day discovering its change does nothing.

## Verification

- 175/175 tests pass.
- Base and candidate built from scratch with verified-identical flags and `CMAKE_HOME_DIRECTORY`; base benched 686052, matching main exactly, before either match was launched.