### PR TITLE
docs: record what Stage 2 actually found

### DIFF
--- a/docs/nnue-integration.md
+++ b/docs/nnue-integration.md
@@ -530,3 +530,108 @@ error. The stage did exactly what a known-answer test is for — it failed on th
 thing that was actually wrong, which was the answer, not the code. Finding this
 now cost an afternoon; finding it after a full training run would have cost
 days and would have been blamed on the labels.
+
+## 11. Stage 2: the bottleneck was a type declaration
+
+Stage 2 set out to answer "which datagen depth produces the best labels" and
+ended up answering a different question, because the answer to the first one
+turned out not to matter yet.
+
+### The two numbers that had to be read together
+
+The first honestly-trained net (depth-6 labels, 15.7M positions, L1=256) was
+measured against the HCE it was distilled from:
+
+| comparison | result |
+|---|---|
+| d6 net vs HCE, **fixed depth 8**, 1000 games | **+93.6 ± 19.2 Elo** (LOS 100%) |
+| d6 net vs HCE, **10+0.1**, 1000 games | **−4.2 ± 18.8 Elo** (LOS 33%) |
+
+The evaluation was decisively better and the speed penalty ate all of it. Quoting
+either number alone would have been misleading in opposite directions, which is
+why they belong in the same table.
+
+The gap between them is ~98 Elo. A 36.9% nps loss is 0.66 doublings and should
+cost roughly 46 Elo, so the observed cost was more than twice the simple model.
+That discrepancy was the useful part: a model that is wrong by 2× is pointing at
+something, and here it was pointing at the measurement.
+
+### The accumulator was int32 and the weights were int16
+
+The feature transformer's weights are `int16` and its accumulator was `int32`,
+so every incremental update moved twice the bytes it needed to and filled half
+as many AVX2 lanes per vector.
+
+The evidence had already been collected and not read correctly. Dropping QA to
+127 so the dense layers could use `maddubs` (section 9) doubled the dense
+multiply throughput and bought only 7% — which was not a disappointing result,
+it was a measurement saying *the dense layers were never the bottleneck*. The
+L1=256 accumulator was.
+
+Safety is a property of the weights, so the loader checks it rather than
+assuming it. HalfKP activates one feature per non-king piece, so thirty is the
+most that can ever sum into a single accumulator slot; a network whose feature
+weights could carry that past `int16` is rejected at load. The first net's worst
+case was ±1288 against a range of ±32767 — 25× headroom, so no training-side
+clamp was needed.
+
+| bench depth 11, 5-rep medians | single-threaded | 24-way concurrent (per instance) |
+|---|---|---|
+| HCE | 1,906,803 | 1,239,751 |
+| int32 accumulator | 1,116,725 | 514,620 |
+| int16 accumulator | **1,800,920** | **817,981** |
+
+The penalty against the HCE falls from **41.4% to 5.6%** single-threaded. The
+same time-control match, rerun with only the storage type changed:
+
+| build | 10+0.1, 1000 games |
+|---|---|
+| int32 accumulator | −4.2 ± 18.8 Elo |
+| int16 accumulator | **+75.9 ± 18.9 Elo** (LOS 100%) |
+
+An **+80 Elo swing with a bit-identical evaluation** — same net, same weights,
+identical bestmoves on 200 book positions at depth 9. This is haVoc's first real
+NNUE strength gain, and it came from none of the three things that had been
+measured all day.
+
+### Two methodological lessons, both expensive
+
+**Measure under the load the result will be used at.** Every NNUE nps figure in
+this document before this section was taken single-threaded on an idle box. The
+int32 penalty is 41.4% measured that way and 58.5% under the 24-way concurrency
+that matches actually run at. The idle-box figure was not merely imprecise, it
+was biased in the flattering direction, and it hid the bottleneck for months.
+
+**Validation MAE does not gate NNUE decisions.** It was used all through Stage 2
+to rank label sources, and it is close to blind at the gaps that matter:
+
+| MAE gap | measured Elo |
+|---|---|
+| 37 cp (two of our own nets) | +260.5 ± 24.2 |
+| 3.6 cp (d6 net vs HCE) | +93.6 at fixed depth |
+
+A 10× smaller MAE gap produced only a 2.8× smaller Elo gap, so the relationship
+is steeply nonlinear and MAE badly understates a good net. The likely reason is
+structural rather than incidental: MAE is a *mean* over a distribution with a
+heavy tactical tail — the 90th percentile is 209 cp — and those positions
+dominate the mean while contributing almost nothing to move choice, which is
+decided by quiet positions and by the *ordering* of candidate moves. MAE is
+therefore retired as a gate and kept only as a sign-only screen: `mae(net) <
+mae(baseline)` is a cheap necessary-but-not-sufficient check before spending an
+hour of machine time on a match.
+
+### What this changes downstream
+
+- **A wider L1 is now affordable.** L1=256 was chosen under a 41% penalty. At
+  5.6% the trade has moved and 384 or 512 should be re-examined.
+- **The net is now the better labeller.** It is +75.9 Elo over the HCE at time
+  control, and a label is a depth-N search score whose accuracy is bounded by
+  the evaluator that produced it. This is what makes a second training iteration
+  worth running, and it answers the standing question of whether the HCE must be
+  improved first to get better labels: it need not be, because the net has
+  already replaced it in that role.
+- **It is not free.** Labelling with the net costs 31.5% of datagen throughput
+  at depth 8 on 24 threads (1,877 → 1,286 pos/s), and Stage 2 established that
+  we are data-limited rather than label-limited. Which side of that trade wins
+  is a question for a match, and Stage 3 runs both arms at equal machine time
+  rather than assuming.

--- a/tools/datagen.cpp
+++ b/tools/datagen.cpp
@@ -1,5 +1,6 @@
 /// @file datagen.cpp
 #include "havoc/build_info.hpp"
