### PR TITLE
nnue: hold accumulators in int16 instead of int32

### DIFF
--- a/include/havoc/eval/nnue_evaluator.hpp
+++ b/include/havoc/eval/nnue_evaluator.hpp
@@ -52,7 +52,7 @@ class NNUEEvaluator : public IEvaluator {
     [[nodiscard]] int evaluate(const position& pos, int lazy_margin = -1) override {
         (void)lazy_margin;
         const int us = static_cast<int>(pos.to_move());
-        const int32_t* base = frame(top_);
+        const int16_t* base = frame(top_);
         return net_->forward(base + static_cast<size_t>(us) * static_cast<size_t>(l1_),
                              base + static_cast<size_t>(us ^ 1) * static_cast<size_t>(l1_));
     }
@@ -70,7 +70,7 @@ class NNUEEvaluator : public IEvaluator {
 
     void refresh(const position& pos) override {
         top_ = 0;
-        int32_t* base = frame(0);
+        int16_t* base = frame(0);
         recompute(base, pos, white);
         recompute(base + static_cast<size_t>(l1_), pos, black);
     }
@@ -93,15 +93,15 @@ class NNUEEvaluator : public IEvaluator {
 
     [[nodiscard]] size_t frame_stride() const { return static_cast<size_t>(2 * l1_); }
 
-    [[nodiscard]] int32_t* frame(int i) {
+    [[nodiscard]] int16_t* frame(int i) {
         return frames_.data() + static_cast<size_t>(i) * frame_stride();
     }
-    [[nodiscard]] const int32_t* frame(int i) const {
+    [[nodiscard]] const int16_t* frame(int i) const {
         return frames_.data() + static_cast<size_t>(i) * frame_stride();
     }
 
     /// Rebuild one perspective from the board. `dst` is `l1_` wide.
-    void recompute(int32_t* dst, const position& pos, Color perspective) const {
+    void recompute(int16_t* dst, const position& pos, Color perspective) const {
         const int16_t* bias = net_->ft_bias();
         for (int i = 0; i < l1_; ++i)
             dst[i] = bias[i];
@@ -116,7 +116,7 @@ class NNUEEvaluator : public IEvaluator {
     int l1_ = 0;
     int top_ = 0;
     int capacity_ = 0;
-    std::vector<int32_t> frames_;
+    std::vector<int16_t> frames_;
 };
 
 inline void NNUEEvaluator::push(const position& pos, const FeatureDelta& d) {
@@ -124,9 +124,9 @@ inline void NNUEEvaluator::push(const position& pos, const FeatureDelta& d) {
         capacity_ *= 2;
         frames_.resize(static_cast<size_t>(capacity_) * frame_stride(), 0);
     }
-    const int32_t* prev = frame(top_);
+    const int16_t* prev = frame(top_);
     ++top_;
-    int32_t* cur = frame(top_);
+    int16_t* cur = frame(top_);
 
     // A king move rebuilds only its own perspective. Detect it before touching
     // anything, because the events for the two perspectives are the same list
@@ -138,13 +138,13 @@ inline void NNUEEvaluator::push(const position& pos, const FeatureDelta& d) {
 
     for (int ci = 0; ci < 2; ++ci) {
         const Color perspective = static_cast<Color>(ci);
-        int32_t* dst = cur + static_cast<size_t>(ci) * static_cast<size_t>(l1_);
+        int16_t* dst = cur + static_cast<size_t>(ci) * static_cast<size_t>(l1_);
         if (king_moved[ci]) {
             recompute(dst, pos, perspective);
             continue;
         }
         std::memcpy(dst, prev + static_cast<size_t>(ci) * static_cast<size_t>(l1_),
-                    static_cast<size_t>(l1_) * sizeof(int32_t));
+                    static_cast<size_t>(l1_) * sizeof(int16_t));
 
         // This perspective's king did not move, so its bucket is the same
         // before and after -- reading it from the post-move board is safe.
@@ -164,10 +164,10 @@ inline void NNUEEvaluator::push(const position& pos, const FeatureDelta& d) {
 }
 
 inline bool NNUEEvaluator::matches_full_recompute(const position& pos) const {
-    std::vector<int32_t> want(static_cast<size_t>(l1_));
+    std::vector<int16_t> want(static_cast<size_t>(l1_));
     for (int ci = 0; ci < 2; ++ci) {
         recompute(want.data(), pos, static_cast<Color>(ci));
-        const int32_t* have = frame(top_) + static_cast<size_t>(ci) * static_cast<size_t>(l1_);
+        const int16_t* have = frame(top_) + static_cast<size_t>(ci) * static_cast<size_t>(l1_);
         for (int i = 0; i < l1_; ++i)
             if (have[i] != want[i])
                 return false;

--- a/include/havoc/nnue/network.hpp
+++ b/include/havoc/nnue/network.hpp
@@ -35,6 +35,8 @@
 /// approximately but identically. Anything less and the two implementations
 /// have merely been observed to be similar.
 
+#include <algorithm>
+#include <cstdlib>
 #include <cstdint>
 #include <cstring>
 #include <istream>
@@ -87,6 +89,11 @@ inline constexpr int32_t kQA = 127;
 /// The scales live in the file rather than here, because they are a property
 /// of the trained network and not of the engine.
 inline constexpr int32_t kMaxDenseWeight = 127;
+
+/// Accumulators are int16. `kMaxActiveFeatures` (features.hpp) is the most
+/// HalfKP features that can be active at once -- one per non-king piece -- and
+/// bounds how far a single accumulator slot can travel from its bias.
+inline constexpr int32_t kAccumulatorMax = 32767;
 
 /// Centipawns per unit of network output. Must equal `CP_SCALE` in
 /// `scripts/nnue/train.py`; it is stored in the file and checked on load.
@@ -152,7 +159,7 @@ class Network {
     /// widths suit it, and to `forward_reference` otherwise. The two must
     /// agree exactly, not nearly -- integer addition is associative, so a
     /// different summation order is not an excuse for a different answer.
-    [[nodiscard]] int forward(const int32_t* acc_us, const int32_t* acc_them) const {
+    [[nodiscard]] int forward(const int16_t* acc_us, const int16_t* acc_them) const {
 #if defined(__AVX2__)
         if (simd_ok_)
             return forward_avx2(acc_us, acc_them);
@@ -162,11 +169,11 @@ class Network {
 
     /// The definition of what the network computes. Never dispatched around;
     /// a vectorised kernel is checked against this, not trusted instead of it.
-    [[nodiscard]] int forward_reference(const int32_t* acc_us, const int32_t* acc_them) const;
+    [[nodiscard]] int forward_reference(const int16_t* acc_us, const int16_t* acc_them) const;
 
   private:
 #if defined(__AVX2__)
-    [[nodiscard]] int forward_avx2(const int32_t* acc_us, const int32_t* acc_them) const;
+    [[nodiscard]] int forward_avx2(const int16_t* acc_us, const int16_t* acc_them) const;
 #endif
 
     bool loaded_ = false;
@@ -189,7 +196,7 @@ class Network {
 
     };
 
-inline int Network::forward_reference(const int32_t* acc_us, const int32_t* acc_them) const {
+inline int Network::forward_reference(const int16_t* acc_us, const int16_t* acc_them) const {
     // Scratch is thread_local rather than automatic because this runs at every
     // node: three fresh allocations per evaluation cost more than the network.
     // It is per-thread, so a shared const Network stays safe to call from every
@@ -246,7 +253,7 @@ inline int Network::forward_reference(const int32_t* acc_us, const int32_t* acc_
 /// approximation of the scalar one; it is the same sum in a different order,
 /// and integer addition does not care about the order. `tests/
 /// test_nnue_network.cpp` asserts that over 20,000 random accumulators.
-inline int Network::forward_avx2(const int32_t* acc_us, const int32_t* acc_them) const {
+inline int Network::forward_avx2(const int16_t* acc_us, const int16_t* acc_them) const {
     // Plain stack arrays, not thread_local vectors: a thread_local with a
     // non-trivial constructor costs a guard check and an indirection on every
     // access, which at this call rate was measurably larger than the layer it
@@ -412,6 +419,23 @@ inline std::string Network::load(std::istream& in) {
     in.read(&extra, 1);
     if (in)
         return "network: file is longer than the declared architecture";
+
+    // Accumulators are int16, so a network whose feature weights could sum
+    // past that range would evaluate garbage rather than fail. HalfKP activates
+    // one feature per non-king piece, so thirty is the most that can ever be
+    // summed into one accumulator slot. Checked against the loosest bound that
+    // is still sound -- every weight simultaneously at the maximum -- because a
+    // false accept here is silent and a false reject is not.
+    {
+        int32_t w_max = 0;
+        for (int16_t w : ft_weights_)
+            w_max = std::max(w_max, std::abs(static_cast<int32_t>(w)));
+        int32_t b_max = 0;
+        for (int16_t b : ft_bias_)
+            b_max = std::max(b_max, std::abs(static_cast<int32_t>(b)));
+        if (b_max + kMaxActiveFeatures * w_max > kAccumulatorMax)
+            return "network: feature weights can overflow an int16 accumulator";
+    }
 
     // The vector kernel walks thirty-two values at a time and carries a single
     // sixteen-wide remainder, so it is used only when every inner dimension is

--- a/tests/test_nnue_network.cpp
+++ b/tests/test_nnue_network.cpp
@@ -132,8 +132,8 @@ TEST(NnueNetwork, ComputesTheDocumentedFixedPointArithmetic) {
     nnue::Network net;
     ASSERT_EQ(load_from(w.serialise(), net), "");
 
-    const int32_t acc_us[kL1] = {nnue::kQA, 0};
-    const int32_t acc_them[kL1] = {0, 0};
+    const int16_t acc_us[kL1] = {nnue::kQA, 0};
+    const int16_t acc_them[kL1] = {0, 0};
     EXPECT_EQ(net.forward(acc_us, acc_them), 0);
 
     // Scale the output weight up so the result clears the truncation and the
@@ -155,10 +155,10 @@ TEST(NnueNetwork, ClipsAccumulatorsIntoTheActivationRange) {
     nnue::Network net;
     ASSERT_EQ(load_from(w.serialise(), net), "");
 
-    const int32_t huge[kL1] = {1 << 20, 0};
-    const int32_t at_max[kL1] = {nnue::kQA, 0};
-    const int32_t zero[kL1] = {0, 0};
-    const int32_t negative[kL1] = {-(1 << 20), 0};
+    const int16_t huge[kL1] = {30000, 0};  // far above kQA, still representable in the accumulator
+    const int16_t at_max[kL1] = {nnue::kQA, 0};
+    const int16_t zero[kL1] = {0, 0};
+    const int16_t negative[kL1] = {-30000, 0};
     EXPECT_EQ(net.forward(huge, zero), net.forward(at_max, zero));
     EXPECT_EQ(net.forward(negative, zero), net.forward(zero, zero));
 }
@@ -178,8 +178,8 @@ TEST(NnueNetwork, TheSideToMoveHalfIsNotInterchangeableWithTheOther) {
 
     nnue::Network net;
     ASSERT_EQ(load_from(w.serialise(), net), "");
-    const int32_t on[kL1] = {nnue::kQA, 0};
-    const int32_t off[kL1] = {0, 0};
+    const int16_t on[kL1] = {nnue::kQA, 0};
+    const int16_t off[kL1] = {0, 0};
     EXPECT_NE(net.forward(on, off), net.forward(off, on));
 }
 
@@ -262,8 +262,8 @@ TEST(NnueNetwork, MatchesThePythonQuantiserExactlyOnRecordedCases) {
     ASSERT_GT(count, 0u);
 
     const int l1 = net.l1();
-    std::vector<int32_t> acc_us(static_cast<size_t>(l1)), acc_them(static_cast<size_t>(l1));
-    auto build = [&](const uint16_t* feats, std::vector<int32_t>& acc) {
+    std::vector<int16_t> acc_us(static_cast<size_t>(l1)), acc_them(static_cast<size_t>(l1));
+    auto build = [&](const uint16_t* feats, std::vector<int16_t>& acc) {
         const int16_t* bias = net.ft_bias();
         for (int i = 0; i < l1; ++i)
             acc[static_cast<size_t>(i)] = bias[i];
@@ -373,7 +373,7 @@ void expect_vector_kernel_matches_reference(int kVL1, int kVL2, int kVL3) {
     nnue::Network net;
     ASSERT_EQ(load_from(s, net), "");
 
-    std::vector<int32_t> us(static_cast<size_t>(kVL1)), them(static_cast<size_t>(kVL1));
+    std::vector<int16_t> us(static_cast<size_t>(kVL1)), them(static_cast<size_t>(kVL1));
     int disagreements = 0, nonzero = 0;
     for (int trial = 0; trial < 20000; ++trial) {
         for (int i = 0; i < kVL1; ++i) {


### PR DESCRIPTION
The feature transformer's weights are `int16` and its accumulator was `int32`, so every incremental update moved twice the bytes it needed to and filled half as many AVX2 lanes per vector.

That is the hot path. Lowering QA to 127 so the dense layers could use `maddubs` (#141) bought only 7%, which was itself the evidence: the dense layers were never the bottleneck, the L1=256 accumulator was.

## Safety

Safety is a property of the weights, so it is checked at load rather than assumed. HalfKP activates one feature per non-king piece, so thirty is the most that can ever sum into a single accumulator slot; the loader rejects any network whose feature weights could carry it past `int16`. The current net's worst case is ±1288 against a range of ±32767, so the bound is not close.

## The evaluation is unchanged, and that is checked rather than argued

- 199/199 tests pass, including the reference-vs-AVX2 equality over 20,000 random accumulators and the incremental-vs-full-recompute check
- 200 book positions searched to depth 9 return identical bestmoves on both builds

## Measurements

Bench depth 11, 5-rep medians, nps:

| | single-threaded | 24-way concurrent (per instance) |
|---|---|---|
| HCE | 1,906,803 | 1,239,751 |
| int32 | 1,116,725 | 514,620 |
| int16 | **1,800,920** | **817,981** |

The penalty against HCE falls from **41.4% to 5.6%** single-threaded.

The second column is why this matters more than it first looks. Measured alone the int32 penalty is 41.4%, but under the 24-way concurrency the matches actually run at, it is 58.5%. Every NNUE speed figure quoted so far was taken on an idle box and understated the cost of a real match.

## Why this is on the critical path

The d6 net is **+93.6 ± 19.2 Elo at fixed depth** but **−4.2 ± 18.8 Elo at time control** — the eval is decisively better and speed ate all of it. Per-instance nps under load goes 514,620 → 817,981, a 1.59× speedup. A time-control match against HCE is running now for a direct comparison against that −4.2.