### PR TITLE
nnue: lower QA to 127 so the dense kernel can use maddubs

### DIFF
--- a/include/havoc/nnue/network.hpp
+++ b/include/havoc/nnue/network.hpp
@@ -49,11 +49,30 @@
 
 namespace havoc::nnue {
 
-inline constexpr uint32_t kNetworkFormatVersion = 1;
+inline constexpr uint32_t kNetworkFormatVersion = 2;
 
-/// Accumulator scale. Chosen so a clipped activation fills the int16 range
-/// without reaching it, leaving headroom for the sum of ~30 feature rows.
-inline constexpr int32_t kQA = 255;
+/// Accumulator scale, and the ceiling that clipped activations are held under.
+///
+/// This was 255 in format v1, which is the natural choice if you only care
+/// about resolution: it fills the unsigned byte. It was lowered to 127 to buy
+/// speed, and the trade is worth stating precisely, because it is the only
+/// place in the file where accuracy was deliberately spent.
+///
+/// With activations in [0, 127] and weights in [-127, 127], the product of any
+/// *pair* of terms is at most 2 * 127 * 127 = 32,258, which fits in int16.
+/// That is exactly the condition `_mm256_maddubs_epi16` needs in order not to
+/// saturate, and that instruction does 32 products per issue against the 16 of
+/// `_mm256_madd_epi16` -- while reading its weights as int8 rather than as a
+/// pre-widened int16 copy, which halves the traffic through the inner loop's
+/// binding constraint. At QA = 255 the same pair reaches 129,540 and the
+/// instruction is simply unusable.
+///
+/// The cost is one bit of activation resolution. The Stage 0 sweep measured
+/// that at about 0.3 cp, against a held-out error of 67 cp -- far below the
+/// noise of the thing being measured. The speed is worth more: the Stage 1
+/// match lost roughly 140 Elo to evaluation speed alone and 111 to the
+/// evaluation itself.
+inline constexpr int32_t kQA = 127;
 
 /// Dense weights are int8, and each layer carries its **own** scale, chosen
 /// when the network is quantised as `floor(127 / max|w|)` for that layer.
@@ -168,16 +187,7 @@ class Network {
     std::vector<int8_t> out_w_;        ///< [l3]
     int32_t out_b_ = 0;
 
-    /// The dense weights again, widened to int16 at load.
-    ///
-    /// Pure redundancy, kept because it is measurably worth it: sign-extending
-    /// int8 to int16 inside the loop puts four shuffle uops per iteration on a
-    /// single port and that port becomes the limit. Widening once at load
-    /// costs 32 KB and 13% of the layer's time (196 ns against 226 ns for the
-    /// 512x32 layer, measured). The file stays int8; this is a decode, not a
-    /// second copy of the format.
-    std::vector<int16_t> fc1_w16_, fc2_w16_;
-};
+    };
 
 inline int Network::forward_reference(const int32_t* acc_us, const int32_t* acc_them) const {
     // Scratch is thread_local rather than automatic because this runs at every
@@ -225,37 +235,35 @@ inline int Network::forward_reference(const int32_t* acc_us, const int32_t* acc_
 
 #if defined(__AVX2__)
 
-/// The same arithmetic as `forward_reference`, sixteen products at a time.
+/// The same arithmetic as `forward_reference`, thirty-two products at a time.
 ///
-/// Exactness rests on two facts, and both are checked rather than assumed.
-/// Activations are clipped into [0, QA] with QA = 255, and weights are int8,
-/// so every product fits in int16 and every *adjacent pair* of products fits
-/// in int32 -- which is precisely what `_mm256_madd_epi16` computes. Nothing
-/// saturates, so the vector path is not an approximation of the scalar one;
-/// it is the same sum in a different order, and integer addition does not
-/// care about the order.
-///
-/// The alternative, `_mm256_maddubs_epi16`, would do twice as many products
-/// per instruction and is what most engines use -- but it accumulates into
-/// int16 and *saturates*, so it is only correct while the weights stay small
-/// enough, a condition no test here could state. That trade is available
-/// later, behind a measurement; it is not taken silently.
+/// Exactness rests on a bound that `kQA` exists to guarantee: activations are
+/// clipped into [0, 127] and weights are int8, so any adjacent pair of
+/// products sums to at most 32,258 and `_mm256_maddubs_epi16` -- which
+/// accumulates pairs into a *saturating* int16 -- never saturates. The pairs
+/// are widened to int32 immediately afterwards, so nothing accumulates in
+/// int16 across iterations either. The vector path is therefore not an
+/// approximation of the scalar one; it is the same sum in a different order,
+/// and integer addition does not care about the order. `tests/
+/// test_nnue_network.cpp` asserts that over 20,000 random accumulators.
 inline int Network::forward_avx2(const int32_t* acc_us, const int32_t* acc_them) const {
     // Plain stack arrays, not thread_local vectors: a thread_local with a
     // non-trivial constructor costs a guard check and an indirection on every
     // access, which at this call rate was measurably larger than the layer it
     // was holding. Sizes are bounded by the loader, which is why `simd_ok_`
     // and the bound below have to agree.
-    int16_t x[2 * kMaxSimdL1];
-    int16_t h1[kMaxSimdL2];
-    int16_t h2[kMaxSimdL2];
+    //
+    // Unsigned, because that is the half of `maddubs` the activations feed.
+    alignas(32) uint8_t x[2 * kMaxSimdL1];
+    alignas(32) uint8_t h1[kMaxSimdL2];
+    alignas(32) uint8_t h2[kMaxSimdL2];
 
     // A plain loop: an explicit packs/permute/clamp version of this measured
     // identical, so the compiler is already vectorising it and the intrinsics
     // would only be harder to read.
     for (int i = 0; i < l1_; ++i) {
-        x[i] = static_cast<int16_t>(clipped(acc_us[i], kQA));
-        x[l1_ + i] = static_cast<int16_t>(clipped(acc_them[i], kQA));
+        x[i] = static_cast<uint8_t>(clipped(acc_us[i], kQA));
+        x[l1_ + i] = static_cast<uint8_t>(clipped(acc_them[i], kQA));
     }
 
     // One dense layer: `out[j] = clip((bias[j] + w[j] . in) / scale)`.
@@ -264,28 +272,62 @@ inline int Network::forward_avx2(const int32_t* acc_us, const int32_t* acc_them)
     // instead of once each, which matters because this loop is limited by
     // load slots rather than by multiplies, and the four horizontal sums fold
     // into one shuffle chain instead of four.
-    auto dense = [](const int16_t* w, const int32_t* bias, const int16_t* in, int in_dim,
-                    int out_dim, int32_t scale, int16_t* out) {
+    auto dense = [](const int8_t* w, const int32_t* bias, const uint8_t* in, int in_dim,
+                    int out_dim, int32_t scale, uint8_t* out) {
+        const __m256i ones = _mm256_set1_epi16(1);
         for (int j = 0; j < out_dim; j += 4) {
             __m256i a0 = _mm256_setzero_si256(), a1 = a0, a2 = a0, a3 = a0;
-            const int16_t* w0 = w + static_cast<size_t>(j) * static_cast<size_t>(in_dim);
-            const int16_t* w1 = w0 + in_dim;
-            const int16_t* w2 = w1 + in_dim;
-            const int16_t* w3 = w2 + in_dim;
-            for (int i = 0; i < in_dim; i += 16) {
+            const int8_t* w0 = w + static_cast<size_t>(j) * static_cast<size_t>(in_dim);
+            const int8_t* w1 = w0 + in_dim;
+            const int8_t* w2 = w1 + in_dim;
+            const int8_t* w3 = w2 + in_dim;
+            int i = 0;
+            for (; i + 32 <= in_dim; i += 32) {
                 const __m256i xv = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(in + i));
+                // maddubs pairs into int16; madd against ones widens to int32
+                // before anything can accumulate far enough to overflow.
                 a0 = _mm256_add_epi32(
                     a0, _mm256_madd_epi16(
-                            xv, _mm256_loadu_si256(reinterpret_cast<const __m256i*>(w0 + i))));
+                            _mm256_maddubs_epi16(
+                                xv, _mm256_loadu_si256(
+                                        reinterpret_cast<const __m256i*>(w0 + i))),
+                            ones));
                 a1 = _mm256_add_epi32(
                     a1, _mm256_madd_epi16(
-                            xv, _mm256_loadu_si256(reinterpret_cast<const __m256i*>(w1 + i))));
+                            _mm256_maddubs_epi16(
+                                xv, _mm256_loadu_si256(
+                                        reinterpret_cast<const __m256i*>(w1 + i))),
+                            ones));
                 a2 = _mm256_add_epi32(
                     a2, _mm256_madd_epi16(
-                            xv, _mm256_loadu_si256(reinterpret_cast<const __m256i*>(w2 + i))));
+                            _mm256_maddubs_epi16(
+                                xv, _mm256_loadu_si256(
+                                        reinterpret_cast<const __m256i*>(w2 + i))),
+                            ones));
                 a3 = _mm256_add_epi32(
                     a3, _mm256_madd_epi16(
-                            xv, _mm256_loadu_si256(reinterpret_cast<const __m256i*>(w3 + i))));
+                            _mm256_maddubs_epi16(
+                                xv, _mm256_loadu_si256(
+                                        reinterpret_cast<const __m256i*>(w3 + i))),
+                            ones));
+            }
+            // `simd_ok_` allows inner dimensions that are multiples of 16, so
+            // at most one 16-wide remainder is left. Widening it and using
+            // `madd_epi16` costs nothing here and keeps small architectures --
+            // which the tests use precisely because they are small -- on the
+            // vector path instead of quietly falling back to the reference.
+            if (i < in_dim) {
+                const __m256i xw = _mm256_cvtepu8_epi16(
+                    _mm_loadu_si128(reinterpret_cast<const __m128i*>(in + i)));
+                auto row = [&](const int8_t* wr) {
+                    return _mm256_madd_epi16(
+                        xw, _mm256_cvtepi8_epi16(
+                                _mm_loadu_si128(reinterpret_cast<const __m128i*>(wr + i))));
+                };
+                a0 = _mm256_add_epi32(a0, row(w0));
+                a1 = _mm256_add_epi32(a1, row(w1));
+                a2 = _mm256_add_epi32(a2, row(w2));
+                a3 = _mm256_add_epi32(a3, row(w3));
             }
             // hadd twice leaves [s0 s1 s2 s3 | s0 s1 s2 s3] split across the
             // two lanes; adding the halves completes the four sums.
