### PR TITLE
Add Senpai 1.0 as the top gauntlet anchor

### DIFF
--- a/scripts/testing/anchor_rating.py
+++ b/scripts/testing/anchor_rating.py
@@ -33,6 +33,7 @@ ANCHORS = {
     "phalanx24": (2521, 887),
     "fruit":     (2694, 505),
     "glaurung":  (2793, 1396),
+    "senpai":    (2985, 2072),
 }
 
 # Deliberately excluded, with the reason, so nobody re-adds them.

--- a/scripts/testing/fetch-anchors.sh
+++ b/scripts/testing/fetch-anchors.sh
@@ -37,7 +37,7 @@ for a in "$@"; do
 done
 
 WANT=("${ARGS[@]:-}")
-[ -z "${WANT[0]:-}" ] && WANT=(fruit glaurung arasan phalanx zurichess)
+[ -z "${WANT[0]:-}" ] && WANT=(fruit glaurung arasan phalanx zurichess senpai)
 
 mkdir -p "$REFENGINES"
 LOG="$REFENGINES/build.log"
@@ -90,6 +90,26 @@ record() { RESULTS+=("$1"); echo "  $1"; }
 # Fruit 2.1 -- CCRL 40/40 2694. Original host (wbec-ridderkerk.nl) is dead;
 # this is a mirror of the unmodified 2005 distribution.
 # --------------------------------------------------------------------------
+# --------------------------------------------------------------------------
+# Senpai 1.0 -- CCRL 40/40 2985 (64-bit, 1 CPU, 2072 games). The top anchor:
+# without something above ~2900 the rating fit is extrapolating past its
+# highest anchor, which is what invalidated every pre-2582 row in
+# docs/ratings.md. Ships as a single translation unit, so no Makefile.
+# --------------------------------------------------------------------------
+build_senpai() {
+    local d="$REFENGINES/senpai-1.0" bin="$REFENGINES/senpai-1.0/senpai"
+    [ -x "$bin" ] && [ "$FORCE" = 0 ] && { record "senpai     skip (already built)"; return; }
+    echo "senpai 1.0..."
+    [ -d "$d" ] || run git clone --quiet https://github.com/rwbc/Senpai-1.0.git "$d" || {
+        record "senpai     FAILED (clone)"; return; }
+    # The source #defines NDEBUG itself, so passing -DNDEBUG here is a
+    # redefinition warning, not an error. Left off to keep the build quiet.
+    if ! run g++ -O2 -std=c++14 -pthread -o "$bin" "$d/Source/senpai_10.cpp"; then
+        record "senpai     FAILED (build)"; return
+    fi
+    verify_uci "$bin" "senpai" && record "senpai     OK" || record "senpai     FAILED (no uciok)"
+}
+
 build_fruit() {
     local d="$REFENGINES/fruit-2.1" bin="$REFENGINES/fruit-2.1/src/fruit"
     [ -x "$bin" ] && [ "$FORCE" = 0 ] && { record "fruit      skip (already built)"; return; }
@@ -265,6 +285,7 @@ want glaurung  && build_glaurung
 want arasan    && build_arasan
 want phalanx   && build_phalanx
 want zurichess && build_zurichess
+want senpai    && build_senpai
 
 echo
 echo "summary:"

--- a/scripts/testing/gauntlet-anchors.sh
+++ b/scripts/testing/gauntlet-anchors.sh
@@ -34,6 +34,7 @@
 #   Phalanx XXIV                   2521     887     17
 #   Fruit 2.1                      2694     505     21
 #   Glaurung 2.2 64-bit            2793    1396     13
+#   Senpai 1.0 64-bit              2985    2072     10
 #
 # CCRL 40/40 is far slower than the blitz TC used here, and older engines tend
 # to look relatively stronger at long TC, so a systematic offset sits on top of
@@ -87,6 +88,8 @@ add_anchor "$R/fruit-2.1/src/fruit"              name=fruit     proto=uci \
            option.OwnBook=false
 add_anchor "$R/glaurung-2.2/src/glaurung"        name=glaurung  proto=uci \
            option.Threads=1 option.Ponder=false option.OwnBook=false
+add_anchor "$R/senpai-1.0/senpai"                name=senpai    proto=uci \
+           option.Threads=1 option.Ponder=false
 
 if [ "${#FOUND[@]}" -lt 2 ]; then
     echo "error: fewer than two anchors found under REFENGINES=$R" >&2


### PR DESCRIPTION
Restores headroom above the candidate so the rating fit interpolates rather than extrapolates.

- `fetch-anchors.sh`: `build_senpai`, verified to reproduce from scratch into a clean `REFENGINES` (builds, answers `uci`, and returns `bestmove e2e4` on a real search).
- `gauntlet-anchors.sh`: forces `Threads=1` and `Ponder=false` explicitly even though Senpai already defaults that way, per the note in that file about a 300-game run invalidated by unforced defaults.
- `anchor_rating.py`: registers 2985 / 2072 games.

Anchor spread is now 2412 / 2505 / 2521 / 2694 / 2793 / 2985, bracketing the ~2690 projection on both sides.