### PR TITLE
nnue: let the game's outcome into the label

### DIFF
--- a/scripts/nnue/train.py
+++ b/scripts/nnue/train.py
@@ -72,7 +72,62 @@ def build_tensors(records: np.ndarray, device: torch.device):
     feat_them = torch.where(swap, feat_w, feat_b)
 
     score = torch.from_numpy(records["score"].astype(np.float32)).to(device)
-    return feat_us, feat_them, score
+
+    # The game's outcome, from the side to move's chair. datagen plays every
+    # game to the end and writes the result, and nnue_export already stores
+    # it; until now the trainer threw it away. It is the only label we have
+    # that does not pass through the evaluation, so it is the only one whose
+    # quality is not capped by the evaluation's -- and haVoc's static eval is
+    # 93.9 cp MAE against its own depth-12 search.
+    #
+    # 255 marks a result the exporter could not read. Those rows fall back to
+    # the score alone rather than being silently scored as a draw.
+    raw = records["result"].astype(np.int16)
+    known = torch.from_numpy((raw != 255)).to(device)
+    white_pov = torch.from_numpy(np.clip(raw, 0, 2).astype(np.float32) / 2.0).to(device)
+    outcome = torch.where(black_to_move, 1.0 - white_pov, white_pov)
+    return feat_us, feat_them, score, outcome, known
+
+
+def report_wdl_scale(score: torch.Tensor, outcome: torch.Tensor, known: torch.Tensor) -> None:
+    """Fit `p = sigmoid(score / scale)` against what actually happened.
+
+    Copying this constant from another engine would be guessing: it depends on
+    the draw rate, which depends on the engine, the labelling depth and the
+    opening book. Measuring it costs a second and also sanity-checks the
+    `result`/`stm` encoding -- if the outcome column were misaligned, the
+    curve would be flat and the mean would not sit at 0.5.
+    """
+    sc = score[known].double()
+    ou = outcome[known].double()
+    print(f"win-probability fit on {len(sc):,} labelled positions")
+    print(f"  outcome mean {ou.mean().item():.4f} from the side to move (0.5 = unbiased)")
+    edges = [-2000, -800, -400, -250, -150, -75, -25, 25, 75, 150, 250, 400, 800, 2000]
+    xs, ws, ys = [], [], []
+    print("      score bucket |       n | empirical win rate")
+    for lo, hi in zip(edges[:-1], edges[1:]):
+        m = (sc >= lo) & (sc < hi)
+        n = int(m.sum().item())
+        if n < 200:
+            continue
+        rate = ou[m].mean().item()
+        print(f"  {lo:6d}..{hi:<6d} | {n:7,} | {rate:.3f}")
+        xs.append(0.5 * (lo + hi))
+        ws.append(float(n))
+        ys.append(rate)
+    x = np.array(xs)
+    w = np.array(ws)
+    y = np.array(ys)
+    ok = (y > 0.02) & (y < 0.98)
+    if ok.sum() < 3:
+        print("  too few usable buckets to fit a scale; is the result column populated?")
+        return
+    logit = np.log(y[ok] / (1.0 - y[ok]))
+    denom = float((w[ok] * x[ok] * logit).sum())
+    if abs(denom) < 1e-9:
+        print("  degenerate fit; the win rate does not track the score at all")
+        return
+    print(f"  fitted --wdl-scale {float((w[ok] * x[ok] * x[ok]).sum() / denom):.1f}")
 
 
 def drop_leaked(records: np.ndarray, train_idx: np.ndarray, val_idx: np.ndarray) -> np.ndarray:
@@ -130,6 +185,33 @@ def main() -> int:
         default=200_000,
         help="Records dropped between the training block and the validation "
         "block, so the two cannot share a game.",
