### PR TITLE
feat: NNUE stage 1 -- run the network in the engine behind EvalFile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ set(HAVOC_CORE_SOURCES
     src/material_table.cpp
     src/kpk.cpp
     src/eval/hce.cpp
+    src/eval/nnue_evaluator.cpp
     src/move_order.cpp
     src/thread_pool.cpp
     src/search.cpp

--- a/docs/nnue-integration.md
+++ b/docs/nnue-integration.md
@@ -344,3 +344,86 @@ at 1.4 s/epoch it was nearly free to test. It cut int8-versus-float error from
 12.2 cp to 14.5 cp, because the constrained network fits the target less well.
 It is kept behind `--qat`, off by default, and recorded here so it is not
 retried on the assumption that it must help.
+
+## 9. Stage 1: the network in the engine
+
+Stage 0 proved a network could be trained, quantised and read back. Stage 1
+puts it behind `IEvaluator` and makes the search drive it, which is where the
+accumulator becomes a thing that can silently drift out of step with the
+board.
+
+### What was built
+
+- `NNUEEvaluator` (`include/havoc/eval/nnue_evaluator.hpp`) — per-thread stack
+  of accumulator frames, one per ply, patched by `push` and unwound by `pop`.
+- `setoption name EvalFile value <path>` loads a network and installs the
+  evaluator on every search thread; `value none` puts the handcrafted
+  evaluation back. A network that fails to load leaves the engine playing with
+  the evaluation it already had rather than refusing to start.
+- An AVX2 kernel for the dense layers, dispatched to only when the layer widths
+  suit it, with `forward_reference` kept as the definition it is checked
+  against.
+
+The HCE path is untouched: `bench` is 709908 with and without the branch.
+
+### Correctness, and what each check can actually see
+
+| check | what it would catch |
+|---|---|
+| accumulator vs full rebuild at every node of a real search, five position families | any desynchronisation, at the node it happens on |
+| every legal king move walked by hand, plus one reply | bucket crossing, which a search is free to prune away entirely |
+| mutation: king events stripped from the delta | a king move that failed to rebuild its own perspective |
+| mutation: removals stripped from the delta | a lost update on the perspective that was *not* rebuilt |
+| 20,000 recorded cases replayed against `quantise.py` | any divergence between the C++ and Python integer paths |
+| vector kernel vs `forward_reference`, 20,000 random accumulators | a SIMD kernel that is only nearly right |
+
+The two mutation tests are the load-bearing ones. Rebuilding a perspective is
+always correct, so a sync check alone cannot distinguish "updated correctly"
+from "rebuilt anyway" — it can only prove something if deliberately breaking
+each half makes it fail. Both do.
+
+The cross-language replay agreed on **20,000 of 20,000** positions exactly.
+
+### Speed, measured rather than assumed
+
+The scalar reference was never going to be fast enough, and was not:
+
+| kernel | ns per forward | bench nps |
+|---|---|---|
+| scalar reference | 1174 | 657k |
+| AVX2, one output row at a time | 481 | 959k |
+| AVX2, four output rows blocked, stack scratch | 347 | — |
+| AVX2, dense weights pre-widened to int16 at load | **284** | **1047k** |
+| (handcrafted evaluation, for comparison) | — | 1841k |
+
+Three things that were tried and measured as worthless are worth recording so
+they are not retried: **eight-row blocking** (229 ns against 226 ns for four),
+**an explicit packs/permute/clamp for the accumulator narrowing** (identical to
+the plain loop — the compiler was already vectorising it), and `thread_local`
+scratch vectors, which were *worse* than plain stack arrays because a
+`thread_local` with a non-trivial constructor pays a guard check on every
+access.
+
+`_mm256_maddubs_epi16` would double the products per instruction and is what
+most engines use, but it accumulates into int16 and **saturates**: with
+activations in [0, 255] and weights in [-127, 127] a pair of products reaches
+64,770 against a 32,767 ceiling. Engines that use it clip activations to
+[0, 127] instead, where `127·127·2 = 32,258` fits exactly. Since the Stage 0
+sweep showed activation resolution to be worth nothing (QA 255 → 16383 changed
+the error by 0.3 cp), dropping QA to 127 is very likely free and would unlock
+it. That is the next optimisation, together with exploiting the sparsity of the
+clipped accumulator; neither is on the critical path for the staged plan.
+
+### What the Stage 1 SPRT can and cannot say
+
+The original expectation written here was "~0 Elo, and a large number in either
+direction is a bug report". That was wrong in one respect, and the measurement
+above is why: **the network costs 43% of the engine's speed** (1841k → 1047k
+nps). At 10+0.1 that is worth roughly −50 Elo on its own, before the network's
+26.7 cp modelling error and 9.2 cp of quantisation noise are counted at all.
+
+So the honest Stage 1 expectation is a clear *loss*, and the informative
+quantity is not the Elo but how it decomposes. A result far worse than the
+speed cost plus the eval noise would mean something is wrong that the tests
+above did not see; a result better than the speed cost alone would mean the
+comparison is not measuring what it claims.

--- a/docs/nnue-integration.md
+++ b/docs/nnue-integration.md
@@ -427,3 +427,101 @@ quantity is not the Elo but how it decomposes. A result far worse than the
 speed cost plus the eval noise would mean something is wrong that the tests
 above did not see; a result better than the speed cost alone would mean the
 comparison is not measuring what it claims.
+
+## 10. What Stage 1 actually found: the held-out number was a lie
+
+The Stage 1 match was supposed to be a formality. It was not, and this section
+is the most useful thing in this document.
+
+### The measurements
+
+| comparison | result |
+|---|---|
+| NNUE-mimic vs HCE, 10+0.1, 200 games | **−252 ± 52 Elo** |
+| NNUE-mimic vs HCE, **fixed depth 8**, 200 games | **−111 ± 45 Elo** |
+
+Fixed depth removes the 43% speed cost from the comparison, so roughly 140 Elo
+was speed and 111 Elo was the evaluation itself. A network reproducing the HCE
+to 26.7 cp should not lose 111 Elo at equal depth, so either the integration
+was wrong or the 26.7 cp was.
+
+### The 26.7 cp was
+
+Relabelling positions taken from **real games** with the HCE and running the
+same network over them gave **82 cp**, not 26.7. Nothing in the C++ was
+involved in either number, so this was not an integration fault — and the
+integration tests, including a 20,000-position exact replay of the Python
+quantiser, all passed.
+
+The corpus is written by self-play datagen in game order. Measured on it:
+
+- adjacent records share **85%** of their features (median Jaccard) — they are
+  consecutive plies of one game;
+- records 1,000 apart share **0.8%**;
+- **11.5%** of feature vectors occur more than once outright.
+
+A random train/validation split therefore places nearly every validation
+position's near-twin, and often its exact twin, into the training set. The
+26.7 cp was measuring memorisation.
+
+### Three numbers for the same network
+
+| validation protocol | MAE |
+|---|---|
+| random split of the corpus | 26.7 cp |
+| contiguous tail block, 200k-record gap, exact duplicates dropped | 48.7 cp |
+| independent positions from real games | **67–71 cp** |
+
+Both effects are real and separable. The gap between the first two rows is
+**leakage**; the gap between the last two is **distribution shift** — a
+held-out block of a datagen corpus is still a datagen position, and the engine
+does not play datagen positions. `train.py` now defaults to the contiguous
+protocol and takes `--val-file` for the third, which is the only one that is
+honest by construction and is what every real run should use.
+
+### What is actually limiting the network
+
+With the honest measurement in place, two sweeps say the same thing.
+
+**Data (L1=256, 25 epochs, validated on game positions):**
+
+| positions | MAE |
+|---|---|
+| 0.36M | 139.8 cp |
+| 0.9M | 100.6 cp |
+| 1.8M | 83.8 cp |
+| 3.6M | 71.3 cp |
+
+Every doubling buys about 15%, with no sign of flattening.
+
+**Capacity (3.6M positions, 25 epochs):**
+
+| L1 | MAE |
+|---|---|
+| 64 | 68.3 cp |
+| 128 | 68.1 cp |
+| 512 | 67.1 cp |
+| 1024 | 67.0 cp |
+
+Flat. Sixteen times the first-layer width buys 2%.
+
+The network is **data-limited, not capacity-limited**, and it is not close. At
+~15% per doubling, 30M positions lands near 45 cp and 100M near 35 cp; datagen
+runs at 2,100 positions/second, which makes 30M about four hours and 100M about
+thirteen. That is the lever, and it is cheap.
+
+The capacity result has an immediate practical consequence: **L1=64 costs a
+quarter of L1=256 in the dense layer** — which is where all the evaluation time
+goes — and at present data volumes evaluates just as well. Stage 3 should start
+small and grow the network only when the data justifies it, rather than the
+other way round.
+
+### Verdict on Stage 1
+
+The integration is correct: every exactness and synchronisation test passes,
+the C++ and Python integer paths agree on 20,000 of 20,000 positions, and the
+Elo loss is fully accounted for by 43% of the speed plus 70–80 cp of evaluation
+error. The stage did exactly what a known-answer test is for — it failed on the
+thing that was actually wrong, which was the answer, not the code. Finding this
+now cost an afternoon; finding it after a full training run would have cost
+days and would have been blamed on the labels.