+#include "havoc/eval/nnue_evaluator.hpp"
 #include "havoc/kpk.hpp"
 /// @brief Training data generator: parallel self-play games → quiet position EPD file.
 
@@ -145,7 +146,8 @@ static GameOutcome play_game(SearchEngine& engine, int depth, int random_plies,
 
 /// Worker function: each thread plays its share of games, flushing to disk periodically.
 static void worker(int thread_id, int games_per_thread, int depth, int random_plies,
-                   unsigned seed, int hash_mb, const std::string& output_file,
+                   unsigned seed, int hash_mb, std::shared_ptr<const nnue::Network> net,
+                   const std::string& output_file,
                    std::mutex& file_mutex, std::atomic<int>& games_done,
                    std::atomic<uint64_t>& total_positions, int total_games,
                    std::atomic<int>& games_abandoned, std::atomic<bool>& write_failed) {
@@ -159,6 +161,11 @@ static void worker(int thread_id, int games_per_thread, int depth, int random_pl
     std::mt19937 rng(sequence);
 
     SearchEngine engine;
+    // Weights are immutable and shared; only the accumulators are per-thread,
+    // so one loaded network serves every worker.
+    if (net)
+        engine.set_evaluator_factory(
+            [net](Searchthread&) { return std::make_unique<NNUEEvaluator>(net); });
     if (!engine.set_hash_size(hash_mb)) {
         // Refused rather than clamped, so the engine is still holding its
         // default. Say so rather than report a size that is not in use.
@@ -239,6 +246,10 @@ static void print_usage(const char* prog) {
               << "  --random-plies N Random opening plies (default: 6)\n"
               << "  --hash N         Transposition table MB per thread (default: 16)\n"
               << "  --output FILE    Output EPD file (default: training_data.epd)\n"
+              << "  --eval-file FILE Label with this NNUE network instead of the\n"
+              << "                   handcrafted evaluation. A stronger evaluator makes a\n"
+              << "                   depth-N label more accurate, which is what makes a\n"
+              << "                   second training iteration worth running.\n"
               << "  --append         Append to an existing file. This adds games, it does\n"
               << "                   not resume a run: no RNG or game position is restored,\n"
               << "                   so reusing the same --seed regenerates the same games.\n"
@@ -256,6 +267,7 @@ int main(int argc, char* argv[]) {
     // that never comes close to filling it.
     int hash_mb = 16;
     std::string output = "training_data.epd";
+    std::string eval_file;
     bool append = false;
     unsigned seed =
         static_cast<unsigned>(std::chrono::steady_clock::now().time_since_epoch().count());
@@ -276,6 +288,8 @@ int main(int argc, char* argv[]) {
             output = argv[++i];
         else if (key == "--append" || key == "-a")
             append = true;
+        else if (key == "--eval-file" && i + 1 < argc)
+            eval_file = argv[++i];
         else if (key == "--seed" && i + 1 < argc)
             seed = static_cast<unsigned>(std::stoul(argv[++i]));
         else if (key == "--help" || key == "-h") {
@@ -285,6 +299,21 @@ int main(int argc, char* argv[]) {
     }
 
     if (num_threads < 1) num_threads = 1;
+
+    // Loaded once, before any game is played. A network that cannot be loaded
+    // stops the run rather than quietly relabelling the whole corpus with the
+    // handcrafted evaluation: the labels are the product, and which evaluator
+    // produced them is not something a later reader can recover from the file.
+    std::shared_ptr<const nnue::Network> net;
+    if (!eval_file.empty()) {
+        std::string err;
+        net = load_network_file(eval_file, err);
+        if (!net) {
+            std::cerr << "datagen: " << err << std::endl;
+            return 1;
+        }
+        std::cout << "Labelling with network " << eval_file << std::endl;
+    }
 
     // Count existing positions if appending
     uint64_t existing_positions = 0;
@@ -343,7 +372,7 @@ int main(int argc, char* argv[]) {
 
     for (int t = 0; t < num_threads; ++t) {
         int count = base + (t < remainder ? 1 : 0);
-        threads.emplace_back(worker, t, count, depth, random_plies, seed, hash_mb,
+        threads.emplace_back(worker, t, count, depth, random_plies, seed, hash_mb, net,
                              std::cref(output), std::ref(file_mutex),
                              std::ref(games_done), std::ref(total_positions), num_games,
                              std::ref(games_abandoned), std::ref(write_failed));


### PR DESCRIPTION
Stage 2 set out to rank datagen depths. It ended up finding that the accumulator was `int32` while the feature weights were `int16`, which was worth **+80 Elo at time control with a bit-identical evaluation**.

Adds section 11 to `docs/nnue-integration.md` covering:

- The two numbers that must be read together (+93.6 Elo at fixed depth, −4.2 at time control) and why quoting either alone misleads in opposite directions
- How the `maddubs` result from section 9 was already the evidence — 7% from doubling dense throughput was a measurement saying the dense layers were never the bottleneck, and it was not read that way
- The int16 safety argument and why it is checked at load rather than assumed
- The full speed table, single-threaded **and** at 24-way concurrency

## Two methodological lessons, both expensive

**Measure under the load the result will be used at.** Every NNUE nps figure in this document before section 11 was taken single-threaded on an idle box. The int32 penalty is 41.4% measured that way and 58.5% under the concurrency matches actually run at — biased in the flattering direction, and it hid the bottleneck.

**Validation MAE does not gate NNUE decisions.** A 10× smaller MAE gap produced only a 2.8× smaller Elo gap. MAE is a mean over a heavy tactical tail (90th pct 209 cp) that dominates the mean and contributes almost nothing to move choice. Demoted to a sign-only screen.