### PR TITLE
Four search optimizations that cannot change the tree

### DIFF
--- a/include/havoc/move_order.hpp
+++ b/include/havoc/move_order.hpp
@@ -13,6 +13,7 @@
 #include <functional>
 #include <limits>
 #include <memory>
+#include <span>
 #include <vector>
 
 namespace havoc {
@@ -171,22 +172,22 @@ struct Movehistory {
     /// kMaxHistory or the table never leaves the neighbourhood of zero and
     /// every threshold read against it is dead.
     void update(const Color& c, const Move& m, const Move& previous, int bonus, int16_t eval,
-                const std::vector<Move>& quiets, Move* killers);
+                std::span<const Move> quiets, Move* killers);
 
     /// Penalty applied to every quiet move that was tried at a node which
     /// failed low. Without it the table only ever learns from beta cutoffs,
     /// where a mean of 0.34 quiets have been tried, so the negative side never
     /// develops and any threshold read against it is unreachable.
-    void malus(const Color& c, int bonus, const std::vector<Move>& quiets);
+    void malus(const Color& c, int bonus, std::span<const Move> quiets);
 
     /// Continuation history counterparts. `stack` is the node whose move loop
     /// produced the cutoff (or fail-low); it carries the predecessor context.
     /// `p` must be the position at that node, with every searched move undone,
     /// so that piece_on(from) still identifies the piece each quiet moved.
     void update_continuation(const position& p, const SearchNode* stack, const Move& best,
-                             int bonus, const std::vector<Move>& quiets);
+                             int bonus, std::span<const Move> quiets);
     void malus_continuation(const position& p, const SearchNode* stack, int bonus,
-                            const std::vector<Move>& quiets);
+                            std::span<const Move> quiets);
 
     void clear();
 
@@ -231,7 +232,7 @@ struct Movehistory {
     /// `p` must be the position at that node with every searched move undone,
     /// so that piece_on identifies both the moving and the captured piece.
     void update_capture(const position& p, const Move& best, int bonus,
-                        const std::vector<Move>& captures);
+                        std::span<const Move> captures);
 
     /// ─── Correction history ─────────────────────────────────────────────
     ///

