### PR TITLE
Find the network without being told where it is

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,13 @@ option(HAVOC_WERROR            "Treat compiler warnings as errors"    OFF)
 option(HAVOC_NATIVE            "Enable -march=native for SIMD/popcnt" ON)
 option(HAVOC_SYZYGY            "Build Syzygy tablebase probing (Fathom)" ON)
 
+# Network the binary looks for on startup when EvalFile is not set. Networks are
+# named after their own sha256 so the name pins the contents; see
+# include/havoc/net_path.hpp. Set to "" to build an engine that only ever uses
+# the handcrafted evaluation unless told otherwise.
+set(HAVOC_DEFAULT_NET "nn-69c7d05e4298.nnue" CACHE STRING
+    "Filename of the evaluation network to auto-load at startup")
+
 # ── CMake Modules ────────────────────────────────────────────────────────────
 include(cmake/CompilerWarnings.cmake)
 include(cmake/Sanitizers.cmake)
@@ -44,6 +51,7 @@ set(HAVOC_CORE_SOURCES
     src/pawn_table.cpp
     src/material_table.cpp
     src/kpk.cpp
+    src/net_path.cpp
     src/eval/endgame_probe.cpp
     src/eval/hce.cpp
     src/eval/nnue_evaluator.cpp
@@ -57,6 +65,10 @@ set(HAVOC_CORE_SOURCES
 )
 
 add_library(havoc_core STATIC ${HAVOC_CORE_SOURCES})
+
+if(HAVOC_DEFAULT_NET)
+    target_compile_definitions(havoc_core PUBLIC HAVOC_DEFAULT_NET="${HAVOC_DEFAULT_NET}")
+endif()
 
 # ── Syzygy tablebases (Fathom, vendored, MIT) ────────────────────────────────
 # Third-party C sources are their own target: they are not ours to keep clean,

--- a/include/havoc/net_path.hpp
+++ b/include/havoc/net_path.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+/// @file net_path.hpp
+/// @brief Finding the evaluation network without being told where it is.
+///
+/// The engine ships as a binary and a separate ~21 MB network file. Requiring
+/// the user to set `EvalFile` before the network is used makes the handcrafted
+/// evaluation the silent default, which is roughly 160 Elo weaker -- a mistake
+/// that produces a working but much worse engine and no error message. So the
+/// binary looks for its network on startup in the places a network is likely
+/// to be, and says loudly which one it found, or that it found none.
+///
+/// Networks are named after their own content: `nn-<first 12 hex of sha256>.nnue`.
+/// The name is therefore immutable and self-verifying -- two files with the same
+/// name are the same file, and a truncated download cannot masquerade as a good
+/// one. `HAVOC_DEFAULT_NET` is the name the binary was built to expect.
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace havoc::net {
+
+/// The network filename this binary was built against, e.g. "nn-69c7d05e4298.nnue".
+/// Empty if the build did not specify one, in which case discovery is skipped
+/// and the handcrafted evaluation is used unless `EvalFile` says otherwise.
+[[nodiscard]] std::string_view default_net_name();
+
+/// Directory containing the running executable, or empty if it cannot be
+/// determined. Used so that a network sitting next to the binary is found
+/// regardless of the working directory the GUI happens to launch from.
+[[nodiscard]] std::string executable_dir();
+
+/// Every path that would be accepted, in the order they are tried. Exposed
+/// so that the startup message can explain where it looked when it fails,
+/// and so the search order can be tested without touching the filesystem.
+///
+/// Order, most specific first:
+///   1. `$HAVOC_EVAL_FILE`             -- an explicit override, used verbatim
+///   2. `<executable dir>/<name>`      -- shipped alongside the binary
+///   3. `<executable dir>/nets/<name>`
+///   4. `<cwd>/<name>`                 -- the usual place while developing
+///   5. `<cwd>/nets/<name>`
+///   6. `$HAVOC_NET_DIR/<name>`
+///   7. `<user data dir>/havoc/<name>` -- where fetch-net.sh installs
+[[nodiscard]] std::vector<std::string> candidate_paths(std::string_view name);
+
+/// First candidate that exists and is a regular file, if any.
+[[nodiscard]] std::optional<std::string> find_default_net();
+
+} // namespace havoc::net

--- a/scripts/nnue/README.md
+++ b/scripts/nnue/README.md
@@ -57,6 +57,73 @@ Read the result as a verdict on the pipeline:
 | `dataset.py` | reads `.hbin`, checks versions, refuses mismatches |
 | `model.py` | the network; clipped ReLU because that is what quantises exactly |
 | `train.py` | training loop, holds the corpus resident in VRAM |
+| `fetch-net.sh` | downloads and verifies a published network |
+
+## Distributing networks
+
+Networks are ~21 MB and there will be many of them, so they are not in git
+history. git-lfs was rejected too: it puts a bandwidth meter on a public
+repository, and the failure mode when the quota runs out is that clones start
+handing people pointer files that the engine cannot load.
+
+Instead they are assets on a permanent GitHub release tagged
+[`nets`](https://github.com/mjglatzmaier/haVoc/releases/tag/nets), which is
+deliberately **not** tied to an engine version — any binary can fetch any
+network, and networks are only added there, never replaced.
+
+A network is named after the first 12 hex digits of its own sha256:
+
+```
+nn-69c7d05e4298.nnue
+   └── sha256sum of the file begins 69c7d05e4298
+```
+
+That makes the name a complete integrity check rather than something to be
+maintained separately. `fetch-net.sh` verifies every download against its own
+filename and refuses to install a mismatch, so a truncated or corrupted fetch
+cannot masquerade as a good network, and two files with the same name are
+necessarily the same file.
+
+```bash
+scripts/nnue/fetch-net.sh            # the network this checkout expects
+scripts/nnue/fetch-net.sh --list     # everything published
+scripts/nnue/fetch-net.sh --dir ./   # install somewhere specific
+```
+
+With no arguments it reads `HAVOC_DEFAULT_NET` out of `CMakeLists.txt`, so it
+always fetches the network matching the code you are about to build.
+
+### Where the engine looks
+
+The engine loads its network at startup without being told to, because the
+alternative — silently falling back to the handcrafted evaluation, ~160 Elo
+weaker, with no error — is a bad default. Search order is in
+`include/havoc/net_path.hpp` and pinned by `tests/test_net_path.cpp`:
+
+1. `$HAVOC_EVAL_FILE` (used verbatim)
+2. next to the binary, then `<binary dir>/nets/`
+3. the working directory, then `./nets/`
+4. `$HAVOC_NET_DIR`
+5. `~/.local/share/havoc/` (`%LOCALAPPDATA%\havoc\` on Windows) — where
+   `fetch-net.sh` installs by default
+
+The UCI `EvalFile` option overrides all of it, and `EvalFile none` returns the
+engine to the handcrafted evaluation. If nothing is found the engine says so
+and keeps playing rather than refusing to start.
+
+### Published networks
+
+| network | L1 | corpus | notes |
+|---|---|---|---|
+| `nn-69c7d05e4298.nnue` | 256 | 28.9M positions, iteration 4 | ships with v2.3; +60.8 ± 22.0 Elo over the iteration-3 net |
+
+Because `bench` node counts differ between evaluations, the bench line names
+the evaluation it used. Do not compare across them:
+
+```
+Bench: 728941 nodes, ..., eval NNUE     # with nn-69c7d05e4298.nnue
+Bench: 709908 nodes, ..., eval HCE      # no network, e.g. in CI
+```
 
 ## Notes
 

--- a/scripts/nnue/fetch-net.sh
+++ b/scripts/nnue/fetch-net.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Fetch a haVoc evaluation network and verify it.
+#
+# Networks are too large and too numerous to keep in git history, and git-lfs
+# puts a bandwidth meter on a public repository. They live instead as assets on
+# a permanent GitHub release tagged `nets`, which is not tied to any engine
+# version -- an old binary can fetch a new network and vice versa.
+#
+# Verification is intrinsic rather than bolted on: a network is named after the
+# first 12 hex digits of its own sha256, so checking the file against its name
+# is a complete integrity check. A truncated or corrupted download cannot keep
+# the name it was asked for.
+#
+# Usage:
+#   fetch-net.sh                     # fetch the network this checkout expects
+#   fetch-net.sh nn-abc123456789.nnue
+#   fetch-net.sh --dir ./nets        # install somewhere specific
+#   fetch-net.sh --list              # show published networks
+set -euo pipefail
+
+REPO="${HAVOC_REPO:-mjglatzmaier/haVoc}"
+NETS_TAG="${HAVOC_NETS_TAG:-nets}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+die() { echo "error: $*" >&2; exit 1; }
+
+# The name the source tree expects, so `fetch-net.sh` with no arguments always
+# fetches the network that matches the code you are about to build.
+default_net() {
+    sed -n 's/^set(HAVOC_DEFAULT_NET "\([^"]*\)".*/\1/p' "$ROOT/CMakeLists.txt" | head -1
+}
+
+default_dir() {
+    if [[ -n "${XDG_DATA_HOME:-}" ]]; then echo "$XDG_DATA_HOME/havoc"
+    else echo "$HOME/.local/share/havoc"; fi
+}
+
+sha256_of() {
+    if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | cut -d' ' -f1
+    elif command -v shasum   >/dev/null 2>&1; then shasum -a 256 "$1" | cut -d' ' -f1
+    else die "need sha256sum or shasum to verify the download"; fi
+}
+
+NET=""
+DEST=""
+LIST=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dir)  DEST="${2:?--dir needs a directory}"; shift 2 ;;
+        --list) LIST=1; shift ;;
+        -h|--help) sed -n '2,26p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        -*)     die "unknown option $1" ;;
+        *)      NET="$1"; shift ;;
+    esac
+done
+
+if [[ $LIST -eq 1 ]]; then
+    command -v gh >/dev/null 2>&1 || die "--list needs the gh CLI"
+    gh release view "$NETS_TAG" --repo "$REPO" --json assets \
+        --jq '.assets[] | "\(.name)  \(.size) bytes  \(.downloadCount) downloads"'
+    exit 0
+fi
+
+[[ -n "$NET" ]] || NET="$(default_net)"
+[[ -n "$NET" ]] || die "no network requested and none found in CMakeLists.txt"
+[[ "$NET" =~ ^nn-[0-9a-f]{12}\.nnue$ ]] \
+    || die "'$NET' is not a network name (expected nn-<12 hex digits>.nnue)"
+
+[[ -n "$DEST" ]] || DEST="$(default_dir)"
+mkdir -p "$DEST"
+OUT="$DEST/$NET"
+
+if [[ -f "$OUT" ]]; then
+    have="$(sha256_of "$OUT")"
+    if [[ "${have:0:12}" == "${NET:3:12}" ]]; then
+        echo "already have $OUT (verified)"
+        exit 0
+    fi
+    echo "warning: $OUT does not match its name, refetching" >&2
+fi
+
+URL="https://github.com/$REPO/releases/download/$NETS_TAG/$NET"
+TMP="$(mktemp "$DEST/.$NET.XXXXXX")"
+# Never leave a partial file where the engine might load it as a network.
+trap 'rm -f "$TMP"' EXIT
+
+echo "fetching $URL"
+if command -v curl >/dev/null 2>&1; then
+    curl -fL --retry 3 --progress-bar -o "$TMP" "$URL" \
+        || die "download failed; is $NET published under the '$NETS_TAG' release?"
+elif command -v wget >/dev/null 2>&1; then
+    wget -q --show-progress -O "$TMP" "$URL" || die "download failed"
+else
+    die "need curl or wget"
+fi
+
+got="$(sha256_of "$TMP")"
+[[ "${got:0:12}" == "${NET:3:12}" ]] \
+    || die "checksum mismatch: got ${got:0:12}, expected ${NET:3:12}. Refusing to install."
+
+mv "$TMP" "$OUT"
+trap - EXIT
+chmod 0644 "$OUT"
+echo "installed $OUT"
+echo "sha256 $got"
+echo
+echo "The engine finds this automatically. To use it from elsewhere, either"
+echo "copy it next to the binary or set EvalFile in your GUI."

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,12 +1,51 @@
 #include "havoc/bitboard.hpp"
+#include "havoc/eval/nnue_evaluator.hpp"
 #include "havoc/kpk.hpp"
 #include "havoc/magics.hpp"
+#include "havoc/net_path.hpp"
 #include "havoc/search.hpp"
 #include "havoc/uci.hpp"
 #include "havoc/version.hpp"
 #include "havoc/zobrist.hpp"
 
 #include <iostream>
+#include <memory>
+
+namespace {
+
+/// Loads the network the binary was built to expect, if it can be found.
+///
+/// A missing network is not fatal -- the handcrafted evaluation still plays
+/// chess -- but it is worth complaining about, because the engine is far
+/// weaker without it and nothing else would say so. `EvalFile` overrides
+/// whatever happens here.
+void load_default_network(havoc::SearchEngine& engine) {
+    const auto name = havoc::net::default_net_name();
+    if (name.empty())
+        return;
+
+    const auto path = havoc::net::find_default_net();
+    if (!path) {
+        std::cout << "info string no network found (expected " << name
+                  << "), using the handcrafted evaluation, which is much weaker.\n"
+                  << "info string fetch it with scripts/nnue/fetch-net.sh, or set EvalFile."
+                  << std::endl;
+        return;
+    }
+
+    std::string err;
+    auto net = havoc::load_network_file(*path, err);
+    if (!net) {
+        std::cout << "info string " << err << ", using the handcrafted evaluation" << std::endl;
+        return;
+    }
+    engine.set_evaluator_factory([net](havoc::Searchthread&) {
+        return std::make_unique<havoc::NNUEEvaluator>(net);
+    });
+    std::cout << "info string Loaded network from " << *path << std::endl;
+}
+
+} // namespace
 
 int main() {
     std::cout << havoc::ENGINE_NAME << " v" << havoc::VERSION_STRING << std::endl;
@@ -18,6 +57,7 @@ int main() {
     havoc::kpk::init();
 
     havoc::SearchEngine engine;
+    load_default_network(engine);
     havoc::uci::loop(engine);
 
     return 0;

--- a/src/net_path.cpp
+++ b/src/net_path.cpp
@@ -1,0 +1,138 @@
+#include "havoc/net_path.hpp"
+
+#include <cstdlib>
+#include <filesystem>
+
+#if defined(_WIN32)
+#include <windows.h>
+#elif defined(__APPLE__)
+#include <mach-o/dyld.h>
+#include <vector>
+#else
+#include <unistd.h>
+#endif
+
+namespace havoc::net {
+namespace {
+
+/// Reads an environment variable, treating "set but empty" as unset. An empty
+/// value would otherwise turn into a path like "/nn-....nnue".
+std::optional<std::string> env(const char* key) {
+#if defined(_MSC_VER)
+    // getenv is deprecated under MSVC and _dupenv_s is the sanctioned form.
+    char* buf = nullptr;
+    size_t len = 0;
+    if (_dupenv_s(&buf, &len, key) != 0 || buf == nullptr)
+        return std::nullopt;
+    std::string value(buf);
+    free(buf);
+    if (value.empty())
+        return std::nullopt;
+    return value;
+#else
+    const char* raw = std::getenv(key);
+    if (raw == nullptr || *raw == '\0')
+        return std::nullopt;
+    return std::string(raw);
+#endif
+}
+
+} // namespace
+
+std::string_view default_net_name() {
+#if defined(HAVOC_DEFAULT_NET)
+    return HAVOC_DEFAULT_NET;
+#else
+    return {};
+#endif
+}
+
+std::string executable_dir() {
+    std::error_code ec;
+#if defined(_WIN32)
+    std::wstring buf(MAX_PATH, L'\0');
+    for (;;) {
+        const DWORD n = GetModuleFileNameW(nullptr, buf.data(), static_cast<DWORD>(buf.size()));
+        if (n == 0)
+            return {};
+        // Truncation is reported by filling the buffer exactly; grow and retry
+        // rather than silently using a clipped path.
+        if (n < buf.size()) {
+            buf.resize(n);
+            break;
+        }
+        if (buf.size() > 32768)
+            return {};
+        buf.resize(buf.size() * 2);
+    }
+    const std::filesystem::path exe(buf);
+#elif defined(__APPLE__)
+    std::uint32_t size = 0;
+    _NSGetExecutablePath(nullptr, &size); // asks for the required size
+    std::vector<char> buf(size + 1, '\0');
+    if (_NSGetExecutablePath(buf.data(), &size) != 0)
+        return {};
+    const std::filesystem::path exe(buf.data());
+#else
+    const std::filesystem::path link("/proc/self/exe");
+    const std::filesystem::path exe = std::filesystem::read_symlink(link, ec);
+    if (ec)
+        return {};
+#endif
+    const std::filesystem::path dir = std::filesystem::absolute(exe, ec).parent_path();
+    if (ec)
+        return {};
+    return dir.string();
+}
+
+std::vector<std::string> candidate_paths(std::string_view name) {
+    std::vector<std::string> out;
+    if (const auto explicit_file = env("HAVOC_EVAL_FILE"))
+        out.push_back(*explicit_file);
+
+    if (name.empty())
+        return out;
+
+    const std::filesystem::path leaf(name);
+    const auto push = [&out, &leaf](const std::filesystem::path& dir) {
+        if (dir.empty())
+            return;
+        out.push_back((dir / leaf).string());
+        out.push_back((dir / "nets" / leaf).string());
+    };
+
+    push(executable_dir());
+
+    std::error_code ec;
+    const std::filesystem::path cwd = std::filesystem::current_path(ec);
+    if (!ec)
+        push(cwd);
+
+    if (const auto dir = env("HAVOC_NET_DIR"))
+        out.push_back((std::filesystem::path(*dir) / leaf).string());
+
+    // Platform convention for per-user application data. This is where
+    // scripts/nnue/fetch-net.sh installs, so a fetched network is found by a
+    // binary anywhere on the system.
+#if defined(_WIN32)
+    if (const auto appdata = env("LOCALAPPDATA"))
+        out.push_back((std::filesystem::path(*appdata) / "havoc" / leaf).string());
+#else
+    if (const auto xdg = env("XDG_DATA_HOME"))
+        out.push_back((std::filesystem::path(*xdg) / "havoc" / leaf).string());
+    else if (const auto home = env("HOME"))
+        out.push_back((std::filesystem::path(*home) / ".local" / "share" / "havoc" / leaf).string());
+#endif
+    return out;
+}
+
+std::optional<std::string> find_default_net() {
+    std::error_code ec;
+    for (const auto& path : candidate_paths(default_net_name())) {
+        if (std::filesystem::is_regular_file(path, ec))
+            return path;
+    }
+    return std::nullopt;
+}
+
+} // namespace havoc::net

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -312,9 +312,15 @@ bool parse_command(const std::string& input, SearchEngine& engine, position& uci
             auto end_time = std::chrono::steady_clock::now();
             double ms = std::chrono::duration<double, std::milli>(end_time - start).count();
 
+            // The evaluation is named alongside the node count because the two
+            // are only meaningful together: the same search over the same
+            // positions visits a different number of nodes under the
+            // handcrafted evaluation than under a network, and CI has no
+            // network to load. An unlabelled bench number invites exactly the
+            // comparison that cannot legitimately be made.
             std::cout << "Bench: " << total_nodes << " nodes, " << static_cast<int>(ms) << " ms, "
                       << static_cast<U64>(static_cast<double>(total_nodes) * 1000.0 / ms)
-                      << " nps" << std::endl;
+                      << " nps, eval " << engine.evaluator_name(0) << std::endl;
         } else if (cmd == "exit" || cmd == "quit") {
             engine.stop();
             engine.wait();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ set(HAVOC_TEST_SOURCES
     test_nnue_features.cpp
     test_nnue_network.cpp
     test_nnue_evaluator.cpp
+    test_net_path.cpp
     test_search.cpp
     test_tablebase.cpp
 )

--- a/tests/test_net_path.cpp
+++ b/tests/test_net_path.cpp
@@ -1,0 +1,191 @@
+/// @file test_net_path.cpp
+/// @brief Where the engine looks for its network, and in what order.
+///
+/// The search order is the whole point of this module: an engine that finds
+/// the wrong network, or silently finds none, plays about 160 Elo below what
+/// the binary is capable of and says nothing useful about why. The order is
+/// therefore pinned by tests rather than left to whatever the implementation
+/// happens to do.
+///
+/// These tests only exercise path *construction* and existence checks. They
+/// deliberately do not load a network: the network is a 21 MB artifact that is
+/// not in the repository, so a test that needed one could not run in CI.
+
+#include "havoc/net_path.hpp"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+namespace {
+
+void set_env(const char* key, const char* value) {
+#if defined(_WIN32)
+    _putenv_s(key, value);
+#else
+    setenv(key, value, 1);
+#endif
+}
+
+void clear_env(const char* key) {
+#if defined(_WIN32)
+    _putenv_s(key, "");
+#else
+    unsetenv(key);
+#endif
+}
+
+/// Saves and restores every variable these tests touch, so that test order
+/// cannot leak state and so a failure part-way through does not poison the
+/// rest of the suite.
+class NetPathEnv : public ::testing::Test {
+protected:
+    void SetUp() override {
+        for (const char* key : keys_) {
+            if (const char* value = std::getenv(key))
+                saved_.emplace_back(key, value);
+            clear_env(key);
+        }
+    }
+    void TearDown() override {
+        for (const char* key : keys_)
+            clear_env(key);
+        for (const auto& [key, value] : saved_)
+            set_env(key.c_str(), value.c_str());
+        saved_.clear();
+    }
+    static constexpr const char* keys_[] = {"HAVOC_EVAL_FILE", "HAVOC_NET_DIR"};
+    std::vector<std::pair<std::string, std::string>> saved_;
+};
+
+bool contains(const std::vector<std::string>& haystack, const std::string& needle) {
+    return std::find(haystack.begin(), haystack.end(), needle) != haystack.end();
+}
+
+std::size_t index_of(const std::vector<std::string>& haystack, const std::string& needle) {
+    const auto it = std::find(haystack.begin(), haystack.end(), needle);
+    return static_cast<std::size_t>(std::distance(haystack.begin(), it));
+}
+
+} // namespace
+
+TEST_F(NetPathEnv, ExplicitOverrideIsTriedFirstAndUsedVerbatim) {
+    set_env("HAVOC_EVAL_FILE", "/some/where/custom.nnue");
+    const auto paths = havoc::net::candidate_paths("nn-000000000000.nnue");
+    ASSERT_FALSE(paths.empty());
+    // Verbatim: the override names a file, not a directory to search, so no
+    // network name is appended to it.
+    EXPECT_EQ(paths.front(), "/some/where/custom.nnue");
+}
+
+TEST_F(NetPathEnv, AnEmptyOverrideIsTreatedAsUnset) {
+    // "set but empty" is what an unset shell variable expands to in a script,
+    // and turning that into the path "/nn-....nnue" would be a confusing way
+    // to fail.
+    set_env("HAVOC_EVAL_FILE", "");
+    const auto paths = havoc::net::candidate_paths("nn-000000000000.nnue");
+    for (const auto& p : paths)
+        EXPECT_NE(p, "");
+    EXPECT_FALSE(contains(paths, std::string("nn-000000000000.nnue")));
+}
+
+TEST_F(NetPathEnv, WithoutANameOnlyTheExplicitOverrideIsOffered) {
+    // A build with HAVOC_DEFAULT_NET="" should not go hunting for files whose
+    // name it does not know.
+    EXPECT_TRUE(havoc::net::candidate_paths("").empty());
+    set_env("HAVOC_EVAL_FILE", "/x/y.nnue");
+    EXPECT_EQ(havoc::net::candidate_paths("").size(), 1u);
+}
+
+TEST_F(NetPathEnv, TheExecutableDirectoryIsSearchedBeforeTheWorkingDirectory) {
+    // A GUI can launch the engine from any working directory, so a network
+    // shipped next to the binary must win over an unrelated file that happens
+    // to share its name in the directory the GUI chose.
+    //
+    // The working directory is moved somewhere else for the duration: ctest
+    // runs the suite *from* the executable's directory, which would make the
+    // two candidates the same string and the comparison vacuous.
+    const std::string name = "nn-000000000000.nnue";
+    const std::filesystem::path exe_dir(havoc::net::executable_dir());
+    ASSERT_FALSE(exe_dir.empty()) << "executable_dir() must work on this platform";
+
+    const auto original = std::filesystem::current_path();
+    const auto elsewhere = std::filesystem::temp_directory_path();
+    ASSERT_NE(std::filesystem::canonical(elsewhere), std::filesystem::canonical(exe_dir))
+        << "test needs a working directory distinct from the executable's";
+    std::filesystem::current_path(elsewhere);
+
+    const auto paths = havoc::net::candidate_paths(name);
+    const std::string beside_exe = (exe_dir / name).string();
+    const std::string beside_cwd = (std::filesystem::current_path() / name).string();
+
+    std::filesystem::current_path(original);
+
+    ASSERT_TRUE(contains(paths, beside_exe));
+    ASSERT_TRUE(contains(paths, beside_cwd));
+    EXPECT_LT(index_of(paths, beside_exe), index_of(paths, beside_cwd));
+}
+
+TEST_F(NetPathEnv, ANetsSubdirectoryIsSearchedInBothPlaces) {
+    const std::string name = "nn-000000000000.nnue";
+    const auto paths = havoc::net::candidate_paths(name);
+    const std::filesystem::path exe_dir(havoc::net::executable_dir());
+    EXPECT_TRUE(contains(paths, (exe_dir / "nets" / name).string()));
+    EXPECT_TRUE(contains(paths, (std::filesystem::current_path() / "nets" / name).string()));
+}
+
+TEST_F(NetPathEnv, HavocNetDirIsHonoured) {
+    set_env("HAVOC_NET_DIR", "/opt/havoc-nets");
+    const std::string name = "nn-000000000000.nnue";
+    const auto paths = havoc::net::candidate_paths(name);
+    EXPECT_TRUE(contains(paths, (std::filesystem::path("/opt/havoc-nets") / name).string()));
+}
+
+TEST_F(NetPathEnv, ExecutableDirectoryIsAbsoluteAndReal) {
+    const std::string dir = havoc::net::executable_dir();
+    ASSERT_FALSE(dir.empty());
+    const std::filesystem::path p(dir);
+    EXPECT_TRUE(p.is_absolute());
+    EXPECT_TRUE(std::filesystem::is_directory(p));
+}
+
+TEST_F(NetPathEnv, MissingNetworkIsReportedRatherThanGuessed) {
+    // Nothing by this name exists anywhere, so discovery must decline instead
+    // of returning a path that does not resolve.
+    set_env("HAVOC_NET_DIR", "/nonexistent-havoc-net-dir");
+    const auto paths = havoc::net::candidate_paths("nn-ffffffffffff.nnue");
+    std::error_code ec;
+    for (const auto& p : paths)
+        ASSERT_FALSE(std::filesystem::is_regular_file(p, ec)) << p << " unexpectedly exists";
+}
+
+TEST_F(NetPathEnv, AnExistingFileIsFoundThroughTheOverride) {
+    const auto tmp = std::filesystem::temp_directory_path() / "havoc-net-path-test.nnue";
+    {
+        std::ofstream out(tmp, std::ios::binary);
+        out << "not a real network";
+    }
+    set_env("HAVOC_EVAL_FILE", tmp.string().c_str());
+    const auto found = havoc::net::find_default_net();
+    // find_default_net only consults the override when it exists on disk, and
+    // it does here, so it must be returned regardless of the built-in name.
+    ASSERT_TRUE(found.has_value());
+    EXPECT_EQ(*found, tmp.string());
+    std::filesystem::remove(tmp);
+}
+
+TEST_F(NetPathEnv, ADirectoryIsNotMistakenForANetwork) {
+    // is_regular_file, not exists: pointing EvalFile at a directory should
+    // fall through to the next candidate rather than trying to read it.
+    const auto dir = std::filesystem::temp_directory_path() / "havoc-net-path-dir";
+    std::filesystem::create_directories(dir);
+    set_env("HAVOC_EVAL_FILE", dir.string().c_str());
+    const auto found = havoc::net::find_default_net();
+    if (found)
+        EXPECT_NE(*found, dir.string());
+    std::filesystem::remove(dir);
+}


### PR DESCRIPTION
## Why

The engine shipped as a binary that used the **handcrafted evaluation unless someone set `EvalFile`**. For a release that is a bad default: the network is worth roughly 160 Elo, the fallback plays perfectly plausible chess, and nothing said which one was running. Anyone downloading v2.3 would get the weaker engine with no reason to suspect it.

This also answers the "how do other people get the nets, and how are they backed up" question, without git-lfs.

## What

**Startup discovery** (`include/havoc/net_path.hpp`, `src/net_path.cpp`). Search order, most specific first:

1. `$HAVOC_EVAL_FILE` — used verbatim
2. next to the binary, then `<binary dir>/nets/`
3. the working directory, then `./nets/`
4. `$HAVOC_NET_DIR`
5. `~/.local/share/havoc/` (`%LOCALAPPDATA%\havoc\` on Windows)

The executable's own directory is resolved per-platform (`/proc/self/exe`, `_NSGetExecutablePath`, `GetModuleFileNameW`) rather than from `argv[0]`, so it is right even when the engine is launched through `PATH` from an unrelated working directory — which is what a GUI does.

A missing network is **not** fatal; the engine complains and plays on. `EvalFile` overrides everything, `EvalFile none` still returns to the HCE.

**Content-addressed names.** `nn-<first 12 hex of sha256>.nnue`. The name *is* the integrity check, so there is no separate checksum to drift out of sync, two files with the same name are the same file, and a truncated download cannot keep the name it asked for.

**Publication.** A permanent GitHub release tagged [`nets`](https://github.com/mjglatzmaier/haVoc/releases/tag/nets), not tied to any engine version — any binary can fetch any network, and networks are only added, never replaced. git-lfs was rejected: it meters bandwidth on a public repo and its failure mode is handing clones pointer files the engine cannot load.

`scripts/nnue/fetch-net.sh` fetches, verifies against the filename, and installs onto the search path. With no arguments it reads the expected name out of `CMakeLists.txt`, so it always fetches the network matching the code you are about to build.

## Bench is now labelled

```
Bench: 728941 nodes, ..., eval NNUE     # with nn-69c7d05e4298.nnue
Bench: 709908 nodes, ..., eval HCE      # no network, e.g. CI
```

Both correct, not comparable. CI has no network so it reports the HCE figure while a developer's machine reports the NNUE one. An unlabelled number invites precisely that mistaken comparison — the same class of error as comparing nps measured under different load.

## Verification

- 219/219 tests pass. 10 new tests in `tests/test_net_path.cpp` pin the search order, the "set but empty" env case, the no-name build, and that a directory is not mistaken for a network.
- One of those tests initially failed *only* under `ctest`, which runs the suite from the executable's own directory and so made "beside the binary" and "beside the cwd" the same string. The test now moves the working directory so the assertion is real.
- Fetch verified end to end against the live release: download → checksum → install → auto-discovery from an unrelated directory. Corruption is detected and refetched; a malformed name is rejected.

## Note

`VERSION_MAJOR/MINOR/PATCH` in `version.hpp` say 2.1.0 while `VERSION_STRING` says "2.2.0". Left alone here; it will be fixed in the release packaging change.