+    )
+    ap.add_argument(
+        "--wdl-lambda",
+        type=float,
+        default=None,
+        help="Blend the game's outcome into the target: "
+        "lambda * sigmoid(score/scale) + (1 - lambda) * outcome, with the loss "
+        "taken in win-probability space. 1.0 is the search score alone (but "
+        "still in probability space); 0.0 is the outcome alone. Omit the flag "
+        "entirely to keep the plain centipawn regression, which is what every "
+        "measurement before this used.",
+    )
+    ap.add_argument(
+        "--wdl-scale",
+        type=float,
+        default=166.0,
+        help="Centipawns per unit of logit: p = sigmoid(score / scale). The "
+        "default is fitted to haVoc's own depth-12 self-play, where the "
+        "empirical win rate runs 0.498 at 0 cp and 0.810 at +200 cp. Refit it "
+        "with --fit-wdl-scale if the labelling depth or engine changes.",
+    )
+    ap.add_argument(
+        "--fit-wdl-scale",
+        action="store_true",
+        help="Report the scale implied by this corpus's own scores and "
+        "results, then exit. Costs nothing and beats copying a constant out "
+        "of another engine.",
     )
     ap.add_argument("--seed", type=int, default=1)
     ap.add_argument(
@@ -189,11 +271,41 @@ def main() -> int:
 
     val_idx = drop_leaked(records, train_idx, val_idx)
 
-    feat_us, feat_them, score = build_tensors(records, device)
+    feat_us, feat_them, score, outcome, outcome_known = build_tensors(records, device)
     del data
     tr = torch.from_numpy(train_idx.astype(np.int64)).to(device)
     va = torch.from_numpy(val_idx.astype(np.int64)).to(device)
     print(f"train {len(tr):,}  val {len(va):,}  device {device}")
+    # --val-gap defaults to 200k records, which is right for a real corpus and
+    # silently destroys a small one: on a 199k-record file it left *one*
+    # training position, and two different losses then produced identical
+    # numbers because neither had trained. Fail loudly instead.
+    if len(tr) < max(1000, len(records) // 100):
+        print(
+            f"refusing: only {len(tr):,} training records survive a --val-gap of "
+            f"{args.val_gap:,} on a {len(records):,}-record corpus. Lower --val-gap "
+            f"or pass --val-file."
+        )
+        return 1
+
+    if args.fit_wdl_scale:
+        # Every record, not the training split: this is a property of the
+        # corpus, and the split may legitimately be tiny.
+        report_wdl_scale(score, outcome, outcome_known)
+        return 0
+
+    def target_probability(b: torch.Tensor) -> torch.Tensor:
+        """lambda * sigmoid(score/scale) + (1 - lambda) * outcome.
+
+        Rows whose outcome the exporter could not read fall back to the score
+        alone. Scoring them as a draw instead would be a quiet lie in exactly
+        the direction the blend is meant to correct.
+        """
+        p_score = torch.sigmoid(score[b] / args.wdl_scale)
+        lam = torch.where(
+            outcome_known[b], torch.full_like(p_score, args.wdl_lambda), torch.ones_like(p_score)
+        )
+        return lam * p_score + (1.0 - lam) * outcome[b]
 
     net = NNUE(args.l1, args.l2, args.l3, qat=args.qat).to(device)
     opt = torch.optim.AdamW(net.parameters(), lr=args.lr, weight_decay=0.0)
@@ -219,7 +331,15 @@ def main() -> int:
         for lo in range(0, len(shuffled), args.batch):
             b = shuffled[lo : lo + args.batch]
             pred = net(sanitise(feat_us[b]).long(), sanitise(feat_them[b]).long())
-            loss = torch.nn.functional.huber_loss(pred, score[b] / CP_SCALE, delta=1.0)
+            if args.wdl_lambda is None:
+                loss = torch.nn.functional.huber_loss(pred, score[b] / CP_SCALE, delta=1.0)
+            else:
+                # In probability space a blunder near 0 cp matters and a
+                # rounding error at +900 does not, which is the weighting the
+                # centipawn loss gets backwards.
+                loss = torch.nn.functional.mse_loss(
+                    torch.sigmoid(pred * CP_SCALE / args.wdl_scale), target_probability(b)
+                )
             opt.zero_grad(set_to_none=True)
             loss.backward()
             opt.step()


### PR DESCRIPTION
The labels are search scores, and the search's leaves are the HCE — so **label quality is capped by evaluation quality**, and the evaluation is not good. Measured on the depth-12 gold set:

> haVoc's static evaluation is **93.9 cp MAE** against its own depth-12 search (median 33.0, 90th pct 209.0, correlation 0.927).

Training a network to reproduce a filtered version of that evaluation inherits its bias by construction.

The game's **outcome** does not pass through the evaluation at all — and we have been recording it the whole time. `datagen` plays every game to the end and writes the result into the EPD `c9` field; `nnue_export` already decodes it into `record.result`. The trainer was throwing it away.

### The blend

```
target = lambda * sigmoid(score / scale) + (1 - lambda) * outcome
```

Probability space is the point, not an implementation detail: a 50 cp error near equality decides games and a 50 cp error at +900 decides nothing, and the centipawn loss weights those identically.

### The scale is fitted, not copied

It depends on the draw rate, which depends on the engine, the labelling depth and the book — so copying a constant out of another engine would be guessing. `--fit-wdl-scale` reports it from the corpus's own scores and results. On the depth-12 gold set:

| score bucket | n | empirical win rate |
|---|---|---|
| −250..−150 | 12,045 | 0.188 |
| −75..−25 | 20,824 | 0.401 |
| −25..25 | 36,566 | 0.498 |
| 75..150 | 19,215 | 0.698 |
| 250..400 | 9,747 | 0.901 |

→ **166 cp per logit.**

That fit doubles as a check on the `result`/`stm` encoding: the outcome mean from the side to move is **0.5003**, and a misaligned column could not produce a curve that clean.

### Deliberately inert by default

Omitting `--wdl-lambda` keeps the plain centipawn regression *exactly* as it was. Every measurement so far was made with it, and the Stage 2 arms currently running have to stay comparable. Rows whose result the exporter could not read fall back to the score alone rather than being scored as a draw.

### How not to judge this

Val MAE in centipawns is a **biased** judge of this flag — it must prefer `lambda = 1`, since that is precisely what it measures. On a six-epoch toy run: 239.9 cp at lambda=1 (implicit), 241.6 at 0.7, 254.4 at 0.0. That ordering is the metric working as designed, not the flag failing. The arbiter has to be an SPRT.

### Also fixes a trap this exposed

`--val-gap` defaults to 200k records, which is right for a real corpus and silently destroys a small one. On the 199k-record gold set it left **one** training position — and two different losses then produced *identical* numbers because neither had trained anything. That now refuses to run rather than reporting a confident number about nothing.