### PR TITLE
Return a draw from the NNUE evaluator on dead material

### DIFF
--- a/include/havoc/eval/nnue_evaluator.hpp
+++ b/include/havoc/eval/nnue_evaluator.hpp
@@ -51,6 +51,25 @@ class NNUEEvaluator : public IEvaluator {
 
     [[nodiscard]] int evaluate(const position& pos, int lazy_margin = -1) override {
         (void)lazy_margin;
+
+        // A dead position is worth exactly nothing, and the network does not
+        // know that. Asked about king and bishop against a bare king it
+        // reports +252 -- it has learned that a bishop is worth a bishop, and
+        // nothing in the training signal separates "ahead" from "ahead in a
+        // position where no legal sequence of moves mates".
+        //
+        // The search cannot cover for it. `search()` tests `is_draw()` before
+        // evaluating, but qsearch does not: it is entered on a child that was
+        // never draw-checked and recurses through captures without checking
+        // either, so a capture into a dead draw stands pat at the network's
+        // number. That is the shape of the bug that matters -- the engine
+        // trades into a drawn ending believing it is winning.
+        //
+        // HCEEvaluator has always opened with this test. The network path
+        // simply never inherited it, because it is a bare forward pass.
+        if (pos.is_material_draw())
+            return score::kDraw;
+
         const int us = static_cast<int>(pos.to_move());
         const int16_t* base = frame(top_);
         return net_->forward(base + static_cast<size_t>(us) * static_cast<size_t>(l1_),

--- a/tests/test_nnue_evaluator.cpp
+++ b/tests/test_nnue_evaluator.cpp
@@ -511,4 +511,44 @@ TEST_F(NnueEvaluatorTest, SeveralThreadsShareOneNetworkSafely) {
     EXPECT_EQ(engine.evaluator_name(0), "NNUE");
 }
 
+
+// A network has no way to learn that a bishop is worthless when no legal
+// sequence of moves can mate. Asked about king and bishop against a bare king
+// the trained net reported +252, and the search cannot cover for it: search()
+// tests is_draw() before evaluating, but qsearch does not, so a capture into a
+// dead draw stands pat at whatever the network says. The engine then trades
+// into a drawn ending believing it is winning.
+//
+// HCEEvaluator has opened with this test since it was written. The network
+// path is a bare forward pass and never inherited it.
+TEST_F(NnueEvaluatorTest, DeadMaterialIsWorthNothingWhateverTheNetworkThinks) {
+    struct Case {
+        const char* fen;
+        const char* what;
+    };
+    const Case dead[] = {
+        {"8/8/8/4k3/8/8/8/2B1K3 w - - 0 1", "king and bishop against a bare king"},
+        {"8/8/8/4k3/8/8/8/2N1K3 w - - 0 1", "king and knight against a bare king"},
+        {"8/8/8/4k3/8/8/8/4K3 w - - 0 1", "bare kings"},
+        {"8/8/8/2b1k3/8/8/8/2B1K3 w - - 0 1", "a bishop each, same colour complex"},
+    };
+
+    for (const auto& c : dead) {
+        std::istringstream ss(c.fen);
+        position p(ss);
+        NNUEEvaluator ev(net_);
+        ev.refresh(p);
+        EXPECT_EQ(ev.evaluate(p), score::kDraw) << c.what << " -- " << c.fen;
+    }
+
+    // The guard must not swallow positions that are merely quiet. A rook is
+    // still a rook, and returning a draw here would be a far worse bug than
+    // the one being fixed.
+    std::istringstream ss("8/8/8/4k3/8/8/8/R3K3 w - - 0 1");
+    position alive(ss);
+    NNUEEvaluator ev(net_);
+    ev.refresh(alive);
+    EXPECT_NE(ev.evaluate(alive), score::kDraw) << "king and rook against a bare king is not dead";
+}
+
 } // namespace havoc


### PR DESCRIPTION
Asked about king and bishop against a bare king, the trained network reports **+252**. It has learned that a bishop is worth a bishop, and nothing in a corpus of search scores separates *ahead* from *ahead in a position where no legal sequence of moves can mate*.

## Why the search does not cover for it

`search()` tests `is_draw()` — which calls `is_material_draw()` — before evaluating. **`qsearch()` does not.** It is entered on a child that was never draw-checked and recurses through captures without checking either, so a capture into a dead draw stands pat at the network's number.

The practical consequence is that the engine trades into drawn endings believing it is two and a half pawns up.

## Why the NNUE path was missing it

`HCEEvaluator::evaluate` has opened with this test since it was written. `NNUEEvaluator::evaluate` is a bare forward pass, so it never inherited it — the same reason KPK, KRK, KBNK and the draw-scaling factors are all dead code whenever a net is loaded.

This change fixes only the case that is unambiguous and needs no measurement to agree with: a dead position is worth exactly nothing. The specialised endgame evaluators and the scale factors are a judgement call about whether the net already prices them, they need matches, and they are not in this PR.

## Measurements

| position, depth 1 | HCE | net before | net after |
|---|---|---|---|
| `8/8/8/4k3/8/8/3n4/2B1K3 w - - 0 1` | 0 | **+252** | 0 |

Cost: none detectable. `is_material_draw()` rejects on its first test for any position containing a pawn, rook or queen, which is nearly all of them.

| | before | after |
|---|---|---|
| NNUE bench nps (median of 3) | 723060 | 720933 |
| HCE bench | 709908 | 709908 |

## Tests

A regression test covering four dead-material shapes, plus a guard that KR vs K is **not** reported as a draw — swallowing a live position would be a worse bug than the one being fixed. 208/208 pass.