### PR TITLE
eval: give the phase model one spelling instead of four

### DIFF
--- a/include/havoc/material_table.hpp
+++ b/include/havoc/material_table.hpp
@@ -31,7 +31,7 @@ struct material_entry {
     /// board, which over a random walk of 89,062 positions was 8.5% of them
     /// and only 24% of the positions with phase 16 or beyond. Anything that
     /// wants to know how far into the endgame we are wants the phase, not
-    /// this: use mg_weight() and eg_weight().
+    /// this: use taper() or mg_only().
     [[nodiscard]] bool is_endgame() const { return endgame != EndgameType::none; }
 
     /// Weight of the middlegame half of a tapered term, out of kPhaseMax.
@@ -40,12 +40,16 @@ struct material_entry {
     /// Weight of the endgame half of a tapered term, out of kPhaseMax.
     [[nodiscard]] int eg_weight() const { return phase_interpolant; }
 
-    /// Blends a middlegame and an endgame value by game phase.
+    /// Blends a middlegame and an endgame value by this position's game phase.
     [[nodiscard]] int taper(int mg, int eg) const {
-        return (mg * mg_weight() + eg * eg_weight()) / kPhaseMax;
+        return havoc::taper(mg, eg, phase_interpolant);
     }
 
-    static constexpr int kPhaseMax = 24;
+    /// A term that is worth its full value in the opening and nothing at all
+    /// with bare kings: pawn shelter, the king's open-file penalty, the pawn
+    /// storm and space. Spelling these as taper(v, 0) rather than by hand
+    /// keeps them on the same phase model as everything else.
+    [[nodiscard]] int mg_only(int v) const { return taper(v, 0); }
 };
 
 class material_table {

--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -542,9 +542,7 @@ struct parameters {
 template <Color c>
 [[nodiscard]] inline int square_score(const parameters& p, Piece pc, Square s, int game_phase) {
     const int idx = (c == white) ? static_cast<int>(s) : mirror_square(s);
-    const int mid = p.pst_mg[pc][idx];
-    const int eg = p.pst_eg[pc][idx];
-    return (eg * game_phase + mid * (24 - game_phase)) / 24;
+    return taper(p.pst_mg[pc][idx], p.pst_eg[pc][idx], game_phase);
 }
 
 } // namespace havoc

--- a/include/havoc/types.hpp
+++ b/include/havoc/types.hpp
@@ -402,4 +402,35 @@ constexpr std::array<char, 8> kSanCols = {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'
            (on_diagonal(s1, s3) && on_diagonal(s1, s2) && on_diagonal(s2, s3));
 }
 
+// ─── Game phase ─────────────────────────────────────────────────────────────
+//
+// The phase runs from 0 (opening, every piece still on) to kPhaseMax (bare
+// kings). Every tapered term in the evaluation is blended by the one function
+// below.
+//
+// It lives here, at the bottom of the include graph, because the alternative
+// is what it replaced: the same expression written out by hand in four places
+// -- material_entry::taper, square_score, the pawn-hash blend in hce.cpp, and
+// the middlegame-only king and space terms -- two of them spelled with a bare
+// literal 24 rather than the named constant. A phase model written four ways
+// is a phase model that will eventually get changed in three of them.
+
+/// Number of phase units between a full opening position and bare kings.
+inline constexpr int kPhaseMax = 24;
+
+/// Blends a middlegame and an endgame value by game phase.
+///
+/// @param mg    the value this term is worth with every piece on the board
+/// @param eg    the value it is worth with bare kings
+/// @param phase 0 (opening) to kPhaseMax (endgame)
+///
+/// Integer division truncates towards zero, which pulls both bonuses and
+/// penalties slightly towards zero. That is symmetric, so it introduces no
+/// side-to-move or sign bias, but it does mean a term tapered in several small
+/// pieces loses more than the same term tapered once. Prefer to sum first and
+/// taper the total.
+[[nodiscard]] constexpr int taper(int mg, int eg, int phase) {
+    return (mg * (kPhaseMax - phase) + eg * phase) / kPhaseMax;
+}
+
 } // namespace havoc

--- a/src/eval/hce.cpp
+++ b/src/eval/hce.cpp
@@ -293,9 +293,7 @@ int HCEEvaluator::evaluate(const position& p, int /*lazy_margin*/) {
     // until now only reached a one-point king-harassment term in eval_pawns
     // while the real pawn structure bypassed it entirely.
     score += ei.pe->material;
-    score += ((ei.pe->score_eg * ei.me->phase_interpolant +
-               ei.pe->score_mg * (24 - ei.me->phase_interpolant)) /
-              24) *
+    score += ei.me->taper(ei.pe->score_mg, ei.pe->score_eg) *
              params_.pawn_structure_category_scale / 100;
     score += ei.me->score;
 
@@ -915,8 +913,8 @@ template <Color c> int HCEEvaluator::eval_king(const position& p, einfo& ei) {
     // They used to switch off in one step when the material happened to match
     // a classified ending, which is 8.5% of positions, so a king was still
     // charged full middlegame shelter through most real endgames and then had
-    // the whole term vanish at an arbitrary boundary.
-    const int mg = ei.me->mg_weight();
+    // the whole term vanish at an arbitrary boundary. They now go through
+    // mg_only(), which is the same phase model as every other tapered term.
 
     for (Square s = *kings; s != no_square; s = *++kings) {
         U64 sq_bb = bitboards::squares[s];
@@ -1090,7 +1088,7 @@ template <Color c> int HCEEvaluator::eval_king(const position& p, einfo& ei) {
             if (!kflank)
                 shelter -= params_.pawnless_flank_penalty;
 
-            score += (shelter * mg) / material_entry::kPhaseMax;
+            score += ei.me->mg_only(shelter);
 
             // Open and half-open files beside the king.
             //
@@ -1119,7 +1117,7 @@ template <Color c> int HCEEvaluator::eval_king(const position& p, einfo& ei) {
                 if ((file & heavies) != 0ULL)
                     file_penalty += params_.king_open_file_heavy_penalty;
             }
-            score -= (file_penalty * mg) / material_entry::kPhaseMax;
+            score -= ei.me->mg_only(file_penalty);
         }
 
 
@@ -1161,7 +1159,7 @@ template <Color c> int HCEEvaluator::eval_king(const position& p, einfo& ei) {
                 }
             }
             storm -= params_.king_storm_penalty[std::min(3, numAttackers)];
-            score += (storm * mg) / material_entry::kPhaseMax;
+            score += ei.me->mg_only(storm);
         }
     }
     return score;
@@ -1174,9 +1172,9 @@ template <Color c> int HCEEvaluator::eval_space(const position& p, einfo& ei) {
     // Space is worth having because pieces need somewhere to go, so it fades
     // as the pieces do. Returning zero the moment the material matched a
     // classified ending made it worth full value right up to that boundary and
-    // nothing after it.
-    const int mg = ei.me->mg_weight();
-    if (mg == 0)
+    // nothing after it. The early exit is an optimisation only: mg_only()
+    // would return zero anyway once the middlegame weight reaches zero.
+    if (ei.me->mg_weight() == 0)
         return score;
 
     U64 spacemask =
@@ -1195,7 +1193,7 @@ template <Color c> int HCEEvaluator::eval_space(const position& p, einfo& ei) {
         space |= util::squares_behind(bitboards::col[util::col(s)], c, s);
     }
     score += bits::count(space) * params_.space_bonus;
-    return (score * mg) / material_entry::kPhaseMax;
+    return ei.me->mg_only(score);
 }
 
 // ─── eval_threats ───────────────────────────────────────────────────────────


### PR DESCRIPTION
The evaluation blends middlegame and endgame values in four places and did the arithmetic four separate times:

| site | spelling |
|---|---|
| `material_entry::taper()` | `(mg * mg_weight() + eg * eg_weight()) / kPhaseMax` |
| `square_score()` | `(eg * phase + mid * (24 - phase)) / 24` |
| pawn-hash blend, `hce.cpp:296` | `(score_eg * phase + score_mg * (24 - phase)) / 24` |
| shelter / file / storm / space | `(x * mg) / material_entry::kPhaseMax` |

They agree today. Two spell the denominator as a bare `24` rather than the named constant, and the last group is `taper(x, 0)` written out by hand, so nothing about the arrangement makes them keep agreeing. A disagreement here would be close to undetectable: every spelling produces a plausible score, and the tuner would quietly fit around the discrepancy.

The arithmetic moves to a single `constexpr havoc::taper(mg, eg, phase)` in `types.hpp` — at the bottom of the include graph, where both `parameters.hpp` and `material_table.hpp` can reach it — and everything else delegates. `mg_only()` is named rather than left as `taper(x, 0)` because "full value in the opening, nothing with bare kings" recurs four times.

## Verification

Every substitution is bit-identical, so this is verified by an unchanged bench rather than an SPRT:

```
main:          Bench: 709908 nodes
eval/taper-unify: Bench: 709908 nodes, 405 ms, 1749413 nps
```

Same node count means the same search tree, which means the same evaluation at every node. 199/199 tests pass.

## What this does not do

Mobility and passed pawns still taper at *category-scale* granularity, which cannot express a knight and a rook whose mobility moves in opposite directions as the board empties. That needs a packed `Score` pair through every term — a behaviour change that invalidates every tuned scalar — and it should wait for the endgame measurements to say whether the untapered residue is where the errors actually are.