### PR TITLE
Adopt the SPSA-tuned search parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,14 @@ unaware of which is in use. Training and data-generation details are in
 
 - **The search is capped at 64 plies** (`MAX_PLY`). Ten seconds already reaches
   ply 29.
+- **The search constants are tuned for the network, not for the handcrafted
+  evaluation.** Several are margins compared against a static evaluation in
+  centipawns, and the two evaluators do not produce centipawns with the same
+  distribution, so `EvalFile none` now runs on margins calibrated for something
+  else — it searches ~45% more nodes for the same bench and measures -16.5 Elo
+  against its own older settings, while the network gains +10.4. The handcrafted
+  evaluation is kept as provenance rather than as a playing configuration; for
+  a handcrafted-only engine, take the parameters from commit `158e544`.
 - **Search parameters are tuned below their own resolution.** SPSA at 32 games
   an iteration cannot resolve anything below ~8–10 Elo per parameter, which is
   why recent tunes move one parameter and leave the rest untouched. Fixed-node

--- a/docs/nnue-integration.md
+++ b/docs/nnue-integration.md
@@ -369,7 +369,9 @@ board.
   suit it, with `forward_reference` kept as the definition it is checked
   against.
 
-The HCE path is untouched: `bench` is 709908 with and without the branch.
+The HCE path is untouched by that branch: `bench` was 709908 with and without
+it. (Both bench figures moved later, when the search constants were retuned
+against the network; see `include/havoc/parameters.hpp`.)
 
 ### Correctness, and what each check can actually see
 

--- a/include/havoc/parameters.hpp
+++ b/include/havoc/parameters.hpp
@@ -421,20 +421,37 @@ struct parameters {
     // position is worth. They can only be tuned against game results, which
     // is what SPSA is for. They live here so the tuner and the ParamFile
     // machinery can reach them; search.cpp reads them through params_.
+    //
+    // These values were tuned against the NNUE evaluation and are specific to
+    // it. Several are margins compared against a static evaluation in
+    // centipawns, and the two evaluators do not produce the same distribution
+    // of centipawns, so a margin that is well placed for one is not for the
+    // other. Running them on the handcrafted evaluation costs it ~45% more
+    // nodes for the same bench, because reverse futility pruning fires far
+    // less often than it was calibrated to, and measures -16.5 Elo (95% CI
+    // -41.8 to +8.7, 400 games at 10+0.1) against the same evaluation on the
+    // values below. The network gains +10.4 Elo from the same change.
+    //
+    // That is accepted rather than fixed: the engine ships with a network and
+    // the handcrafted evaluation is kept as provenance, not as a playing
+    // configuration. Anyone who wants a handcrafted-only engine should take
+    // the values from commit 158e5445a25c95254063d8d566a5ef5a399964c5, the
+    // last one whose defaults were tuned against it. Making the margins
+    // evaluation-dependent is the real repair; see search-retune-nnue-2.
     int double_ext_margin = 24;     // singular by more than this extends twice
     int max_double_ext = 6;         // ...but at most this many times on a path
-    int rfp_max_depth = 6;          // reverse futility only below this depth
-    int rfp_margin = 80;            // ...and only if eval - margin*depth >= beta
+    int rfp_max_depth = 4;          // reverse futility only below this depth
+    int rfp_margin = 87;            // ...and only if eval - margin*depth >= beta
     int razor_max_depth = 3;        // razoring only below this depth
     int razor_base = 300;           // ...and only if eval + base + margin*depth <= alpha
     int razor_margin = 400;
     int nmp_min_depth = 3;          // null move needs at least this much depth
     int nmp_base_r = 3;             // base null-move reduction
     int nmp_depth_div = 6;          // extra reduction of depth/this
-    int nmp_eval_div = 200;         // extra reduction of (eval-beta)/this
+    int nmp_eval_div = 217;         // extra reduction of (eval-beta)/this
     int nmp_eval_max = 3;           // ...capped here
-    int futility_base = 6;          // (base + depth^2) / (2 - improving)
-    int fp_max_depth = 6;           // forward futility pruning of quiets below this depth
+    int futility_base = 7;          // (base + depth^2) / (2 - improving)
+    int fp_max_depth = 7;           // forward futility pruning of quiets below this depth
     int fp_base = 100;              // ...prune when eval + base + margin*depth <= alpha
     int fp_margin = 90;
     int history_prune_depth = 3;    // history pruning only below this depth

--- a/scripts/nnue/README.md
+++ b/scripts/nnue/README.md
@@ -128,8 +128,8 @@ Because `bench` node counts differ between evaluations, the bench line names
 the evaluation it used. Do not compare across them:
 
 ```
-Bench: 728941 nodes, ..., eval NNUE     # with havoc-69c7d05e4298.nnue
-Bench: 709908 nodes, ..., eval HCE      # no network, e.g. in CI
+Bench: 776644 nodes, ..., eval NNUE      # with havoc-69c7d05e4298.nnue
+Bench: 1028826 nodes, ..., eval HCE      # no network, e.g. in CI
 ```
 
 ## Notes


### PR DESCRIPTION
Five constants move: `rfp_margin` 80→87, `rfp_max_depth` 6→4, `nmp_eval_div` 200→217, `futility_base` 6→7, `fp_max_depth` 6→7. The other four the tune touched stayed within random-walk distance of their starting values.

## Measurement

**+10.4 Elo, 95% CI [−0.7, +21.5], 2000 games at 10+0.1**, against the same binary running the old values via `ParamFile`.

The SPRT **did not formally conclude** — LLR reached 1.23 of the ±2.94 needed, and would want ~4,800 games at this effect size. Shipping anyway is a judgement call: the interval's lower bound is −0.7, so the realistic worst case is approximately nothing, against an expected +10.4 and a 96.7% posterior that the effect is positive.

The point estimate decayed as games accumulated — **+14.2 at 490, +13.6 at 1205, +10.4 at 2000** — which is what a modest real effect looks like once early noise washes out. My stated prediction before the run was −5 to +10, so this landed on the top edge of it.

The tune itself showed no learning signal: mean score 0.4997 across 240 iterations, last third (0.4912) *worse* than the first (0.5070), and only `rfp_max_depth` moved beyond random-walk expectation. The gain appears to come almost entirely from that one parameter.

## The values are specific to the network

Several of these are margins compared against a static evaluation **in centipawns**, and the two evaluators do not produce centipawns with the same distribution. A margin well placed for one is misplaced for the other.

On the handcrafted evaluation these settings search **~45% more nodes** for the same bench — reverse futility pruning fires far less often than it was calibrated to — and measure **−16.5 Elo (95% CI −41.8 to +8.7, 400 games)** against the values they replace. The same change is worth +10.4 to the network and −16.5 to HCE.

That trade is taken deliberately rather than repaired here. The engine ships with a network, and the handcrafted evaluation is kept as provenance rather than as a playing configuration. Commit `158e5445a25c95254063d8d566a5ef5a399964c5` is pinned in `parameters.hpp` and the README as the last revision whose defaults were tuned against it, so a handcrafted-only build can restore them in one step. Making the margins evaluation-dependent is the real fix, filed as `search-retune-nnue-2`.

## Verification

Compiled defaults reproduce the `ParamFile` bench **exactly** (776644), the check the harness docs ask for. Bench: **776644 NNUE, 1028826 HCE**; docs quoting the old figures updated. 219/219 tests, 3031 fuzz cases, TSan clean on 6 concurrency cases, seq-nodes determinism check identical, adversarial `SyzygyPath` survived.