--- a/include/havoc/eval/nnue_evaluator.hpp
+++ b/include/havoc/eval/nnue_evaluator.hpp
@@ -1,0 +1,182 @@
+#pragma once
+
+/// @file nnue_evaluator.hpp
+/// @brief An IEvaluator that runs the quantised network with an incrementally
+///        maintained feature transformer.
+///
+/// What is incremental and what is not
+/// ----------------------------------
+/// Only the first layer is incremental, because only the first layer is a
+/// plain sum over active features: a move adds and removes a handful of them,
+/// so the accumulator is patched rather than rebuilt. Everything after it is
+/// dense and must be recomputed every time.
+///
+/// HalfKP makes one perspective's entire accumulator a function of that side's
+/// king square, so when a king moves, that perspective is rebuilt from
+/// scratch. The *other* perspective is untouched by it -- kings are not
+/// features here, they are the bucket -- so it is still patched normally, and
+/// a king capture still removes the captured piece from it. That asymmetry is
+/// the part most likely to be got wrong, and it is what
+/// `matches_full_recompute` exists to check.
+///
+/// State, and why it is per-thread
+/// -------------------------------
+/// Weights are immutable and shared. Accumulators are not: each search thread
+/// walks its own line and needs its own stack of them, one frame per ply, so
+/// that `pop` is a decrement rather than an inverse-move replay. The frames
+/// are indices into one flat buffer so growing it cannot dangle a pointer.
+
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "havoc/eval/evaluator.hpp"
+#include "havoc/nnue/features.hpp"
+#include "havoc/nnue/network.hpp"
+#include "havoc/position.hpp"
+
+namespace havoc {
+
+class NNUEEvaluator : public IEvaluator {
+  public:
+    /// @param net Must be loaded and must outlive every search that uses it;
+    ///            shared ownership is how that is guaranteed across a thread
+    ///            count change.
+    explicit NNUEEvaluator(std::shared_ptr<const nnue::Network> net)
+        : net_(std::move(net)), l1_(net_->l1()) {
+        frames_.assign(static_cast<size_t>(kInitialFrames) * frame_stride(), 0);
+        capacity_ = kInitialFrames;
+    }
+
+    [[nodiscard]] int evaluate(const position& pos, int lazy_margin = -1) override {
+        (void)lazy_margin;
+        const int us = static_cast<int>(pos.to_move());
+        const int32_t* base = frame(top_);
+        return net_->forward(base + static_cast<size_t>(us) * static_cast<size_t>(l1_),
+                             base + static_cast<size_t>(us ^ 1) * static_cast<size_t>(l1_));
+    }
+
+    [[nodiscard]] std::string name() const override { return "NNUE"; }
+
+    [[nodiscard]] bool wants_deltas() const override { return true; }
+
+    void push(const position& pos, const FeatureDelta& d) override;
+
+    void pop() override {
+        if (top_ > 0)
+            --top_;
+    }
+
+    void refresh(const position& pos) override {
+        top_ = 0;
+        int32_t* base = frame(0);
+        recompute(base, pos, white);
+        recompute(base + static_cast<size_t>(l1_), pos, black);
+    }
+
+    /// Current stack depth. Should always equal the search's ply. Tests only.
+    [[nodiscard]] int stack_depth() const { return top_; }
+
+    /// Whether the live accumulator equals a from-scratch rebuild of `pos`.
+    ///
+    /// This is the only check that can tell "updated correctly" from
+    /// "happened to be refreshed anyway", which is why it compares raw
+    /// accumulators and not evaluations: two different accumulators can round
+    /// to the same centipawn and a comparison of scores would pass.
+    [[nodiscard]] bool matches_full_recompute(const position& pos) const;
+
+  private:
+    /// One frame per ply of the search. Grown, never assumed: a search that
+    /// exceeds it would otherwise write past the end.
+    static constexpr int kInitialFrames = 192;
+
+    [[nodiscard]] size_t frame_stride() const { return static_cast<size_t>(2 * l1_); }
+
+    [[nodiscard]] int32_t* frame(int i) {
+        return frames_.data() + static_cast<size_t>(i) * frame_stride();
+    }
+    [[nodiscard]] const int32_t* frame(int i) const {
+        return frames_.data() + static_cast<size_t>(i) * frame_stride();
+    }
+
+    /// Rebuild one perspective from the board. `dst` is `l1_` wide.
+    void recompute(int32_t* dst, const position& pos, Color perspective) const {
+        const int16_t* bias = net_->ft_bias();
+        for (int i = 0; i < l1_; ++i)
+            dst[i] = bias[i];
+        nnue::for_each_active(pos, perspective, [&](int f) {
+            const int16_t* row = net_->ft_row(f);
+            for (int i = 0; i < l1_; ++i)
+                dst[i] += row[i];
+        });
+    }
+
+    std::shared_ptr<const nnue::Network> net_;
+    int l1_ = 0;
+    int top_ = 0;
+    int capacity_ = 0;
+    std::vector<int32_t> frames_;
+};
+
+inline void NNUEEvaluator::push(const position& pos, const FeatureDelta& d) {
+    if (top_ + 1 >= capacity_) {
+        capacity_ *= 2;
+        frames_.resize(static_cast<size_t>(capacity_) * frame_stride(), 0);
+    }
+    const int32_t* prev = frame(top_);
+    ++top_;
+    int32_t* cur = frame(top_);
+
+    // A king move rebuilds only its own perspective. Detect it before touching
+    // anything, because the events for the two perspectives are the same list
+    // read twice under different rules.
+    bool king_moved[2] = {false, false};
+    for (const auto& e : d)
+        if (e.p == king)
+            king_moved[static_cast<int>(e.c)] = true;
+
+    for (int ci = 0; ci < 2; ++ci) {
+        const Color perspective = static_cast<Color>(ci);
+        int32_t* dst = cur + static_cast<size_t>(ci) * static_cast<size_t>(l1_);
+        if (king_moved[ci]) {
+            recompute(dst, pos, perspective);
+            continue;
+        }
+        std::memcpy(dst, prev + static_cast<size_t>(ci) * static_cast<size_t>(l1_),
+                    static_cast<size_t>(l1_) * sizeof(int32_t));
+
+        // This perspective's king did not move, so its bucket is the same
+        // before and after -- reading it from the post-move board is safe.
+        const Square ksq = pos.king_square(perspective);
+        for (const auto& e : d) {
+            if (e.p == king)
+                continue;
+            const int16_t* row = net_->ft_row(nnue::index(perspective, ksq, e.c, e.p, e.sq));
+            if (e.added)
+                for (int i = 0; i < l1_; ++i)
+                    dst[i] += row[i];
+            else
+                for (int i = 0; i < l1_; ++i)
+                    dst[i] -= row[i];
+        }
+    }
+}
+
+inline bool NNUEEvaluator::matches_full_recompute(const position& pos) const {
+    std::vector<int32_t> want(static_cast<size_t>(l1_));
+    for (int ci = 0; ci < 2; ++ci) {
+        recompute(want.data(), pos, static_cast<Color>(ci));
+        const int32_t* have = frame(top_) + static_cast<size_t>(ci) * static_cast<size_t>(l1_);
+        for (int i = 0; i < l1_; ++i)
+            if (have[i] != want[i])
+                return false;
+    }
+    return true;
+}
+
+/// Read a `.nnue` file. @return The network, or nullptr with `err` set.
+[[nodiscard]] std::shared_ptr<const nnue::Network> load_network_file(const std::string& path,
+                                                                    std::string& err);
+
+} // namespace havoc

--- a/include/havoc/nnue/network.hpp
+++ b/include/havoc/nnue/network.hpp
@@ -41,6 +41,10 @@
 #include <string>
 #include <vector>
 
