### PR TITLE
testing: pick a sweep winner without getting it wrong

### DIFF
--- a/scripts/testing/README.md
+++ b/scripts/testing/README.md
@@ -191,6 +191,48 @@ Two things to get right:
 State is written after every iteration and `--resume` continues from it, which
 matters on a machine that can lock up under a long run.
 
+## Choosing between several candidates
+
+`pick_best_arm.sh LOG_PREFIX ARM [ARM...]` reads a set of cutechess logs and
+prints the arm with the highest Elo:
+
+```sh
+scripts/testing/pick_best_arm.sh testruns/iter4- a b c d
+#   a: 40.1 Elo
+#   b: 60.8 Elo
+#   c: 6.9 Elo
+#   d: -93.1 Elo
+# b 60.8
+```
+
+It exists because doing this inline got the answer wrong in a way that looked
+right. An automated sweep of four nets installed the **worst** of them, 154 Elo
+below the best, and then tuned search against it for twenty-four minutes before
+anyone looked. Two bugs conspired:
+
+- Completion was tested with `grep -q "^Elo difference"`. cutechess prints that
+  line at every `-ratinginterval`, not only at the end, so an arm that was still
+  playing counted as finished.
+- The value was read with `grep -oE`, which returns *every* match. A finished log
+  holds three, so a multi-line string was substituted into
+  `awk "BEGIN{exit !($e > $best)}"`; awk died of a syntax error, and because the
+  comparison was an `if` condition, that arm was **silently skipped**.
+
+The three finished arms were skipped as unparseable. The one arm still mid-match
+had exactly one interim number, parsed cleanly, and won against no comparison at
+all.
+
+So the script insists on all four of:
+
+- completion is the **terminal** marker (`Finished match`), never a value that
+  also appears in progress output;
+- the **last** value is taken, and must be a single number;
+- a parse failure is **fatal**, never a skip;
+- every named arm must be present and complete before anything is chosen.
+
+The awk comparison passes values through `-v` rather than string interpolation,
+which removes the whole syntax-error class instead of guarding against it.
+
 ## Absolute rating
 
 ```sh

--- a/scripts/testing/pick_best_arm.sh
+++ b/scripts/testing/pick_best_arm.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Pick the winning arm of a multi-arm match sweep, by match result.
+#
+# Written after the iteration-4 chain installed the *worst* of four nets --
+# 154 Elo below the best -- and then spent twenty-four minutes tuning search
+# against it. Nothing in the pipeline noticed. The failure is worth recording
+# in full, because neither half of it looked like a bug:
+#
+#   1. Completion was tested with `grep -q "^Elo difference" LOG`. cutechess
+#      prints that line at every `-ratinginterval`, not only at the end, so the
+#      test passed for an arm that was still playing.
+#
+#   2. The value was read with `grep -oE`, which returns *every* match. A
+#      finished log holds three, so the shell substituted a multi-line string
+#      into `awk "BEGIN{exit !($e > $best)}"`. awk died of a syntax error, and
+#      because the comparison was the condition of an `if`, the arm was
+#      silently skipped rather than reported.
+#
+# Together those produced a confident, plausible, wrong answer: three finished
+# arms were skipped as unparseable, and the one arm still mid-match had exactly
+# one interim number, parsed cleanly, and won by default.
+#
+# The rules that follow from that:
+#   - completion means the *terminal* marker, never a value that also appears
+#     in progress output;
+#   - take the last value, and require it to be a single number;
+#   - a parse failure is fatal, never a skip;
+#   - every arm must be present and complete before anything is chosen.
+#
+# Usage: pick_best_arm.sh LOG_PREFIX ARM [ARM...]
+#   e.g. pick_best_arm.sh testruns/iter4- a b c d
+# Prints "<arm> <elo>" on success. Exits non-zero, with a reason, otherwise.
+set -eu
+
+if [ $# -lt 2 ]; then
+    echo "usage: $0 LOG_PREFIX ARM [ARM...]" >&2
+    exit 2
+fi
+
+prefix=$1
+shift
+
+best=""
+best_elo=""
+
+for arm in "$@"; do
+    log="${prefix}${arm}.log"
+
+    [ -s "$log" ] || { echo "$0: $log is missing or empty" >&2; exit 1; }
+
+    # The terminal marker. "Elo difference" is not usable here: cutechess emits
+    # it at every rating interval, which is precisely how a match still in
+    # flight was once mistaken for a finished one.
+    grep -q "^Finished match" "$log" || {
+        echo "$0: $log has no 'Finished match' -- the match did not complete" >&2
+        exit 1
+    }
+
+    # Last value, not every value.
+    elo=$(grep -E "^Elo difference:" "$log" | tail -1 \
+          | sed -nE 's/^Elo difference: (-?[0-9]+(\.[0-9]+)?).*/\1/p')
+
+    # A parse failure is fatal. Skipping is what let a single arm win by
+    # default against no comparison at all.
+    case "$elo" in
+        ""|*[!0-9.-]*|*-*-*)
+            echo "$0: could not read a single Elo value from $log (got '$elo')" >&2
+            exit 1
+            ;;
+    esac
+
+    echo "  $arm: $elo Elo" >&2
+
+    if [ -z "$best_elo" ] || awk -v a="$elo" -v b="$best_elo" 'BEGIN{exit !(a>b)}'; then
+        best_elo=$elo
+        best=$arm
+    fi
+done
+
+[ -n "$best" ] || { echo "$0: no arm selected" >&2; exit 1; }
+
+echo "$best $best_elo"


### PR DESCRIPTION
## What happened

The iteration-4 chain installed the **worst** of four candidate nets — 154 Elo below the best — and then spent twenty-four minutes tuning search against it.

| arm | config | Elo vs net-d8 |
|---|---|---|
| a | 10 ep, L1=256 | +40.1 ± 22.1 |
| **b** | **30 ep, L1=256** | **+60.8 ± 22.0** |
| c | 30 ep, L1=512 | +6.9 ± 21.6 |
| d | 30 ep, L1=1024 | **−93.1 ± 23.6** ← installed |

## Why, exactly

Two bugs, neither of which looks like one:

1. Completion was tested with `grep -q "^Elo difference"`. cutechess prints that line at **every** `-ratinginterval`, not only at the end — so an arm still playing counted as finished.
2. The value was read with `grep -oE`, which returns **every** match. A finished log holds three, so a multi-line string was substituted into `awk "BEGIN{exit !($e > $best)}"`. awk died of a syntax error, and because the comparison was the condition of an `if`, that arm was **silently skipped**.

Together: the three *finished* arms were skipped as unparseable, and the one arm still mid-match had exactly **one** interim number, parsed cleanly, and won against no comparison at all. It was selected for being incomplete, not for being good.

## The fix

`pick_best_arm.sh` insists on all four of:

- completion is the **terminal** marker (`Finished match`), never a value that also appears in progress output
- the **last** value is taken, and must be a single number
- a parse failure is **fatal**, never a skip
- every named arm must be present and complete before anything is chosen

Values reach awk via `-v` rather than string interpolation, removing the syntax-error class rather than guarding against it.

## Verification

| case | result |
|---|---|
| the four real logs | `b 60.8` — correct winner |
| arm truncated mid-match (the actual bug) | reported, exit 1 |
| missing log | reported, exit 1 |
| empty log | reported, exit 1 |
| all arms negative | picks the least bad |

## Recovery already done

SPSA was killed, its state discarded, arm b installed and verified byte-identical, and the retune restarted against it.