### PR TITLE
nets: publish the default network and verify what is fetched

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,32 @@ position startpos moves e2e4
 go depth 12
 ```
 
+### The network
+
+haVoc plays strongest with a neural network evaluation. Networks are not kept in
+git -- one ~20 MB blob per training iteration would make the repository
+permanently expensive to clone -- so the repository commits the hash and the
+provenance, which is what makes a network reproducible, and serves the bytes
+from the release page:
+
+```
+$ scripts/fetch-net.sh
+fetch-net: verified nets/havoc-a311596752e1.nnue
+```
+
+The script checks the download against the SHA256 in `nets/default.txt` and
+refuses a file that does not match. Then either point the engine at it:
+
+```
+setoption name EvalFile value nets/havoc-a311596752e1.nnue
+```
+
+or set `EvalFile` to `none` to fall back to the handcrafted evaluation. Against
+that handcrafted evaluation the current network measures **+75.9 +/- 18.9 Elo**
+over 1000 games at 10+0.1. `nets/*.provenance.json` records, for each network,
+the architecture, the corpus it was trained on, the engine commit that labelled
+that corpus, and what it measured.
+
 Commonly used commands:
 
 ```

--- a/nets/default.txt
+++ b/nets/default.txt
@@ -1,0 +1,8 @@
+# The network this checkout expects. Fetch it with scripts/fetch-net.sh.
+#
+# Networks are not kept in git: ~20 MB per iteration would make the repository
+# permanently expensive to clone. The hash and the provenance are what make a
+# network reproducible, so those are committed and the bytes are not.
+name=havoc-a311596752e1.nnue
+sha256=a311596752e1cbbaa634fd3d799e598dbaaf804d93af086d1d128ed37149e7b8
+url=https://github.com/mjglatzmaier/haVoc/releases/download/net-a311596752e1/havoc-a311596752e1.nnue

--- a/nets/havoc-a311596752e1.provenance.json
+++ b/nets/havoc-a311596752e1.provenance.json
@@ -1,0 +1,17 @@
+{
+  "name": "havoc-a311596752e1.nnue",
+  "sha256": "a311596752e1cbbaa634fd3d799e598dbaaf804d93af086d1d128ed37149e7b8",
+  "architecture": {"feature_set": "HalfKP", "input_dim": 40960, "l1": 256, "l2": 32, "l3": 32, "qa": 127},
+  "training": {
+    "positions": 15721197,
+    "labels": "search score, depth 6, handcrafted evaluation",
+    "datagen_engine_git": "068bfd1",
+    "epochs": 8,
+    "validation": "held-out depth-12 corpus, leaked positions dropped"
+  },
+  "measured": {
+    "vs_hce_fixed_depth_8": "+93.6 +/- 19.2 Elo, 1000 games",
+    "vs_hce_tc_10+0.1": "+75.9 +/- 18.9 Elo, 1000 games, LOS 100%"
+  },
+  "notes": "First network to beat the handcrafted evaluation it was distilled from at a real time control. Requires the int16 accumulator (#146); on the int32 build the same weights measure -4.2 Elo."
+}

--- a/scripts/fetch-net.sh
+++ b/scripts/fetch-net.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Fetch the default network and verify it against the hash this checkout expects.
+#
+# Networks are ~20 MB binaries and are not kept in git: a repository that
+# accumulates one blob per training iteration becomes expensive to clone
+# forever, and git-lfs moves that cost to bandwidth billing rather than
+# removing it. What is committed is the hash and the provenance, which is what
+# makes a network reproducible; the bytes are served from the release page.
+set -euo pipefail
+
+root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+spec="$root/nets/default.txt"
+dest_dir="${HAVOC_NET_DIR:-$root/nets}"
+
+[ -f "$spec" ] || { echo "fetch-net: missing $spec" >&2; exit 1; }
+
+name=$(grep -E '^name=' "$spec" | cut -d= -f2-)
+sha=$(grep -E '^sha256=' "$spec" | cut -d= -f2-)
+url=$(grep -E '^url=' "$spec" | cut -d= -f2-)
+
+[ -n "$name" ] && [ -n "$sha" ] && [ -n "$url" ] || {
+    echo "fetch-net: $spec must set name=, sha256= and url=" >&2; exit 1; }
+
+mkdir -p "$dest_dir"
+out="$dest_dir/$name"
+
+verify() { # A network that fails its hash is not usable, so say so and stop
+           # rather than leaving a plausible-looking file in place.
+    local got
+    got=$(sha256sum "$1" | cut -d' ' -f1)
+    [ "$got" = "$sha" ] || { echo "fetch-net: $1 has sha256 $got, expected $sha" >&2; return 1; }
+}
+
+if [ -f "$out" ] && verify "$out" 2>/dev/null; then
+    echo "fetch-net: $out already present and verified"
+else
+    echo "fetch-net: downloading $name"
+    curl -fL --retry 3 -o "$out.part" "$url"
+    mv "$out.part" "$out"
+    verify "$out" || { rm -f "$out"; exit 1; }
+    echo "fetch-net: verified $out"
+fi
+
+echo
+echo "Load it with:  setoption name EvalFile value $out"


### PR DESCRIPTION
Networks are ~20 MB and one accumulates per training iteration, so keeping them in git would make the repository permanently expensive to clone. `git-lfs` moves that cost to bandwidth billing rather than removing it.

What makes a network reproducible is its **hash and its provenance**, not its presence in history. So those are committed and the bytes are served from the [release page](https://github.com/mjglatzmaier/haVoc/releases/tag/net-a311596752e1) — the same pattern Stockfish uses.

## What this adds

- `scripts/fetch-net.sh` — downloads the network named in `nets/default.txt` and checks it against the recorded SHA256, **deleting it rather than leaving a plausible-looking file in place** if it does not match
- `nets/default.txt` — name, hash and URL of the network this checkout expects
- `nets/havoc-<hash>.provenance.json` — architecture, corpus, the engine commit that labelled it, and what it measured
- A README section covering fetching, loading, and falling back to the handcrafted evaluation

## Verified end to end

Fetched into a clean directory, hash verified, and loaded by the engine.

## The first published network

Measured **+75.9 ± 18.9 Elo** over the handcrafted evaluation at 10+0.1, 1000 games.

Its sidecar records that it **requires the int16 accumulator** (#146): on a build predating that change the same weights measure −4.2 Elo. A network's measured strength is a property of the weights *and* the engine that runs them, not of the weights alone, and the provenance says so rather than leaving a future reader to rediscover it.