--- a/include/havoc/search.hpp
+++ b/include/havoc/search.hpp
@@ -228,6 +228,9 @@ class SearchEngine {
     /// telling the evaluator, which would silently desynchronise it.
     void do_move(position& pos, const Move& m, int thread_id) {
         pos.do_move(m);
+        // The child will probe the table almost immediately; start the fetch
+        // now so the accumulator update below overlaps the memory latency.
+        tt_.prefetch_key(pos.key());
         if (search_threads_[thread_id]->wants_deltas())
             search_threads_[thread_id]->evaluator().push(pos, pos.delta());
     }

--- a/include/havoc/tt.hpp
+++ b/include/havoc/tt.hpp
@@ -142,9 +142,22 @@ struct hash_data {
 
 constexpr unsigned cluster_size = 4;
 
-struct hash_cluster {
+/// A cluster is exactly one cache line, and is aligned to one so that it
+/// actually occupies one. Four 16-byte entries come to 64 bytes, but the
+/// natural alignment of the atomics inside is only 8, so an unaligned array
+/// leaves roughly half of all clusters straddling a line boundary -- and every
+/// probe of such a cluster pulls in two lines instead of one, for no benefit.
+///
+/// `new[]` routes over-aligned types to the aligned allocation functions in
+/// C++17 and later, so `make_unique<hash_cluster[]>` honours this.
+struct alignas(64) hash_cluster {
     entry cluster_entries[cluster_size];
 };
+
+static_assert(sizeof(hash_cluster) == 64,
+              "a cluster is meant to be exactly one cache line; adding a field "
+              "to `entry` has made it something else");
+static_assert(alignof(hash_cluster) == 64, "clusters must be cache-line aligned");
 
 // ─── Hash table ─────────────────────────────────────────────────────────────
 
@@ -193,9 +206,20 @@ class hash_table {
     [[nodiscard]] size_t size_mb() const { return sz_mb_; }
     [[nodiscard]] int hashfull() const;
 
+    /// Warms the cache line this key will probe.
+    ///
+    /// Called right after a move is made, so the miss is paid while the child
+    /// is still computing whatever it computes before its first probe. The
+    /// prefetch that used to sit inside fetch() bought nothing: it was one
+    /// instruction ahead of the very load it was meant to hide, so the
+    /// hardware had no window to work in.
+    inline void prefetch_key(U64 key) {
+        if (entries_ != nullptr)
+            prefetch(first_entry(key));
+    }
+
     [[nodiscard]] inline entry* first_entry(U64 key) {
         return &entries_[key & (cluster_count_ - 1)].cluster_entries[0];
     }
 };
-
 } // namespace havoc

--- a/src/move_order.cpp
+++ b/src/move_order.cpp
@@ -68,7 +68,7 @@ int Movehistory::continuation_score(const position& p, const Move& m, const Sear
 }
 
 void Movehistory::update_continuation(const position& p, const SearchNode* stack, const Move& best,
-                                      int bonus, const std::vector<Move>& quiets) {
+                                      int bonus, std::span<const Move> quiets) {
     if (best.type != static_cast<U8>(Movetype::quiet))
         return;
     Color c = p.to_move();
@@ -87,7 +87,7 @@ void Movehistory::update_continuation(const position& p, const SearchNode* stack
 }
 
 void Movehistory::malus_continuation(const position& p, const SearchNode* stack, int bonus,
-                                     const std::vector<Move>& quiets) {
+                                     std::span<const Move> quiets) {
     Color c = p.to_move();
     for (int plane = 0; plane < 2; ++plane)
         for (const auto& q : quiets)
@@ -123,7 +123,7 @@ int Movehistory::capture_score(const position& p, const Move& m) const {
 }
 
 void Movehistory::update_capture(const position& p, const Move& best, int bonus,
-                                 const std::vector<Move>& captures) {
+                                 std::span<const Move> captures) {
     if (int16_t* h = capture_slot(p, best))
         apply_history_bonus(*h, bonus);
 
@@ -136,7 +136,7 @@ void Movehistory::update_capture(const position& p, const Move& best, int bonus,
 }
 
 void Movehistory::update(const Color& c, const Move& m, const Move& previous, int bonus,
-                         int16_t eval, const std::vector<Move>& quiets, Move* killers) {
+                         int16_t eval, std::span<const Move> quiets, Move* killers) {
     if (m.type == static_cast<U8>(Movetype::quiet)) {
         apply_history_bonus(history_[c][m.f][m.t], bonus);
         if (previous.type != static_cast<U8>(no_type)) {
@@ -165,7 +165,7 @@ void Movehistory::update(const Color& c, const Move& m, const Move& previous, in
     }
 }
 
-void Movehistory::malus(const Color& c, int bonus, const std::vector<Move>& quiets) {
+void Movehistory::malus(const Color& c, int bonus, std::span<const Move> quiets) {
     for (auto& q : quiets)
         apply_history_bonus(history_[c][q.f][q.t], -bonus);
 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -704,8 +704,19 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
     U8 tt_bound = static_cast<U8>(no_bound);
 
     bool in_check = pos.in_check();
-    std::vector<Move> quiets;
-    std::vector<Move> captures;
+    // Quiet and capture moves actually searched at this node, kept for the
+    // history updates below. These were std::vector, which put a malloc and a
+    // free on the path of essentially every interior node. The bound is the
+    // same 256 the move generator is capped at, so the counters cannot
+    // overflow: a node can never search more moves than can be generated.
+    Move quiets_buf[kMaxMoves];
+    Move captures_buf[kMaxMoves];
+    int quiets_n = 0;
+    int captures_n = 0;
+    const auto quiets = [&] { return std::span<const Move>(quiets_buf, static_cast<size_t>(quiets_n)); };
+    const auto captures = [&] {
+        return std::span<const Move>(captures_buf, static_cast<size_t>(captures_n));
+    };
     stack->in_check = in_check;
     stack->ply = (stack - 1)->ply + 1;
 
@@ -810,9 +821,9 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
                     // populates killers and countermoves at all -- nodes that
                     // return here never reach a move loop. Leave it.
                     thread_history(thread_id).update(pos.to_move(), ttm, (stack - 1)->curr_move,
-                                    history_bonus(depth), static_cast<int16_t>(ttvalue), quiets,
+                                    history_bonus(depth), static_cast<int16_t>(ttvalue), quiets(),
                                     stack->killers);
-                    thread_history(thread_id).update_continuation(pos, stack, ttm, history_bonus(depth), quiets);
+                    thread_history(thread_id).update_continuation(pos, stack, ttm, history_bonus(depth), quiets());
                     // The capture table, unlike the quiet ones above, is only
                     // allowed to learn here from a genuine fail-high. The
                     // asymmetry is not an oversight and it is not small: with
@@ -846,7 +857,7 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
                     // the only evidence this table wants.
                     if (e.bound == bound_low && ttvalue >= beta)
                         thread_history(thread_id).update_capture(pos, ttm, history_bonus(depth),
-                                                                 captures);
+                                                                 captures());
                     return ttvalue;
                 }
             }
@@ -908,8 +919,6 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
 
     // Static evaluation
     const bool anyPawnsOn7th = pos.pawns_near_promotion();
-    const bool weHavePawnsOn7th = pos.pawns_on_7th();
-    (void)weHavePawnsOn7th;
 
     int16_t static_eval_val;
     if (in_check) {
@@ -1417,9 +1426,9 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
         ++moves_searched;
 
         if (move.type == static_cast<U8>(Movetype::quiet))
-            quiets.emplace_back(move);
+            quiets_buf[quiets_n++] = move;
         else if (is_capture(static_cast<Movetype>(move.type)))
-            captures.emplace_back(move);
+            captures_buf[captures_n++] = move;
 
         undo_move(pos, move, thread_id);
 
@@ -1453,11 +1462,11 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
 
             if (score_val >= beta) {
                 thread_history(thread_id).update(pos.to_move(), best_move, (stack - 1)->curr_move,
-                                history_bonus(depth), static_cast<int16_t>(bestScore), quiets,
+                                history_bonus(depth), static_cast<int16_t>(bestScore), quiets(),
                                 stack->killers);
-                thread_history(thread_id).update_continuation(pos, stack, best_move, history_bonus(depth), quiets);
+                thread_history(thread_id).update_continuation(pos, stack, best_move, history_bonus(depth), quiets());
                 thread_history(thread_id).update_capture(pos, best_move, history_bonus(depth),
-                                                         captures);
+                                                         captures());
                 break;
             }
 
@@ -1481,10 +1490,10 @@ int SearchEngine::search(position& pos, int alpha, int beta, U16 depth, SearchNo
     // because history_malus_pct is 0, which makes the malus itself 0 -- so the
     // first thing an SPSA fit does when it raises that parameter is corrupt the
     // continuation tables at every cutoff node in the search.
-    if (bestScore <= alpha_orig && !quiets.empty()) {
+    if (bestScore <= alpha_orig && quiets_n > 0) {
         const int malus = history_bonus(depth) * params_.history_malus_pct / 100;
-        thread_history(thread_id).malus(to_mv, malus, quiets);
-        thread_history(thread_id).malus_continuation(pos, stack, malus, quiets);
+        thread_history(thread_id).malus(to_mv, malus, quiets());
+        thread_history(thread_id).malus_continuation(pos, stack, malus, quiets());
     }
 
     // Best move bonus

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -72,7 +72,6 @@ void hash_table::clear() {
 
 bool hash_table::fetch(U64 key, hash_data& e) {
     entry* stored = first_entry(key);
-    prefetch(stored);
 
     for (unsigned i = 0; i < cluster_size; ++i, ++stored) {
         const U64 p = stored->pk();


### PR DESCRIPTION
Part of the v2.3 release optimization pass. Strictly search-side; nothing here touches the evaluation.

Every change **preserves bench exactly — 709908 nodes, HCE**, verified over repeated runs. That is deliberate: none of them alter the search tree, so they require a speed measurement rather than an SPRT.

## 1. Per-node heap allocation

`src/search.cpp` opened every interior node with

```cpp
std::vector<Move> quiets;
std::vector<Move> captures;
```

which puts a `malloc`/`free` pair on the path of essentially every node in the search. They are now fixed arrays bounded by `kMaxMoves` — the same 256 the move generator is capped at, so the counters provably cannot overflow: a node cannot search more moves than can be generated. The five history consumers take `std::span<const Move>` instead of `const std::vector<Move>&`.

## 2. Transposition table cluster alignment

`hash_cluster` is four 16-byte entries, exactly 64 bytes — but the `std::atomic<U64>` members only require 8-byte alignment, so the array was 8-aligned and roughly **half of all clusters straddled a cache line boundary**. Each probe of a straddling cluster touches two lines instead of one.

Now `alignas(64)`, with `static_assert`s pinning both size and alignment, so adding a field to `entry` fails the build instead of silently reintroducing the straddle.

## 3. Prefetch placement

The prefetch inside `fetch()` sat one instruction ahead of the very load it was meant to hide, which gives the hardware no window to work in. It now happens just after `do_move`, where the child's key is known and the accumulator update provides real work to overlap the memory latency with.

## 4. Dead computation

`pos.pawns_on_7th()` was called at every node, assigned, cast to `void`, and never read.

## Verification

- 209/209 tests pass.
- Bench identical at 709908 across repeated runs and across all four changes.
- **nps not yet measured.** The box is running a 24-way SPSA tune, and this morning demonstrated how badly a loaded machine corrupts an nps reading — the same net measured 725k under load and 1.69M quiet. The measurement will be taken on a quiet box before this is considered done, and posted here.

## Not included

From the same analysis, deliberately deferred:

- **Split `is_legal`** into a cheap path for generated (already pseudo-legal) moves and full validation for untrusted TT/killer moves. Highest estimated win, but it must reproduce the accept/reject set exactly, move type by move type.
- **Cache SEE** so qsearch does not recompute it per capture. The capture list is already partitioned at the `see<0` boundary — the scoring constants make `sign(score) == sign(see)` exact — but the phase a move came from is not observable, and killer/hash moves in qsearch bypass the capture list.
- **Lazy quiet selection** instead of the eager insertion sort, given the mean cutoff node tries 0.34 quiets. This one **can move bench** unless selection picks the earliest maximum.