+#if defined(__AVX2__)
+#include <immintrin.h>
+#endif
+
 #include "havoc/nnue/features.hpp"
 
 namespace havoc::nnue {
@@ -68,6 +72,13 @@ inline constexpr int32_t kMaxDenseWeight = 127;
 /// Centipawns per unit of network output. Must equal `CP_SCALE` in
 /// `scripts/nnue/train.py`; it is stored in the file and checked on load.
 inline constexpr int32_t kDefaultCpScale = 400;
+
+/// Bounds the vector kernel's stack buffers. A network wider than this still
+/// loads and still runs -- on the reference path. The loader's own limits are
+/// looser on purpose: refusing to load a wide network would make this an
+/// architecture constraint rather than a kernel one.
+inline constexpr int kMaxSimdL1 = 2048;
+inline constexpr int kMaxSimdL2 = 512;
 
 #pragma pack(push, 1)
 struct NetworkHeader {
@@ -117,10 +128,33 @@ class Network {
     /// @param acc_us   Raw accumulator for the side to move, `l1()` wide.
     /// @param acc_them Raw accumulator for the other side.
     /// @return Centipawns, side-to-move point of view.
-    [[nodiscard]] int forward(const int32_t* acc_us, const int32_t* acc_them) const;
+    ///
+    /// Dispatches to a vectorised kernel where one is available and the layer
+    /// widths suit it, and to `forward_reference` otherwise. The two must
+    /// agree exactly, not nearly -- integer addition is associative, so a
+    /// different summation order is not an excuse for a different answer.
+    [[nodiscard]] int forward(const int32_t* acc_us, const int32_t* acc_them) const {
+#if defined(__AVX2__)
+        if (simd_ok_)
+            return forward_avx2(acc_us, acc_them);
+#endif
+        return forward_reference(acc_us, acc_them);
+    }
+
+    /// The definition of what the network computes. Never dispatched around;
+    /// a vectorised kernel is checked against this, not trusted instead of it.
+    [[nodiscard]] int forward_reference(const int32_t* acc_us, const int32_t* acc_them) const;
 
   private:
+#if defined(__AVX2__)
+    [[nodiscard]] int forward_avx2(const int32_t* acc_us, const int32_t* acc_them) const;
+#endif
+
     bool loaded_ = false;
+    /// Whether the layer widths are multiples of the vector width. Checked
+    /// once at load rather than per call, and false falls back rather than
+    /// failing: a network with an odd layer size should still run.
+    bool simd_ok_ = false;
     int l1_ = 0, l2_ = 0, l3_ = 0;
     int32_t cp_scale_ = kDefaultCpScale;
     int32_t s_fc1_ = 1, s_fc2_ = 1, s_out_ = 1;
@@ -133,19 +167,36 @@ class Network {
     std::vector<int32_t> fc2_b_;       ///< [l3]
     std::vector<int8_t> out_w_;        ///< [l3]
     int32_t out_b_ = 0;
+
+    /// The dense weights again, widened to int16 at load.
+    ///
+    /// Pure redundancy, kept because it is measurably worth it: sign-extending
+    /// int8 to int16 inside the loop puts four shuffle uops per iteration on a
+    /// single port and that port becomes the limit. Widening once at load
+    /// costs 32 KB and 13% of the layer's time (196 ns against 226 ns for the
+    /// 512x32 layer, measured). The file stays int8; this is a decode, not a
+    /// second copy of the format.
+    std::vector<int16_t> fc1_w16_, fc2_w16_;
 };
 
-inline int Network::forward(const int32_t* acc_us, const int32_t* acc_them) const {
+inline int Network::forward_reference(const int32_t* acc_us, const int32_t* acc_them) const {
+    // Scratch is thread_local rather than automatic because this runs at every
+    // node: three fresh allocations per evaluation cost more than the network.
+    // It is per-thread, so a shared const Network stays safe to call from every
+    // search thread at once.
+    thread_local std::vector<int32_t> x, h1, h2;
+    x.resize(static_cast<size_t>(2 * l1_));
+    h1.resize(static_cast<size_t>(l2_));
+    h2.resize(static_cast<size_t>(l3_));
+
     // Layer 1 input: both accumulators clipped, side to move first. The
     // ordering is load-bearing -- it is the only place the network learns
     // whose move it is.
-    std::vector<int32_t> x(static_cast<size_t>(2 * l1_));
     for (int i = 0; i < l1_; ++i) {
         x[static_cast<size_t>(i)] = clipped(acc_us[i], kQA);
         x[static_cast<size_t>(l1_ + i)] = clipped(acc_them[i], kQA);
     }
 
-    std::vector<int32_t> h1(static_cast<size_t>(l2_));
     for (int j = 0; j < l2_; ++j) {
         int32_t sum = fc1_b_[static_cast<size_t>(j)];
         const int8_t* w = fc1_w_.data() + static_cast<size_t>(j) * static_cast<size_t>(2 * l1_);
@@ -154,7 +205,6 @@ inline int Network::forward(const int32_t* acc_us, const int32_t* acc_them) cons
         h1[static_cast<size_t>(j)] = clipped(sum / s_fc1_, kQA);
     }
 
-    std::vector<int32_t> h2(static_cast<size_t>(l3_));
     for (int j = 0; j < l3_; ++j) {
         int32_t sum = fc2_b_[static_cast<size_t>(j)];
         const int8_t* w = fc2_w_.data() + static_cast<size_t>(j) * static_cast<size_t>(l2_);
@@ -172,6 +222,95 @@ inline int Network::forward(const int32_t* acc_us, const int32_t* acc_them) cons
     // the two paths agree exactly rather than nearly.
     return static_cast<int>(out * cp_scale_ / (static_cast<int64_t>(kQA) * s_out_));
 }
+
+#if defined(__AVX2__)
+
+/// The same arithmetic as `forward_reference`, sixteen products at a time.
+///
+/// Exactness rests on two facts, and both are checked rather than assumed.
+/// Activations are clipped into [0, QA] with QA = 255, and weights are int8,
+/// so every product fits in int16 and every *adjacent pair* of products fits
+/// in int32 -- which is precisely what `_mm256_madd_epi16` computes. Nothing
+/// saturates, so the vector path is not an approximation of the scalar one;
+/// it is the same sum in a different order, and integer addition does not
+/// care about the order.
+///
+/// The alternative, `_mm256_maddubs_epi16`, would do twice as many products
+/// per instruction and is what most engines use -- but it accumulates into
+/// int16 and *saturates*, so it is only correct while the weights stay small
+/// enough, a condition no test here could state. That trade is available
+/// later, behind a measurement; it is not taken silently.
+inline int Network::forward_avx2(const int32_t* acc_us, const int32_t* acc_them) const {
+    // Plain stack arrays, not thread_local vectors: a thread_local with a
+    // non-trivial constructor costs a guard check and an indirection on every
+    // access, which at this call rate was measurably larger than the layer it
+    // was holding. Sizes are bounded by the loader, which is why `simd_ok_`
+    // and the bound below have to agree.
+    int16_t x[2 * kMaxSimdL1];
+    int16_t h1[kMaxSimdL2];
+    int16_t h2[kMaxSimdL2];
+
+    // A plain loop: an explicit packs/permute/clamp version of this measured
+    // identical, so the compiler is already vectorising it and the intrinsics
+    // would only be harder to read.
+    for (int i = 0; i < l1_; ++i) {
+        x[i] = static_cast<int16_t>(clipped(acc_us[i], kQA));
+        x[l1_ + i] = static_cast<int16_t>(clipped(acc_them[i], kQA));
+    }
+
+    // One dense layer: `out[j] = clip((bias[j] + w[j] . in) / scale)`.
+    //
+    // Four output rows at a time. The inputs are read once for the four
+    // instead of once each, which matters because this loop is limited by
+    // load slots rather than by multiplies, and the four horizontal sums fold
+    // into one shuffle chain instead of four.
+    auto dense = [](const int16_t* w, const int32_t* bias, const int16_t* in, int in_dim,
+                    int out_dim, int32_t scale, int16_t* out) {
+        for (int j = 0; j < out_dim; j += 4) {
+            __m256i a0 = _mm256_setzero_si256(), a1 = a0, a2 = a0, a3 = a0;
+            const int16_t* w0 = w + static_cast<size_t>(j) * static_cast<size_t>(in_dim);
+            const int16_t* w1 = w0 + in_dim;
+            const int16_t* w2 = w1 + in_dim;
+            const int16_t* w3 = w2 + in_dim;
+            for (int i = 0; i < in_dim; i += 16) {
+                const __m256i xv = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(in + i));
+                a0 = _mm256_add_epi32(
+                    a0, _mm256_madd_epi16(
+                            xv, _mm256_loadu_si256(reinterpret_cast<const __m256i*>(w0 + i))));
+                a1 = _mm256_add_epi32(
+                    a1, _mm256_madd_epi16(
+                            xv, _mm256_loadu_si256(reinterpret_cast<const __m256i*>(w1 + i))));
+                a2 = _mm256_add_epi32(
+                    a2, _mm256_madd_epi16(
+                            xv, _mm256_loadu_si256(reinterpret_cast<const __m256i*>(w2 + i))));
+                a3 = _mm256_add_epi32(
+                    a3, _mm256_madd_epi16(
+                            xv, _mm256_loadu_si256(reinterpret_cast<const __m256i*>(w3 + i))));
+            }
+            // hadd twice leaves [s0 s1 s2 s3 | s0 s1 s2 s3] split across the
+            // two lanes; adding the halves completes the four sums.
+            const __m256i s01 = _mm256_hadd_epi32(a0, a1);
+            const __m256i s23 = _mm256_hadd_epi32(a2, a3);
+            const __m256i s = _mm256_hadd_epi32(s01, s23);
+            const __m128i sums = _mm_add_epi32(_mm256_castsi256_si128(s),
+                                               _mm256_extracti128_si256(s, 1));
+            alignas(16) int32_t part[4];
+            _mm_store_si128(reinterpret_cast<__m128i*>(part), sums);
+            for (int k = 0; k < 4; ++k)
+                out[j + k] = static_cast<int16_t>(clipped((bias[j + k] + part[k]) / scale, kQA));
+        }
+    };
+
+    dense(fc1_w16_.data(), fc1_b_.data(), x, 2 * l1_, l2_, s_fc1_, h1);
+    dense(fc2_w16_.data(), fc2_b_.data(), h1, l2_, l3_, s_fc2_, h2);
+
+    int64_t out = out_b_;
+    for (int i = 0; i < l3_; ++i)
+        out += static_cast<int64_t>(out_w_[static_cast<size_t>(i)]) * h2[i];
+    return static_cast<int>(out * cp_scale_ / (static_cast<int64_t>(kQA) * s_out_));
+}
+
+#endif  // __AVX2__
 
 inline std::string Network::load(std::istream& in) {
     loaded_ = false;
@@ -231,6 +370,15 @@ inline std::string Network::load(std::istream& in) {
     in.read(&extra, 1);
     if (in)
         return "network: file is longer than the declared architecture";
+
+    // The vector kernel walks sixteen values at a time and does not carry a
+    // tail loop, so it is used only when every inner dimension divides evenly.
+    // A network that does not is not rejected; it simply runs the reference.
+    fc1_w16_.assign(fc1_w_.begin(), fc1_w_.end());
+    fc2_w16_.assign(fc2_w_.begin(), fc2_w_.end());
+
+    simd_ok_ = l1_ % 16 == 0 && l2_ % 16 == 0 && l3_ % 4 == 0 && l1_ <= kMaxSimdL1 &&
+               l2_ <= kMaxSimdL2 && l3_ <= kMaxSimdL2;
 
     loaded_ = true;
     return {};

--- a/scripts/nnue/train.py
+++ b/scripts/nnue/train.py
@@ -9,6 +9,26 @@ quantisation and the C++ kernel. If a network cannot learn a function we can
 compute, nothing downstream is worth debugging yet, and finding that out costs
 hours instead of the days a full run costs.
 
+How the validation set is chosen, and why it is not random
+-----------------------------------------------------------
+A random split of this corpus does not measure generalisation. The file is
+written by self-play datagen in game order, so neighbouring records are
+consecutive plies of the same game: sampled 20,000 records apart they share
+0.8% of their features, but *adjacent* ones share 85%, and 11.5% of feature
+vectors appear more than once outright. A random split therefore puts each
+validation position's near-twin -- often its exact twin -- in the training set,
+and the resulting number is a measure of memorisation.
+
+That is not a hypothetical. Stage 0 reported a 26.7 cp held-out error this way.
+Measured on positions from real games instead, the same network was **82 cp**
+off, and the engine using it lost 111 Elo at fixed depth. The split was the bug.
+
+So the validation set is a *contiguous block* at the end of the file, separated
+from the training data by a gap of whole games, and any validation record whose
+feature vector also occurs in training is dropped. `--val-file` overrides all
+of it with a genuinely independent corpus, which is the only fully honest
+option and is what a real run should use.
+
 The dataset is held resident on the GPU. At 128 bytes a record, several
 million positions fit in VRAM with room to spare, and keeping them there
 removes the host-to-device copy that otherwise dominates a network this small.
@@ -55,6 +75,29 @@ def build_tensors(records: np.ndarray, device: torch.device):
     return feat_us, feat_them, score
 
 
+def drop_leaked(records: np.ndarray, train_idx: np.ndarray, val_idx: np.ndarray) -> np.ndarray:
+    """Remove validation records whose exact position also occurs in training.
+
+    A gap between the two blocks separates games, not positions: common
+    openings and simplified endgames recur across games, and a repeated
+    position is a memorised one. Comparing the raw feature bytes is exact and
+    costs a second, which is cheap next to reporting a number that is wrong.
+    """
+    view = np.ascontiguousarray(
+        np.stack(
+            [records["feat_white"].view(np.uint8), records["feat_black"].view(np.uint8)], axis=1
+        )
+    ).reshape(len(records), -1)
+    key = view.view([("", view.dtype)] * view.shape[1]).ravel()
+
+    train_keys = np.unique(key[train_idx])
+    leaked = np.isin(key[val_idx], train_keys)
+    n = int(leaked.sum())
+    if n:
+        print(f"dropped {n:,} of {len(val_idx):,} validation positions that also occur in training")
+    return val_idx[~leaked]
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--data", required=True)
@@ -67,6 +110,19 @@ def main() -> int:
     ap.add_argument("--l3", type=int, default=32)
     ap.add_argument("--limit", type=int, default=None)
     ap.add_argument("--val-frac", type=float, default=0.05)
+    ap.add_argument(
+        "--val-file",
+        default=None,
+        help="An independent .hbin to validate on. Overrides --val-frac and is "
+        "the only measurement that is honest by construction.",
+    )
+    ap.add_argument(
+        "--val-gap",
+        type=int,
+        default=200_000,
+        help="Records dropped between the training block and the validation "
+        "block, so the two cannot share a game.",
+    )
     ap.add_argument("--seed", type=int, default=1)
     ap.add_argument(
         "--qat",
@@ -100,11 +156,32 @@ def main() -> int:
         )
         return 1
 
-    perm = np.random.permutation(len(data))
-    n_val = max(1, int(len(data) * args.val_frac))
-    val_idx, train_idx = perm[:n_val], perm[n_val:]
+    if args.val_file:
+        val_data = ds_mod.load(args.val_file)
+        if val_data.label_kind != data.label_kind:
+            print(
+                f"refusing: training on {data.label_kind} labels but validating "
+                f"on {val_data.label_kind}"
+            )
+            return 1
+        records = np.concatenate([data.records, val_data.records])
+        train_idx = np.arange(len(data), dtype=np.int64)
+        val_idx = np.arange(len(data), len(records), dtype=np.int64)
+        print(f"validating on {args.val_file}: {len(val_idx):,} independent positions")
+    else:
+        records = data.records
+        n_val = max(1, int(len(records) * args.val_frac))
+        gap = min(args.val_gap, max(0, len(records) - n_val - 1))
+        val_idx = np.arange(len(records) - n_val, len(records), dtype=np.int64)
+        train_idx = np.arange(0, len(records) - n_val - gap, dtype=np.int64)
+        print(
+            f"contiguous split: train [0,{train_idx[-1]:,}]  gap {gap:,}  "
+            f"val [{val_idx[0]:,},{val_idx[-1]:,}]"
+        )
 
-    feat_us, feat_them, score = build_tensors(data.records, device)
+    val_idx = drop_leaked(records, train_idx, val_idx)
+
+    feat_us, feat_them, score = build_tensors(records, device)
     del data
     tr = torch.from_numpy(train_idx.astype(np.int64)).to(device)
     va = torch.from_numpy(val_idx.astype(np.int64)).to(device)

--- a/src/eval/nnue_evaluator.cpp
+++ b/src/eval/nnue_evaluator.cpp
@@ -1,0 +1,20 @@
+#include "havoc/eval/nnue_evaluator.hpp"
+
+#include <fstream>
+
+namespace havoc {
+
+std::shared_ptr<const nnue::Network> load_network_file(const std::string& path, std::string& err) {
+    std::ifstream in(path, std::ios::binary);
+    if (!in) {
+        err = "network: cannot open " + path;
+        return nullptr;
+    }
+    auto net = std::make_shared<nnue::Network>();
+    err = net->load(in);
+    if (!err.empty())
+        return nullptr;
+    return net;
+}
+
+} // namespace havoc

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -1,6 +1,7 @@
 #include "havoc/uci.hpp"
 
 #include "havoc/book.hpp"
+#include "havoc/eval/nnue_evaluator.hpp"
 #include "havoc/movegen.hpp"
 #include "havoc/position.hpp"
 #include "havoc/tablebase.hpp"
@@ -142,6 +143,30 @@ bool parse_command(const std::string& input, SearchEngine& engine, position& uci
                 havoc::book::load(cmd);
                 break;
             }
+            if (cmd == "evalfile" && instream >> cmd && instream >> cmd) {
+                // "none" is how a GUI turns the network back off; without it
+                // installing one would be a one-way door for the session.
+                if (cmd == "none" || cmd == "<empty>") {
+                    engine.set_evaluator_factory(nullptr);
+                    std::cout << "info string EvalFile cleared, using the handcrafted evaluation"
+                              << std::endl;
+                    break;
+                }
+                std::string err;
+                auto net = load_network_file(cmd, err);
+                if (!net) {
+                    // Keep playing with the evaluation that already works
+                    // rather than refusing to start: a missing net is a
+                    // configuration mistake, not a reason to forfeit.
+                    std::cout << "info string " << err << ", keeping the current evaluation"
+                              << std::endl;
+                    break;
+                }
+                engine.set_evaluator_factory(
+                    [net](Searchthread&) { return std::make_unique<NNUEEvaluator>(net); });
+                std::cout << "info string Loaded network from " << cmd << std::endl;
+                break;
+            }
             if (cmd == "paramfile" && instream >> cmd && instream >> cmd) {
                 engine.load_params(cmd);
                 std::cout << "info string Loaded parameters from " << cmd << std::endl;
@@ -230,6 +255,7 @@ bool parse_command(const std::string& input, SearchEngine& engine, position& uci
             std::cout << "option name SyzygyPath type string default <empty>" << std::endl;
             std::cout << "option name BookFile type string default <empty>" << std::endl;
             std::cout << "option name ParamFile type string default <empty>" << std::endl;
+            std::cout << "option name EvalFile type string default <empty>" << std::endl;
             std::cout << "uciok" << std::endl;
         } else if (cmd == "bench") {
             settle();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set(HAVOC_TEST_SOURCES
     test_incremental_eval.cpp
     test_nnue_features.cpp
     test_nnue_network.cpp
+    test_nnue_evaluator.cpp
     test_search.cpp
 )
 

--- a/tests/test_nnue_evaluator.cpp
+++ b/tests/test_nnue_evaluator.cpp
@@ -1,0 +1,504 @@
+/// @file test_nnue_evaluator.cpp
+/// @brief Stage 1b: prove the incremental accumulator equals a full rebuild.
+///
+/// The oracle here is not a second implementation of anything: it is the same
+/// `recompute` the evaluator itself uses at a refresh, run against the board
+/// as it actually is. So a mismatch means the *incremental path* is wrong,
+/// which is the only thing that can be wrong once the from-scratch path is
+/// pinned by `test_nnue_features.cpp`.
+///
+/// Why raw accumulators and not evaluations
+/// ---------------------------------------
+/// Two different accumulators routinely round to the same centipawn, so a
+/// test that compared scores would pass with a desynchronised first layer and
+/// only fail once the error grew large enough to change the truncated output.
+/// `matches_full_recompute` compares every one of the 2*l1 integers.
+///
+/// Why king moves get their own tests
+/// ---------------------------------
+/// In HalfKP a side's king square is the bucket for that side's entire
+/// accumulator, so a king move invalidates one perspective completely and
+/// leaves the other one needing an ordinary incremental update. A generic
+/// sync check cannot tell "rebuilt correctly" from "updated correctly",
+/// because rebuilding is always right; what it cannot catch on its own is the
+/// converse -- the perspective that should have been *updated* being rebuilt,
+/// or the perspective that should have been *rebuilt* being updated. The
+/// mutation tests below break each of those deliberately and require the
+/// check to notice.
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "havoc/bitboard.hpp"
+#include "havoc/eval/nnue_evaluator.hpp"
+#include "havoc/kpk.hpp"
+#include "havoc/magics.hpp"
+#include "havoc/movegen.hpp"
+#include "havoc/position.hpp"
+#include "havoc/search.hpp"
+#include "havoc/utils.hpp"
+#include "havoc/zobrist.hpp"
+
+#include <gtest/gtest.h>
+
+namespace havoc {
+namespace {
+
+// Chosen so the vectorised kernel's width conditions are met: the search-
+// driven tests below are the only place it runs against real board states, and
+// dimensions it rejects would silently exercise the reference instead.
+constexpr int kL1 = 16, kL2 = 16, kL3 = 4;
+
+/// A network whose weights are arbitrary but distinct.
+///
+/// Distinctness is the requirement, not realism. Every feature row must differ
+/// from every other, or an accumulator that added the wrong row would still
+/// hold the right numbers and the whole file would prove nothing.
+std::shared_ptr<const nnue::Network> make_test_network() {
+    nnue::NetworkHeader h{};
+    std::memcpy(h.magic, "HVNW", 4);
+    h.format_version = nnue::kNetworkFormatVersion;
+    h.feature_set_version = nnue::kFeatureSetVersion;
+    h.input_dim = nnue::kInputDim;
+    h.l1 = kL1;
+    h.l2 = kL2;
+    h.l3 = kL3;
+    h.cp_scale = nnue::kDefaultCpScale;
+    h.qa = nnue::kQA;
+    h.s_fc1 = 64;
+    h.s_fc2 = 64;
+    h.s_out = 64;
+
+    std::string s(reinterpret_cast<const char*>(&h), sizeof(h));
+    auto append = [&s](const auto& v) {
+        s.append(reinterpret_cast<const char*>(v.data()),
+                 v.size() * sizeof(typename std::decay_t<decltype(v)>::value_type));
+    };
+
+    // A cheap full-period-ish mixer; the values only have to be varied and
+    // reproducible, and a std::mt19937 would make the file depend on the
+    // library's generator.
+    uint32_t state = 0x2545f491u;
+    auto next = [&state]() {
+        state ^= state << 13;
+        state ^= state >> 17;
+        state ^= state << 5;
+        return state;
+    };
+
+    std::vector<int16_t> ft_w(static_cast<size_t>(nnue::kInputDim) * kL1);
+    for (auto& w : ft_w)
+        w = static_cast<int16_t>(static_cast<int32_t>(next() % 63u) - 31);
+    std::vector<int16_t> ft_b(kL1);
+    for (auto& b : ft_b)
+        b = static_cast<int16_t>(static_cast<int32_t>(next() % 41u) - 20);
+    std::vector<int8_t> fc1_w(kL2 * 2 * kL1);
+    for (auto& w : fc1_w)
+        w = static_cast<int8_t>(static_cast<int32_t>(next() % 127u) - 63);
+    std::vector<int32_t> fc1_b(kL2, 0);
+    std::vector<int8_t> fc2_w(kL3 * kL2);
+    for (auto& w : fc2_w)
+        w = static_cast<int8_t>(static_cast<int32_t>(next() % 127u) - 63);
+    std::vector<int32_t> fc2_b(kL3, 0);
+    std::vector<int8_t> out_w(kL3);
+    for (auto& w : out_w)
+        w = static_cast<int8_t>(static_cast<int32_t>(next() % 127u) - 63);
+    const int32_t out_b = 0;
+
+    append(ft_w);
+    append(ft_b);
+    append(fc1_w);
+    append(fc1_b);
+    append(fc2_w);
+    append(fc2_b);
+    append(out_w);
+    s.append(reinterpret_cast<const char*>(&out_b), sizeof(out_b));
+
+    auto net = std::make_shared<nnue::Network>();
+    std::istringstream in(s, std::ios::binary);
+    const std::string err = net->load(in);
+    EXPECT_EQ(err, "") << "the test network is malformed";
+    return net;
+}
+
+/// Checks the accumulator against a full rebuild everywhere it is observable.
+class CheckedNNUE : public NNUEEvaluator {
+  public:
+    using NNUEEvaluator::NNUEEvaluator;
+
+    void push(const position& pos, const FeatureDelta& d) override {
+        NNUEEvaluator::push(pos, d);
+        ++pushes_;
+        verify(pos, "after push");
+    }
+
+    void pop() override {
+        NNUEEvaluator::pop();
+        ++pops_;
+    }
+
+    void refresh(const position& pos) override {
+        NNUEEvaluator::refresh(pos);
+        ++refreshes_;
+        verify(pos, "after refresh");
+    }
+
+    int evaluate(const position& pos, int lazy = -1) override {
+        verify(pos, "at evaluate");
+        return NNUEEvaluator::evaluate(pos, lazy);
+    }
+
+    [[nodiscard]] long pushes() const { return pushes_; }
+    [[nodiscard]] long pops() const { return pops_; }
+    [[nodiscard]] long refreshes() const { return refreshes_; }
+    [[nodiscard]] const std::string& first_mismatch() const { return first_mismatch_; }
+
+  protected:
+    void verify(const position& pos, const char* when) {
+        if (!first_mismatch_.empty())
+            return;
+        if (!matches_full_recompute(pos))
+            first_mismatch_ = std::string(when) +
+                              ": the incremental accumulator differs from a full rebuild, fen " +
+                              pos.to_fen();
+    }
+
+  private:
+    long pushes_ = 0, pops_ = 0, refreshes_ = 0;
+    std::string first_mismatch_;
+};
+
+/// Re-record one event through the public API, so the mutation tests below
+/// build their broken deltas out of the same primitives move-making uses.
+void append(FeatureDelta& d, const FeatureDelta::Event& e) {
+    if (e.added)
+        d.add(e.c, e.p, e.sq);
+    else
+        d.remove(e.c, e.p, e.sq);
+}
+
+class NnueEvaluatorTest : public ::testing::Test {
+  protected:
+    void SetUp() override {
+        bitboards::init();
+        magics::init();
+        zobrist::init();
+        kpk::init();
+        net_ = make_test_network();
+    }
+    std::shared_ptr<const nnue::Network> net_;
+};
+
+const std::vector<std::string>& sync_fens() {
+    static const std::vector<std::string> fens{
+        "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+        // Kiwipete: castling both ways, many captures, both kings can move.
+        "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",
+        // Promotions and promotion-captures.
+        "n1n5/PPPk4/8/8/8/8/4Kppp/5N1N b - - 0 1",
+        // En passant available immediately.
+        "rnbqkbnr/ppp1p1pp/8/3pPp2/8/8/PPPP1PPP/RNBQKBNR w KQkq f6 0 3",
+        // Bare kings and a queen: almost every move is a king move, so the
+        // bucket-crossing path dominates instead of being a rare event.
+        "8/2k5/8/8/8/5Q2/8/4K3 w - - 0 1",
+        // A king capture is available at once: the moving side's perspective
+        // is rebuilt while the other's must still lose the captured pawn.
+        "8/8/8/3k4/3P4/8/8/4K3 b - - 0 1",
+    };
+    return fens;
+}
+
+} // namespace
+
+// The search prunes, reduces, re-searches, makes null moves and drops into
+// quiescence. Driving the seam with the real search is the only way to reach
+// all of those paths, and it is where a bucket-crossing king move happens
+// thousands of times.
+TEST_F(NnueEvaluatorTest, AccumulatorSurvivesARealSearchOnEveryLine) {
+    for (const auto& fen : sync_fens()) {
+        SearchEngine engine;
+        engine.set_threads(1);
+
+        CheckedNNUE* probe = nullptr;
+        engine.set_evaluator_factory([&](Searchthread&) {
+            auto e = std::make_unique<CheckedNNUE>(net_);
+            probe = e.get();
+            return e;
+        });
+
+        std::istringstream ss(fen);
+        position p(ss);
+
+        SearchLimits lims;
+        lims.depth = 6;
+        engine.start(p, lims, /*silent=*/true);
+        engine.wait();
+
+        ASSERT_NE(probe, nullptr) << "the factory was never used for " << fen;
+        EXPECT_TRUE(probe->first_mismatch().empty()) << "in " << fen << "\n"
+                                                     << probe->first_mismatch();
+        EXPECT_GT(probe->pushes(), 1000) << "in " << fen << ": the search barely ran";
+        EXPECT_EQ(probe->pushes(), probe->pops()) << "in " << fen;
+        EXPECT_GT(probe->refreshes(), 0) << "in " << fen;
+    }
+}
+
+// Every king move in a set of positions, walked by hand, so the bucket-
+// crossing case is exercised exhaustively rather than incidentally -- and so
+// the count is asserted, since a search could in principle prune them all.
+TEST_F(NnueEvaluatorTest, EveryKingMoveIsCheckedAgainstAFullRebuild) {
+    int king_moves = 0, king_captures = 0, castles = 0;
+
+    for (const auto& fen : sync_fens()) {
+        std::istringstream ss(fen);
+        position p(ss);
+
+        CheckedNNUE ev(net_);
+        ev.refresh(p);
+        ASSERT_TRUE(ev.first_mismatch().empty()) << fen << "\n" << ev.first_mismatch();
+
+        Movegen mvs(p);
+        mvs.generate<pseudo_legal, pieces>();
+        for (int i = 0; i < mvs.size(); ++i) {
+            const Move m = mvs[i];
+            if (p.piece_on(static_cast<Square>(m.f)) != king)
+                continue;
+            if (!p.is_legal(m))
+                continue;
+            const bool capture = p.piece_on(static_cast<Square>(m.t)) != no_piece;
+            const int file_jump = std::abs(static_cast<int>(util::col(m.t)) -
+                                           static_cast<int>(util::col(m.f)));
+
+            p.do_move(m);
+            ev.push(p, p.delta());
+            ++king_moves;
+            king_captures += capture ? 1 : 0;
+            castles += file_jump > 1 ? 1 : 0;
+
+            // And one reply, so the *other* perspective is updated across a
+            // frame in which its own king did not move.
+            Movegen replies(p);
+            replies.generate<pseudo_legal, pieces>();
+            for (int j = 0; j < replies.size(); ++j) {
+                if (!p.is_legal(replies[j]))
+                    continue;
+                p.do_move(replies[j]);
+                ev.push(p, p.delta());
+                ev.pop();
+                p.undo_move(replies[j]);
+                break;
+            }
+
+            ev.pop();
+            p.undo_move(m);
+        }
+        EXPECT_TRUE(ev.first_mismatch().empty()) << fen << "\n" << ev.first_mismatch();
+    }
+
+    EXPECT_GT(king_moves, 20) << "the positions chosen do not exercise king moves";
+    EXPECT_GT(king_captures, 0) << "no king capture was tested: the enemy perspective must be "
+                                   "updated across a move that also rebuilds ours";
+    EXPECT_GT(castles, 0) << "no castling was tested: it is the only four-event delta";
+}
+
+// Rebuilding is always correct, so the interesting failure is the perspective
+// that should have been rebuilt being incrementally updated instead. In HalfKP
+// that means every one of its 30-odd feature indices is now computed against
+// the wrong king bucket. If the check could not see this, it would be
+// certifying nothing about the case it exists for.
+TEST_F(NnueEvaluatorTest, TheCheckDetectsAKingMoveThatWasNotRebuilt) {
+    class NeverRebuilds : public CheckedNNUE {
+      public:
+        using CheckedNNUE::CheckedNNUE;
+        void push(const position& pos, const FeatureDelta& d) override {
+            // Strip the king events, which is exactly what an implementation
+            // that forgot the bucket would effectively do: the accumulator
+            // carries on from the previous king square.
+            FeatureDelta stripped;
+            for (const auto& e : d)
+                if (e.p != king)
+                    append(stripped, e);
+            CheckedNNUE::push(pos, stripped);
+        }
+    };
+
+    std::istringstream ss("8/2k5/8/8/8/5Q2/8/4K3 w - - 0 1");
+    position p(ss);
+    NeverRebuilds ev(net_);
+    ev.refresh(p);
+
+    Movegen mvs(p);
+    mvs.generate<pseudo_legal, pieces>();
+    bool tried = false;
+    for (int i = 0; i < mvs.size(); ++i) {
+        if (p.piece_on(static_cast<Square>(mvs[i].f)) != king || !p.is_legal(mvs[i]))
+            continue;
+        p.do_move(mvs[i]);
+        ev.push(p, p.delta());
+        ev.pop();
+        p.undo_move(mvs[i]);
+        tried = true;
+    }
+    ASSERT_TRUE(tried) << "no king move was available to break";
+    EXPECT_FALSE(ev.first_mismatch().empty())
+        << "a king move that skipped the rebuild went undetected, so the sync check above "
+           "proves nothing about bucket crossing";
+}
+
+// The converse mutation: the non-moving side's perspective silently rebuilt
+// rather than updated. That is *not* wrong -- it is merely slow -- so this
+// instead breaks the update itself, dropping the events the other perspective
+// still needs across a king move. A king capture is the case that exposes it.
+TEST_F(NnueEvaluatorTest, TheCheckDetectsALostUpdateOnTheOtherPerspective) {
+    class DropsCaptures : public CheckedNNUE {
+      public:
+        using CheckedNNUE::CheckedNNUE;
+        void push(const position& pos, const FeatureDelta& d) override {
+            FeatureDelta kept;
+            for (const auto& e : d)
+                if (e.added || e.p == king)
+                    append(kept, e);
+            CheckedNNUE::push(pos, kept);
+        }
+    };
+
+    std::istringstream ss("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1");
+    position p(ss);
+    DropsCaptures ev(net_);
+    ev.refresh(p);
+
+    Movegen mvs(p);
+    mvs.generate<pseudo_legal, pieces>();
+    for (int i = 0; i < mvs.size(); ++i) {
+        if (!p.is_legal(mvs[i]))
+            continue;
+        p.do_move(mvs[i]);
+        ev.push(p, p.delta());
+        ev.pop();
+        p.undo_move(mvs[i]);
+    }
+    EXPECT_FALSE(ev.first_mismatch().empty())
+        << "an evaluator that never removed a feature went undetected";
+}
+
+// Pop must restore the previous frame exactly, not approximately: the search
+// makes and unmakes millions of moves along one line, and an error that
+// survived a pop would accumulate rather than cancel.
+TEST_F(NnueEvaluatorTest, PopRestoresThePreviousFrameExactly) {
+    std::istringstream ss("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1");
+    position p(ss);
+    NNUEEvaluator ev(net_);
+    ev.refresh(p);
+    const int before = ev.evaluate(p);
+
+    Movegen mvs(p);
+    mvs.generate<pseudo_legal, pieces>();
+    int played = 0;
+    for (int i = 0; i < mvs.size(); ++i) {
+        if (!p.is_legal(mvs[i]))
+            continue;
+        p.do_move(mvs[i]);
+        ev.push(p, p.delta());
+        ev.pop();
+        p.undo_move(mvs[i]);
+        ++played;
+        ASSERT_EQ(ev.evaluate(p), before) << "pop did not restore the frame after move " << i;
+    }
+    EXPECT_GT(played, 20);
+    EXPECT_EQ(ev.stack_depth(), 0);
+}
+
+// A null move pushes an empty delta so that the evaluator's stack depth
+// tracks the search's. The accumulators must be unchanged, but the evaluation
+// must not be: side to move has flipped, and it is the ordering of the two
+// accumulators that carries it.
+TEST_F(NnueEvaluatorTest, ANullMoveKeepsTheAccumulatorAndFlipsThePerspective) {
+    std::istringstream ss("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1");
+    position p(ss);
+    CheckedNNUE ev(net_);
+    ev.refresh(p);
+    const int white_view = ev.evaluate(p);
+
+    p.do_null_move();
+    ev.push(p, p.delta());
+    const int black_view = ev.evaluate(p);
+    EXPECT_TRUE(ev.first_mismatch().empty()) << ev.first_mismatch();
+    EXPECT_EQ(ev.stack_depth(), 1);
+    EXPECT_NE(white_view, black_view)
+        << "a null move left the evaluation unchanged, so the accumulators are either identical "
+           "or their order is not being read";
+
+    ev.pop();
+    p.undo_null_move();
+    EXPECT_EQ(ev.evaluate(p), white_view);
+}
+
+// Refresh is what the search calls at every root, and between two unrelated
+// positions there is no delta to follow. It must discard the whole stack, not
+// just overwrite the top of it.
+TEST_F(NnueEvaluatorTest, RefreshDiscardsTheWholeStack) {
+    std::istringstream ss("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+    position p(ss);
+    NNUEEvaluator ev(net_);
+    ev.refresh(p);
+
+    Movegen mvs(p);
+    mvs.generate<pseudo_legal, pieces>();
+    for (int i = 0; i < mvs.size() && i < 3; ++i) {
+        if (!p.is_legal(mvs[i]))
+            continue;
+        p.do_move(mvs[i]);
+        ev.push(p, p.delta());
+    }
+    ASSERT_GT(ev.stack_depth(), 0);
+
+    std::istringstream ss2("8/2k5/8/8/8/5Q2/8/4K3 w - - 0 1");
+    position other(ss2);
+    ev.refresh(other);
+    EXPECT_EQ(ev.stack_depth(), 0);
+    EXPECT_TRUE(ev.matches_full_recompute(other));
+}
+
+// Every search thread walks its own line, so accumulators cannot be shared.
+// One shared const network across all of them must be, and the thread_local
+// scratch inside `forward` is the part of that claim which is easy to get
+// wrong.
+TEST_F(NnueEvaluatorTest, SeveralThreadsShareOneNetworkSafely) {
+    SearchEngine engine;
+    engine.set_threads(4);
+
+    std::vector<CheckedNNUE*> probes;
+    std::mutex probes_mutex;
+    engine.set_evaluator_factory([&](Searchthread&) {
+        auto e = std::make_unique<CheckedNNUE>(net_);
+        {
+            std::lock_guard<std::mutex> lock(probes_mutex);
+            probes.push_back(e.get());
+        }
+        return e;
+    });
+
+    std::istringstream ss("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1");
+    position p(ss);
+    SearchLimits lims;
+    lims.depth = 7;
+    engine.start(p, lims, /*silent=*/true);
+    engine.wait();
+
+    ASSERT_GE(probes.size(), 4u);
+    long total_pushes = 0;
+    for (auto* probe : probes) {
+        EXPECT_TRUE(probe->first_mismatch().empty()) << probe->first_mismatch();
+        total_pushes += probe->pushes();
+    }
+    EXPECT_GT(total_pushes, 1000);
+    EXPECT_EQ(engine.evaluator_name(0), "NNUE");
+}
+
+} // namespace havoc

--- a/tests/test_nnue_network.cpp
+++ b/tests/test_nnue_network.cpp
@@ -17,7 +17,9 @@
 /// is not itself.
 
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
+#include <fstream>
 #include <functional>
 #include <sstream>
 #include <string>
@@ -220,4 +222,169 @@ TEST(NnueNetwork, RefusesATruncatedOrOverlongFile) {
 
     nnue::Network headerless;
     EXPECT_FALSE(load_from(std::string(16, '\0'), headerless).empty());
+}
+
+// ── Cross-language exactness ────────────────────────────────────────────────
+//
+// Everything above pins the arithmetic against hand-computed values, which
+// proves the engine does what this file says. It does not prove the engine
+// does what `scripts/nnue/quantise.py` does, and that is the mismatch that
+// would matter: the quantiser decides the weights, and if the two integer
+// paths diverge anywhere -- a rounding direction, a division that floors
+// instead of truncating -- the engine plays a network subtly unlike the one
+// that was trained, and nothing reports it.
+//
+// `quantise.py --cases` writes the positions it verified together with the
+// integer evaluation it computed for each. This replays them.
+//
+// The files are training artefacts, not repository content, so the test is
+// opt-in via the environment and skips without them. Skipping is the honest
+// outcome: the alternative is either a 21 MB binary in git or a test that
+// silently passes when its input is missing.
+//
+//   HAVOC_NNUE_NET=/path/net.nnue HAVOC_NNUE_CASES=/path/cases.bin ./havoc_tests
+TEST(NnueNetwork, MatchesThePythonQuantiserExactlyOnRecordedCases) {
+    const char* net_path = std::getenv("HAVOC_NNUE_NET");
+    const char* cases_path = std::getenv("HAVOC_NNUE_CASES");
+    if (!net_path || !cases_path)
+        GTEST_SKIP() << "set HAVOC_NNUE_NET and HAVOC_NNUE_CASES to replay recorded cases";
+
+    std::ifstream nf(net_path, std::ios::binary);
+    ASSERT_TRUE(nf.good()) << "cannot open " << net_path;
+    nnue::Network net;
+    ASSERT_EQ(net.load(nf), "");
+
+    std::ifstream cf(cases_path, std::ios::binary);
+    ASSERT_TRUE(cf.good()) << "cannot open " << cases_path;
+    uint32_t count = 0;
+    cf.read(reinterpret_cast<char*>(&count), sizeof(count));
+    ASSERT_TRUE(cf.good());
+    ASSERT_GT(count, 0u);
+
+    const int l1 = net.l1();
+    std::vector<int32_t> acc_us(static_cast<size_t>(l1)), acc_them(static_cast<size_t>(l1));
+    auto build = [&](const uint16_t* feats, std::vector<int32_t>& acc) {
+        const int16_t* bias = net.ft_bias();
+        for (int i = 0; i < l1; ++i)
+            acc[static_cast<size_t>(i)] = bias[i];
+        for (int k = 0; k < nnue::kMaxActiveFeatures; ++k) {
+            if (feats[k] >= nnue::kInputDim)  // padding
+                continue;
+            const int16_t* row = net.ft_row(feats[k]);
+            for (int i = 0; i < l1; ++i)
+                acc[static_cast<size_t>(i)] += row[i];
+        }
+    };
+
+    uint32_t mismatches = 0;
+    std::string first;
+    for (uint32_t n = 0; n < count; ++n) {
+        uint16_t fu[nnue::kMaxActiveFeatures], ft[nnue::kMaxActiveFeatures];
+        int32_t expected = 0;
+        cf.read(reinterpret_cast<char*>(fu), sizeof(fu));
+        cf.read(reinterpret_cast<char*>(ft), sizeof(ft));
+        cf.read(reinterpret_cast<char*>(&expected), sizeof(expected));
+        ASSERT_TRUE(cf.good()) << "case file truncated at record " << n;
+
+        build(fu, acc_us);
+        build(ft, acc_them);
+        const int got = net.forward(acc_us.data(), acc_them.data());
+        if (got != expected) {
+            ++mismatches;
+            if (first.empty())
+                first = "record " + std::to_string(n) + ": C++ " + std::to_string(got) +
+                        " vs Python " + std::to_string(expected);
+        }
+    }
+
+    // Exactly, on every case. "Close" would mean the two integer pipelines
+    // differ somewhere and the difference merely happens to be small here.
+    EXPECT_EQ(mismatches, 0u) << mismatches << " of " << count << " disagree; first " << first;
+}
+
+// The vectorised kernel sums in a different order and narrows the
+// accumulators through a different path. Integer addition is associative, so
+// "different order" is not licence for a different answer -- and a kernel that
+// is only nearly right is the failure mode that shows up as an engine playing
+// slightly badly with nothing to point at.
+TEST(NnueNetwork, TheVectorKernelAgreesWithTheReferenceExactly) {
+    // Widths the vector path accepts; RawWeights' 2x2x2 is deliberately not
+    // one of them, so this needs its own network.
+    constexpr int kVL1 = 16, kVL2 = 16, kVL3 = 4;
+
+    nnue::NetworkHeader h{};
+    std::memcpy(h.magic, "HVNW", 4);
+    h.format_version = nnue::kNetworkFormatVersion;
+    h.feature_set_version = nnue::kFeatureSetVersion;
+    h.input_dim = nnue::kInputDim;
+    h.l1 = kVL1;
+    h.l2 = kVL2;
+    h.l3 = kVL3;
+    h.cp_scale = nnue::kDefaultCpScale;
+    h.qa = nnue::kQA;
+    h.s_fc1 = 3;  // small scales keep the layer outputs off the clip bounds,
+    h.s_fc2 = 3;  // so a difference has somewhere to show
+    h.s_out = 3;
+
+    uint32_t st = 0x9e3779b9u;
+    auto next = [&st]() {
+        st ^= st << 13;
+        st ^= st >> 17;
+        st ^= st << 5;
+        return st;
+    };
+
+    std::string s(reinterpret_cast<const char*>(&h), sizeof(h));
+    auto append = [&s](const auto& v) {
+        s.append(reinterpret_cast<const char*>(v.data()),
+                 v.size() * sizeof(typename std::decay_t<decltype(v)>::value_type));
+    };
+    std::vector<int16_t> ft_w(static_cast<size_t>(nnue::kInputDim) * kVL1, 0);
+    std::vector<int16_t> ft_b(kVL1, 0);
+    std::vector<int8_t> fc1_w(kVL2 * 2 * kVL1);
+    for (auto& w : fc1_w)
+        w = static_cast<int8_t>(static_cast<int32_t>(next() % 255u) - 127);
+    std::vector<int32_t> fc1_b(kVL2);
+    for (auto& b : fc1_b)
+        b = static_cast<int32_t>(next() % 2001u) - 1000;
+    std::vector<int8_t> fc2_w(kVL3 * kVL2);
+    for (auto& w : fc2_w)
+        w = static_cast<int8_t>(static_cast<int32_t>(next() % 255u) - 127);
+    std::vector<int32_t> fc2_b(kVL3);
+    for (auto& b : fc2_b)
+        b = static_cast<int32_t>(next() % 2001u) - 1000;
+    std::vector<int8_t> out_w(kVL3);
+    for (auto& w : out_w)
+        w = static_cast<int8_t>(static_cast<int32_t>(next() % 255u) - 127);
+    const int32_t out_b = 137;
+
+    append(ft_w);
+    append(ft_b);
+    append(fc1_w);
+    append(fc1_b);
+    append(fc2_w);
+    append(fc2_b);
+    append(out_w);
+    s.append(reinterpret_cast<const char*>(&out_b), sizeof(out_b));
+
+    nnue::Network net;
+    ASSERT_EQ(load_from(s, net), "");
+
+    int32_t us[kVL1], them[kVL1];
+    int disagreements = 0, nonzero = 0;
+    for (int trial = 0; trial < 20000; ++trial) {
+        for (int i = 0; i < kVL1; ++i) {
+            // Include values outside [0, QA] on purpose: the clip and the
+            // narrowing are exactly where the two paths could diverge.
+            us[i] = static_cast<int32_t>(next() % 100000u) - 40000;
+            them[i] = static_cast<int32_t>(next() % 100000u) - 40000;
+        }
+        const int a = net.forward(us, them);
+        const int b = net.forward_reference(us, them);
+        disagreements += (a != b) ? 1 : 0;
+        nonzero += (b != 0) ? 1 : 0;
+    }
+    EXPECT_EQ(disagreements, 0);
+    EXPECT_GT(nonzero, 1000) << "the trial network evaluates to zero almost everywhere, so "
+                                "agreement between the two paths proves nothing";
 }


### PR DESCRIPTION
Stage 1 of the ladder in `docs/nnue-integration.md` §8: the network now runs
inside the engine, behind `setoption name EvalFile`.

**Behaviourally inert by default.** `bench` is **709908** with and without this
branch — the handcrafted evaluation is the default and nothing about it
changed.

### What is here

- `NNUEEvaluator` against the existing `IEvaluator` seam: per-thread stack of
  accumulator frames, one per ply, patched on `push` and unwound on `pop`.
- `EvalFile` UCI option, with `none` to go back to the HCE. A network that
  fails to load leaves the engine playing with the evaluation it already had.
- An AVX2 kernel for the dense layers, with `forward_reference` kept as the
  definition it is checked against.

### Correctness

| check | what it would catch |
|---|---|
| accumulator vs full rebuild at every node of a real search, 5 position families | any desynchronisation, at the node it happens on |
| every legal king move walked by hand, plus one reply | bucket crossing, which a search is free to prune away |
| mutation: king events stripped | a king move that failed to rebuild its own perspective |
| mutation: removals stripped | a lost update on the perspective that was *not* rebuilt |
| 20,000 recorded cases replayed against `quantise.py` | C++/Python integer-path divergence |
| vector kernel vs reference, 20,000 random accumulators | a SIMD kernel that is only nearly right |

The two mutation tests are the load-bearing ones: rebuilding a perspective is
always correct, so a sync check on its own cannot tell "updated correctly" from
"rebuilt anyway". Both mutations do fail the check, so it has teeth.

The cross-language replay agreed on 20,000 of 20,000 positions **exactly**. It
is opt-in via `HAVOC_NNUE_NET` / `HAVOC_NNUE_CASES` and skips in CI, because
the alternative is a 21 MB binary in git.

199/199 tests green.

### Speed

| kernel | ns per forward | bench nps |
|---|---|---|
| scalar reference | 1174 | 657k |
| AVX2, one row at a time | 481 | 959k |
| AVX2, four rows blocked, stack scratch | 347 | — |
| AVX2, weights pre-widened to int16 | **284** | **1047k** |
| handcrafted evaluation | — | 1841k |

Tried and measured as worthless, recorded so they are not retried: eight-row
blocking (229 ns vs 226), hand-vectorised accumulator narrowing (identical to
the plain loop), and `thread_local` scratch vectors (worse than stack arrays —
a guard check on every access).

`maddubs` would roughly halve the dense cost but saturates at QA=255. Dropping
QA to 127 makes it exact, and the Stage 0 sweep says activation resolution is
worth ~0.3 cp, so it is very likely free. That plus accumulator sparsity is the
next optimisation, off the critical path.

### On the Stage 1 SPRT

The expectation recorded earlier was "~0 Elo". That was written before the
speed was measured and is wrong: **the network costs 43% of the engine's
speed**, worth roughly −50 Elo at 10+0.1 before its 26.7 cp modelling error is
counted. The honest expectation is a clear loss whose size is accounted for.
The doc now says so.