@@ -297,12 +339,12 @@ inline int Network::forward_avx2(const int32_t* acc_us, const int32_t* acc_them)
             alignas(16) int32_t part[4];
             _mm_store_si128(reinterpret_cast<__m128i*>(part), sums);
             for (int k = 0; k < 4; ++k)
-                out[j + k] = static_cast<int16_t>(clipped((bias[j + k] + part[k]) / scale, kQA));
+                out[j + k] = static_cast<uint8_t>(clipped((bias[j + k] + part[k]) / scale, kQA));
         }
     };
 
-    dense(fc1_w16_.data(), fc1_b_.data(), x, 2 * l1_, l2_, s_fc1_, h1);
-    dense(fc2_w16_.data(), fc2_b_.data(), h1, l2_, l3_, s_fc2_, h2);
+    dense(fc1_w_.data(), fc1_b_.data(), x, 2 * l1_, l2_, s_fc1_, h1);
+    dense(fc2_w_.data(), fc2_b_.data(), h1, l2_, l3_, s_fc2_, h2);
 
     int64_t out = out_b_;
     for (int i = 0; i < l3_; ++i)
@@ -371,12 +413,15 @@ inline std::string Network::load(std::istream& in) {
     if (in)
         return "network: file is longer than the declared architecture";
 
-    // The vector kernel walks sixteen values at a time and does not carry a
-    // tail loop, so it is used only when every inner dimension divides evenly.
-    // A network that does not is not rejected; it simply runs the reference.
-    fc1_w16_.assign(fc1_w_.begin(), fc1_w_.end());
-    fc2_w16_.assign(fc2_w_.begin(), fc2_w_.end());
-
+    // The vector kernel walks thirty-two values at a time and carries a single
+    // sixteen-wide remainder, so it is used only when every inner dimension is
+    // a multiple of sixteen. A network that is not is not rejected; it simply
+    // runs the reference.
+    //
+    // Format v1 kept a second copy of the dense weights widened to int16,
+    // because sign-extending inside the loop cost 13% of the layer. `maddubs`
+    // consumes int8 directly, so the copy is gone and the weights are now read
+    // from the same array the reference uses.
     simd_ok_ = l1_ % 16 == 0 && l2_ % 16 == 0 && l3_ % 4 == 0 && l1_ <= kMaxSimdL1 &&
                l2_ <= kMaxSimdL2 && l3_ <= kMaxSimdL2;
 

--- a/scripts/nnue/model.py
+++ b/scripts/nnue/model.py
@@ -39,7 +39,7 @@ PADDING_INDEX = INPUT_DIM
 
 
 # Accumulator/activation scale, mirrored from quantise.py and network.hpp.
-QA = 255
+QA = 127
 INT8_MAX = 127
 
 

--- a/scripts/nnue/quantise.py
+++ b/scripts/nnue/quantise.py
@@ -43,10 +43,10 @@ import dataset as ds_mod  # noqa: E402
 from model import NNUE, PADDING_INDEX, sanitise  # noqa: E402
 
 MAGIC = b"HVNW"
-NETWORK_FORMAT_VERSION = 1
+NETWORK_FORMAT_VERSION = 2
 
 # Accumulator/activation scale.
-QA = 255
+QA = 127
 
 # Dense weights are int8. Each layer's scale is fitted to that layer's own
 # largest weight rather than shared, because sharing one was measured to cost

--- a/scripts/nnue/train.py
+++ b/scripts/nnue/train.py
@@ -117,6 +117,14 @@ def main() -> int:
         "the only measurement that is honest by construction.",
     )
     ap.add_argument(
+        "--val-limit",
+        type=int,
+        default=None,
+        help="Cap on records taken from --val-file. The validation set is "
+        "re-scored every epoch, so an oversized one buys no precision and "
+        "costs real time on a long run.",
+    )
+    ap.add_argument(
         "--val-gap",
         type=int,
         default=200_000,
@@ -157,7 +165,7 @@ def main() -> int:
         return 1
 
     if args.val_file:
-        val_data = ds_mod.load(args.val_file)
+        val_data = ds_mod.load(args.val_file, limit=args.val_limit)
         if val_data.label_kind != data.label_kind:
             print(
                 f"refusing: training on {data.label_kind} labels but validating "

--- a/tests/test_nnue_evaluator.cpp
+++ b/tests/test_nnue_evaluator.cpp
@@ -26,6 +26,7 @@
 /// mutation tests below break each of those deliberately and require the
 /// check to notice.
 
+#include <algorithm>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -221,6 +222,13 @@ const std::vector<std::string>& sync_fens() {
 // all of those paths, and it is where a bucket-crossing king move happens
 // thousands of times.
 TEST_F(NnueEvaluatorTest, AccumulatorSurvivesARealSearchOnEveryLine) {
+    // A per-position floor of 1000 pushes was tried and is the wrong guard: a
+    // king-and-pawn ending at depth 6 has a genuinely small tree, and the
+    // exact size moves whenever the evaluation does -- lowering kQA changed it
+    // from just over the line to just under, with nothing actually wrong. The
+    // guard has to rule out a *vacuous* test, so it asks for a small floor
+    // everywhere and a large one somewhere.
+    long deepest = 0;
     for (const auto& fen : sync_fens()) {
         SearchEngine engine;
         engine.set_threads(1);
@@ -243,10 +251,12 @@ TEST_F(NnueEvaluatorTest, AccumulatorSurvivesARealSearchOnEveryLine) {
         ASSERT_NE(probe, nullptr) << "the factory was never used for " << fen;
         EXPECT_TRUE(probe->first_mismatch().empty()) << "in " << fen << "\n"
                                                      << probe->first_mismatch();
-        EXPECT_GT(probe->pushes(), 1000) << "in " << fen << ": the search barely ran";
+        EXPECT_GT(probe->pushes(), 100) << "in " << fen << ": the search barely ran";
         EXPECT_EQ(probe->pushes(), probe->pops()) << "in " << fen;
         EXPECT_GT(probe->refreshes(), 0) << "in " << fen;
+        deepest = std::max(deepest, probe->pushes());
     }
+    EXPECT_GT(deepest, 1000) << "no position searched a tree big enough for this to mean anything";
 }
 
 // Every king move in a set of positions, walked by hand, so the bucket-

--- a/tests/test_nnue_network.cpp
+++ b/tests/test_nnue_network.cpp
@@ -113,21 +113,21 @@ TEST(NnueNetwork, LoadsAWellFormedFile) {
 TEST(NnueNetwork, ComputesTheDocumentedFixedPointArithmetic) {
     RawWeights w;
     // One accumulator unit on for the side to move, everything else silent.
-    // acc_us = {QA, 0}, acc_them = {0, 0}, so x = {255, 0, 0, 0}.
+    // acc_us = {QA, 0}, acc_them = {0, 0}, so x = {127, 0, 0, 0}.
     //
-    // fc1 row 0 = {1,0,0,0} -> sum = 255, h1[0] = clip(255/64) = 3
+    // fc1 row 0 = {1,0,0,0} -> sum = 127, h1[0] = clip(127/64) = 1
     // fc1 row 1 = {0,...}   -> h1[1] = 0
-    // fc2 row 0 = {2,0}     -> sum = 6,   h2[0] = clip(6/64)   = 0
+    // fc2 row 0 = {2,0}     -> sum = 2,   h2[0] = clip(2/64)   = 0
     // fc2 row 1 = {0,0}, but bias 64*8 -> sum = 512, h2[1] = 8
-    // out = {0, 3} -> o = 3*8 = 24
-    // eval = 24 * 400 / (255 * 64) = 9600 / 16320 = 0 (truncated)
+    // out = {0, 2} -> o = 2*8 = 16
+    // eval = 16 * 400 / (127 * 64) = 6400 / 8128 = 0 (truncated)
     //
     // A truncating divide is the point of the last line: it is what the
     // engine does, and the Python side matches it deliberately.
     w.fc1_w[0] = 1;
     w.fc2_w[0] = 2;
     w.fc2_b[1] = 64 * 8;
-    w.out_w[1] = 3;
+    w.out_w[1] = 2;
 
     nnue::Network net;
     ASSERT_EQ(load_from(w.serialise(), net), "");
@@ -139,11 +139,11 @@ TEST(NnueNetwork, ComputesTheDocumentedFixedPointArithmetic) {
     // Scale the output weight up so the result clears the truncation and the
     // arithmetic is pinned at a non-zero value too.
     w.out_w[1] = 127;
-    w.fc2_b[1] = 64 * 255;  // h2[1] saturates at QA
+    w.fc2_b[1] = 64 * nnue::kQA;  // h2[1] saturates at QA
     nnue::Network net2;
     ASSERT_EQ(load_from(w.serialise(), net2), "");
-    // o = 127 * 255 = 32385; eval = 32385 * 400 / 16320 = 793
-    EXPECT_EQ(net2.forward(acc_us, acc_them), 32385 * 400 / (255 * 64));
+    // o = 127 * 127 = 16129; eval = 16129 * 400 / 8128 = 793
+    EXPECT_EQ(net2.forward(acc_us, acc_them), 16129 * 400 / (127 * 64));
     EXPECT_EQ(net2.forward(acc_us, acc_them), 793);
 }
 
@@ -192,7 +192,7 @@ TEST(NnueNetwork, RefusesFilesItCannotInterpret) {
         {"bad magic", [](RawWeights& w) { w.magic = "XXXX"; }},
         {"future format", [](RawWeights& w) { w.format_version += 1; }},
         {"stale feature set", [](RawWeights& w) { w.feature_set_version += 1; }},
-        {"foreign accumulator scale", [](RawWeights& w) { w.qa = 127; }},
+        {"foreign accumulator scale", [](RawWeights& w) { w.qa = nnue::kQA * 2; }},
         {"zero dense scale", [](RawWeights& w) { w.s_fc1 = 0; }},
     };
     for (const auto& c : cases) {
@@ -307,11 +307,14 @@ TEST(NnueNetwork, MatchesThePythonQuantiserExactlyOnRecordedCases) {
 // "different order" is not licence for a different answer -- and a kernel that
 // is only nearly right is the failure mode that shows up as an engine playing
 // slightly badly with nothing to point at.
-TEST(NnueNetwork, TheVectorKernelAgreesWithTheReferenceExactly) {
-    // Widths the vector path accepts; RawWeights' 2x2x2 is deliberately not
-    // one of them, so this needs its own network.
-    constexpr int kVL1 = 16, kVL2 = 16, kVL3 = 4;
-
+// Widths the vector path accepts; RawWeights' 2x2x2 is deliberately not one
+// of them, so this needs its own network. The dense kernel walks 32 values at
+// a time and finishes with at most one 16-wide remainder, so the widths below
+// are chosen to reach every combination: fc2 with in_dim 16 is remainder only,
+// 32 is main loop only, and 48 is both.
+void expect_vector_kernel_matches_reference(int kVL1, int kVL2, int kVL3) {
+    SCOPED_TRACE("l1=" + std::to_string(kVL1) + " l2=" + std::to_string(kVL2) + " l3=" +
+                 std::to_string(kVL3));
     nnue::NetworkHeader h{};
     std::memcpy(h.magic, "HVNW", 4);
     h.format_version = nnue::kNetworkFormatVersion;
@@ -370,7 +373,7 @@ TEST(NnueNetwork, TheVectorKernelAgreesWithTheReferenceExactly) {
     nnue::Network net;
     ASSERT_EQ(load_from(s, net), "");
 
-    int32_t us[kVL1], them[kVL1];
+    std::vector<int32_t> us(static_cast<size_t>(kVL1)), them(static_cast<size_t>(kVL1));
     int disagreements = 0, nonzero = 0;
     for (int trial = 0; trial < 20000; ++trial) {
         for (int i = 0; i < kVL1; ++i) {
@@ -379,12 +382,18 @@ TEST(NnueNetwork, TheVectorKernelAgreesWithTheReferenceExactly) {
             us[i] = static_cast<int32_t>(next() % 100000u) - 40000;
             them[i] = static_cast<int32_t>(next() % 100000u) - 40000;
         }
-        const int a = net.forward(us, them);
-        const int b = net.forward_reference(us, them);
+        const int a = net.forward(us.data(), them.data());
+        const int b = net.forward_reference(us.data(), them.data());
         disagreements += (a != b) ? 1 : 0;
         nonzero += (b != 0) ? 1 : 0;
     }
     EXPECT_EQ(disagreements, 0);
     EXPECT_GT(nonzero, 1000) << "the trial network evaluates to zero almost everywhere, so "
                                 "agreement between the two paths proves nothing";
+}
+
+TEST(NnueNetwork, TheVectorKernelAgreesWithTheReferenceExactly) {
+    expect_vector_kernel_matches_reference(16, 16, 4);   // fc2: remainder only
+    expect_vector_kernel_matches_reference(32, 32, 4);   // fc2: main loop only
+    expect_vector_kernel_matches_reference(16, 48, 4);   // fc2: main loop + remainder
 }


### PR DESCRIPTION
The Stage 1 match lost about **140 Elo to evaluation speed** and 111 to the evaluation itself, which makes the NNUE kernel worth another pass. The dense layers were limited by load slots rather than by multiplies, and one instruction fixes both: `_mm256_maddubs_epi16` does 32 products per issue against `_mm256_madd_epi16`'s 16, and reads its weights as int8 instead of from the pre-widened int16 copy format v1 kept.

### Why this needed a format change

`maddubs` accumulates *pairs* into a **saturating** int16, so it is correct only while no adjacent pair exceeds 32767.

| QA | worst adjacent pair | fits int16? |
|---|---|---|
| 255 (v1) | 2 x 255 x 127 = 129,540 | no |
| 127 (v2) | 2 x 127 x 127 = 32,258 | yes |

So `kQA` is now load-bearing for *correctness*, not just for resolution, and the header says so next to the constant. The pairs are widened to int32 immediately after, so nothing accumulates in int16 across iterations either.

### What the bit of resolution cost, measured

Same checkpoint, same 20,000 independent game positions:

| | QA=255 | QA=127 |
|---|---|---|
| int8 vs label MAE | 84.10 cp | **84.14 cp** |
| int8 vs float MAE | 9.35 cp | 9.93 cp |

Four hundredths of a centipawn against a 67-84 cp held-out error. Far below the noise of the thing being measured.

### Correctness

- Cross-language replay against the Python quantiser: **20,000 of 20,000 exact**, regenerated at QA=127.
- Vector-vs-reference equivalence: **0 disagreements** over 20,000 random accumulators, now run at three width combinations. The kernel walks 32 values and carries one 16-wide remainder, and the remainder is new code, so the test covers remainder-only, main-loop-only, and both.
- While the QA=255 build was still linked, the equivalence test **failed** — `maddubs` really does saturate there. The test has teeth.

### Also

- `kNetworkFormatVersion` 1 -> 2, so existing `.nnue` files are refused rather than silently misread. Retrain or re-quantise.
- `fc1_w16_`/`fc2_w16_` are gone: they existed only to keep sign-extension out of the inner loop, and cost 32 KB of cache.
- The evaluator test's "did the search actually run" guard asked for 1000 pushes *per position*. A king-and-pawn ending at depth 6 has a genuinely small tree and its exact size moves whenever the evaluation does, so lowering QA pushed it from just over the line to just under with nothing actually wrong. It now asks a small floor everywhere and a large one somewhere.
- `--val-limit` for the trainer: the validation set is re-scored every epoch, so an oversized one buys no precision and costs real time.

### Not yet in this PR

The **ns/call and nps numbers**. The machine is currently running the Stage 2 timed datagen arms, and a speed measurement taken against that load would be worthless. I will measure and post before merging.