### PR TITLE
nnue: route king and pawn versus king through the bitbase

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ set(HAVOC_CORE_SOURCES
     src/pawn_table.cpp
     src/material_table.cpp
     src/kpk.cpp
+    src/eval/endgame_probe.cpp
     src/eval/hce.cpp
     src/eval/nnue_evaluator.cpp
     src/move_order.cpp

--- a/include/havoc/eval/endgame_probe.hpp
+++ b/include/havoc/eval/endgame_probe.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+/// @file endgame_probe.hpp
+/// @brief Exactly-solved endings, shared by every evaluator.
+///
+/// The handcrafted evaluation has always routed king-and-pawn-versus-king
+/// through the KPK bitbase. The network never did, because it is a bare
+/// forward pass -- and it shows. Graded against Syzygy over 300 sampled KPvK
+/// positions at depth 10, the handcrafted evaluation scores every theoretically
+/// drawn one at 0 cp; the network averages 122 cp on them and puts 28% above
+/// 150 cp. That is the same defect the bitbase was written to fix, reappearing
+/// the moment a network is loaded.
+///
+/// This lives in its own header rather than inside either evaluator because the
+/// square normalisation the bitbase requires is fiddly enough that two copies
+/// of it would eventually disagree.
+
+#include "havoc/position.hpp"
+
+namespace havoc::eval {
+
+/// True when `p` is king-and-pawn-versus-king, in which case `strong_wins` is
+/// set to the bitbase's verdict for the side holding the pawn.
+///
+/// `kpk::init()` must have run. Callers that are not KPvK are told so and left
+/// alone rather than given a meaningless verdict.
+[[nodiscard]] bool probe_kpk(const position& p, bool& strong_wins);
+
+}  // namespace havoc::eval

--- a/include/havoc/eval/nnue_evaluator.hpp
+++ b/include/havoc/eval/nnue_evaluator.hpp
@@ -31,6 +31,7 @@
 #include <string>
 #include <vector>
 
+#include "havoc/eval/endgame_probe.hpp"
 #include "havoc/eval/evaluator.hpp"
 #include "havoc/nnue/features.hpp"
 #include "havoc/nnue/network.hpp"
@@ -68,6 +69,19 @@ class NNUEEvaluator : public IEvaluator {
         // HCEEvaluator has always opened with this test. The network path
         // simply never inherited it, because it is a bare forward pass.
         if (pos.is_material_draw())
+            return score::kDraw;
+
+        // KPvK is not a dead position -- it is a solved one, and the network
+        // guesses at it. Graded against Syzygy over 300 sampled KPvK positions
+        // at depth 10, the handcrafted evaluation scores every theoretically
+        // drawn one at 0 cp while the network averages 122 cp and puts 28%
+        // above 150 cp. Only the drawn verdict is imposed here: a proven draw
+        // is exact and cannot cost information, whereas a proven win still
+        // needs the network's gradient to tell the search which won position to
+        // steer for. The same measurement found wins already held 98 of 99, so
+        // there is nothing to fix on that side.
+        bool strong_wins = false;
+        if (eval::probe_kpk(pos, strong_wins) && !strong_wins)
             return score::kDraw;
 
         const int us = static_cast<int>(pos.to_move());

--- a/scripts/eval/endgame_oracle.py
+++ b/scripts/eval/endgame_oracle.py
@@ -358,6 +358,13 @@ def main() -> int:
         "Costs one tablebase probe per legal move but makes the metric "
         "discriminating rather than saturated near 100%%.",
     )
+    ap.add_argument(
+        "--eval-file",
+        default=None,
+        help="network to grade. Pass 'hce' to force the handcrafted evaluation. "
+             "Without this the engine grades whatever it loads by default, which "
+             "makes an HCE run and an NNUE run silently incomparable.",
+    )
     ap.add_argument("--hash", type=int, default=64, help="engine hash in MB")
     ap.add_argument("--json", default=None, help="write raw results here")
     args = ap.parse_args()
@@ -379,6 +386,15 @@ def main() -> int:
             engine.configure({"hash": args.hash})
         except chess.engine.EngineError:
             pass
+
+        # Which evaluator is being graded is the whole point of the exercise
+        # when the question is whether the network needs endgame help, so it is
+        # selected explicitly rather than inherited from nets/default.txt.
+        if args.eval_file is not None:
+            if args.eval_file.lower() == "hce":
+                engine.configure({"EvalFile": "<empty>"})
+            else:
+                engine.configure({"EvalFile": args.eval_file})
 
         buckets: dict[str, Bucket] = defaultdict(Bucket)
 

--- a/src/eval/endgame_probe.cpp
+++ b/src/eval/endgame_probe.cpp
@@ -1,0 +1,41 @@
+/// @file endgame_probe.cpp
+
+#include "havoc/eval/endgame_probe.hpp"
+
+#include "havoc/bitboard.hpp"
+#include "havoc/kpk.hpp"
+
+namespace havoc::eval {
+
+bool probe_kpk(const position& p, bool& strong_wins) {
+    const U64 wp = p.get_pieces<white, pawn>();
+    const U64 bp = p.get_pieces<black, pawn>();
+    // Two kings and one pawn, nothing else. Counting the occupancy is what
+    // makes this usable from an evaluator that has no material table in hand.
+    if (bits::count(p.all_pieces()) != 3 || bits::count(wp | bp) != 1)
+        return false;
+
+    const Color strong = wp ? white : black;
+    int psq = bits::lsb(wp | bp);
+    int sk = static_cast<int>(p.king_square(strong));
+    int wk = static_cast<int>(p.king_square(strong == white ? black : white));
+
+    // The bitbase is indexed from the point of view of a white pawn standing on
+    // files a-d, so both reflections have to be applied to every square.
+    if (strong == black) {
+        psq ^= 56;
+        sk ^= 56;
+        wk ^= 56;
+    }
+    if (util::col(psq) > Col::D) {
+        psq ^= 7;
+        sk ^= 7;
+        wk ^= 7;
+    }
+
+    const Color stm = (p.to_move() == strong) ? white : black;
+    strong_wins = kpk::probe(sk, psq, wk, stm);
+    return true;
+}
+
+}  // namespace havoc::eval

--- a/src/eval/hce.cpp
+++ b/src/eval/hce.cpp
@@ -2,6 +2,7 @@
 
 #include "havoc/bitboard.hpp"
 #include "havoc/magics.hpp"
+#include "havoc/eval/endgame_probe.hpp"
 #include "havoc/kpk.hpp"
 #include "havoc/position.hpp"
 #include "havoc/squares.hpp"
@@ -340,29 +341,11 @@ int HCEEvaluator::evaluate(const position& p, int /*lazy_margin*/) {
         case KpK: {
             // A single pawn against a bare king is solved exactly by the
             // bitbase, so there is nothing here for the evaluation to guess at.
-            const U64 wp = p.get_pieces<white, pawn>();
-            const U64 bp = p.get_pieces<black, pawn>();
-            if (bits::count(wp | bp) == 1) {
-                const Color strong = wp ? white : black;
-                U64 pawns = wp | bp;
-                int psq = bits::lsb(pawns);
-                int sk = static_cast<int>(p.king_square(strong));
-                int wk_ = static_cast<int>(p.king_square(strong == white ? black : white));
-                // Normalise so the pawn is white's and stands on files a-d.
-                if (strong == black) {
-                    psq ^= 56;
-                    sk ^= 56;
-                    wk_ ^= 56;
-                }
-                if (util::col(psq) > Col::D) {
-                    psq ^= 7;
-                    sk ^= 7;
-                    wk_ ^= 7;
-                }
-                const Color stm = (p.to_move() == strong) ? white : black;
-                if (!kpk::probe(sk, psq, wk_, stm))
-                    return score::kDraw;
-            }
+            // Shared with the network evaluator, which has the same problem and
+            // used to have no answer to it.
+            bool strong_wins = false;
+            if (eval::probe_kpk(p, strong_wins) && !strong_wins)
+                return score::kDraw;
             score += eval_kpk<white>(p, ei) - eval_kpk<black>(p, ei);
             break;
         }

--- a/tests/test_nnue_evaluator.cpp
+++ b/tests/test_nnue_evaluator.cpp
@@ -551,4 +551,47 @@ TEST_F(NnueEvaluatorTest, DeadMaterialIsWorthNothingWhateverTheNetworkThinks) {
     EXPECT_NE(ev.evaluate(alive), score::kDraw) << "king and rook against a bare king is not dead";
 }
 
+// KPvK is not dead, it is *solved*, and the network guesses at it. Graded
+// against Syzygy over 300 sampled KPvK positions at depth 10, the handcrafted
+// evaluation scores every theoretically drawn one at 0 cp; the network averaged
+// 122 cp on them and put 28% above 150 cp, and threw away one win in 99. With
+// the bitbase wired in those figures are 0 cp, 0% and 99/99.
+//
+// Only the drawn verdict is imposed. A proven draw is exact and cannot cost
+// information; a proven win still needs the network's gradient to tell the
+// search which won position to steer for.
+TEST_F(NnueEvaluatorTest, SolvedKingAndPawnDrawsAreDrawsWhateverTheNetworkThinks) {
+    // The textbook draw the bitbase was written for: the pawn cannot be escorted
+    // past the defending king. haVoc once scored this at +118.
+    const char* drawn[] = {
+        "7k/8/7K/7P/8/8/8/8 w - - 0 1",
+        "8/8/8/8/8/1k6/p7/K7 w - - 0 1",
+    };
+    for (const char* fen : drawn) {
+        std::istringstream ss(fen);
+        position p(ss);
+        NNUEEvaluator ev(net_);
+        ev.refresh(p);
+        EXPECT_EQ(ev.evaluate(p), score::kDraw) << "solved draw -- " << fen;
+    }
+
+    // A won king and pawn ending must still be scored by the network. Forcing
+    // anything here would flatten the gradient the search steers by. Both this
+    // FEN and the drawn ones above are Syzygy-confirmed rather than assumed --
+    // the first draft of this test asserted a win on a position the bitbase
+    // rightly calls a draw, and the code was correct where the test was not.
+    std::istringstream ws("8/8/8/8/8/1K6/1P6/7k w - - 0 1");
+    position won(ws);
+    NNUEEvaluator wev(net_);
+    wev.refresh(won);
+    EXPECT_NE(wev.evaluate(won), score::kDraw) << "a won king and pawn ending is not a draw";
+
+    // And the probe must not fire on anything that is not KPvK.
+    std::istringstream rs("8/8/8/4k3/8/8/4P3/R3K3 w - - 0 1");
+    position rook(rs);
+    NNUEEvaluator rev(net_);
+    rev.refresh(rook);
+    EXPECT_NE(rev.evaluate(rook), score::kDraw) << "king, rook and pawn is not king and pawn";
+}
+
 } // namespace havoc


### PR DESCRIPTION
Answers rel-4 with a measurement instead of an assumption: the network's endgame gap is **specifically KPvK**, and nothing else in the three constellations HCE has specialists for.

## The measurement

300 sampled positions per constellation, depth 10, oracle kept invisible to the engine:

| constellation | evaluator | `|eval|` on drawn | frac >150cp | wins held |
|---|---|---|---|---|
| KPvK | HCE | 0.0 cp | 0.000 | 99/99 |
| KPvK | **NNUE** | **121.9 cp** | **0.280** | **98/99** |
| KRvK | both | 0.0 cp | 0.000 | 134/134 |
| KBNvK | both | 0.0 cp | 0.000 | 129/129 |

KRvK and KBNvK need nothing — #152 already covers them, since what goes wrong there is bare-king material draws. KPvK is different: it is not *dead*, it is *solved*, and the network guesses.

This is the same defect the bitbase was written for after haVoc scored `7k/8/7K/7P/8/8/8/8 w` at +118. Loading a net silently handed it back.

## After

| constellation | `|eval|` on drawn | frac >150cp | wins held |
|---|---|---|---|---|
| KPvK (NNUE) | **0.0 cp** | **0.000** | **99/99** |

## Scope

Only the **drawn** verdict is imposed. A proven draw is exact and cannot cost information; a proven win still needs the network's gradient to tell the search which won position to steer for — and the measurement shows wins were already held, so there is nothing to fix there.

The square normalisation the bitbase needs is fiddly enough that two copies would eventually disagree, so it moves into `eval::probe_kpk` and `hce.cpp` calls the same function. Re-graded after that refactor: HCE unchanged at 0.0 cp, 99/99, 107/107.

## Also

`endgame_oracle.py` gains `--eval-file` (`hce` forces the handcrafted evaluation). Without it the harness grades whatever the engine loads by default, which makes an HCE run and an NNUE run silently incomparable — the same gap fixed in `spsa.py` in #150.

## Verification

- **Bench 709908**, bit-identical to main
- 200 tests pass; new regression test covers a solved draw, a solved win, and a non-KPvK position
- The first draft of that test asserted a win on a position the bitbase rightly calls a draw. Both the drawn and won FENs are now Syzygy-confirmed rather than assumed.