### PR TITLE
Record the v2.3 gauntlet result: 2834 ±12

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,16 @@ way to show where its network came from.
 
 | Version | Evaluation | Rating | Games | Measured |
 |---|---|---|---|---|
-| v2.3 | NNUE, L1=256 | *pending gauntlet* | — | — |
+| v2.3 | NNUE, L1=256 | **2834** ±12 | 1200 | 2026-08-17 |
 | v2.2 | handcrafted | **2582** ±12 | 1000 | 2026-08-16 |
 
-Estimated on the CCRL 40/40 scale against five anchors. Treat the uncertainty
-as roughly ±50 rather than the ±12 the fit reports — it is statistical only,
-and the games are played at blitz against ratings established at 40/40. The
-per-change SPRTs are the trustworthy measurements; this table is a periodic
-check that the engine has not drifted away from the field. Method, per-anchor
-results and superseded measurements are in [`docs/ratings.md`](docs/ratings.md).
+Estimated on the CCRL 40/40 scale against six anchors spanning 2412–2985.
+Treat the uncertainty as roughly ±50 rather than the ±12 the fit reports — it
+is statistical only, and the games are played at blitz against ratings
+established at 40/40. The per-change SPRTs are the trustworthy measurements;
+this table is a periodic check that the engine has not drifted away from the
+field. Method, per-anchor results and superseded measurements are in
+[`docs/ratings.md`](docs/ratings.md).
 
 ## Building
 

--- a/docs/plan-to-3000.md
+++ b/docs/plan-to-3000.md
@@ -1,8 +1,9 @@
 # Plan to 3000
 
-Written 2026-08-17, at an estimated ~2690 on the CCRL 40/40 scale. This is the
-argument for how the engine gets to 3000+, in what order, and why the order is
-that way rather than the more tempting one.
+Written 2026-08-17, revised the same day once the gauntlet came in at **2834
+±12** on the CCRL 40/40 scale. This is the argument for how the engine gets to
+3000+, in what order, and why the order is that way rather than the more
+tempting one.
 
 The short version: **3000 does not require an overhaul.** It requires collecting
 Elo that is already identified and quantified, in an order that keeps the
@@ -13,8 +14,8 @@ ideas are worth doing and should be done *last*, for reasons given below.
 
 | | |
 |---|---|
-| Estimated rating | ~2690 (see §2 for how this is derived; not yet measured) |
-| Last measured rating | 2582 ±12 fit, handcrafted evaluation, 1000 games, 2026-08-16 |
+| Measured rating | **2834 ±12** fit, NNUE L1=256, 1200 games, 6 anchors, 2026-08-17 |
+| Previous | 2582 ±12 fit, handcrafted evaluation, 1000 games, 2026-08-16 |
 | Evaluation | HalfKP 40960→256×2→32→32→1, int8/int16, AVX2 |
 | Corpus | 28.9M self-play positions, training iteration 4 |
 | Speed | ~1.83M nps single-threaded with NNUE |
@@ -24,19 +25,22 @@ the same range as engines rated several hundred points higher, and it is *not*
 the bottleneck. That is the usual reason people conclude an engine needs
 rewriting, and it does not apply here.
 
-## 2. The estimate, and why it is not the naive sum
+## 2. The estimate, and why the naive sum won
+
+This section originally argued that the naive sum of self-play SPRT gains was
+badly inflated. The gauntlet has since been run, so the argument can be scored
+instead of asserted, and **it lost**.
 
 Since the 2582 gauntlet, the SPRT-measured gains sum to roughly +261 Elo:
 +93.6 ±19.2 for the first net over the handcrafted evaluation at fixed depth 8,
 +106.8 ±18.3 for the net-labelled d8 arm, +60.8 ±22.0 for iteration 4. Adding
-those to 2582 gives 2843, and that number should not be believed.
+those to 2582 gives 2843.
 
-Three inflations sit in it:
+Three reasons were given for discounting it:
 
 - **Self-play overstates.** Every one of those figures is haVoc against haVoc:
   same search, same book, same blind spots. A change exploiting a weakness both
-  sides share reads far larger than a foreign field will score it. Transfer is
-  typically 50–75%.
+  sides share reads larger than a foreign field will score it.
 - **Elo does not add across moving baselines.** Compounding assumes
   transitivity, and this engine is measurably non-transitive: Arasan and Phalanx
   are rated 16 points apart and disagree by ~100 Elo about us.
@@ -44,14 +48,29 @@ Three inflations sit in it:
   without charging the speed it costs. The honest time-control number for that
   first step is +75.9 ±18.9 at 10+0.1, not +93.6.
 
-The defensible chain, all at time control: +75.9 (iteration 3 over handcrafted)
-+60.8 (iteration 4 over iteration 3) ≈ **+137 self-play**, plus 5–10 from the
-+9.8% nps in #158. Call it +145–160. At a 0.6–0.75 transfer factor that is
-**+90 to +115**, giving **~2690, 80% interval 2640–2740**.
+That produced a "defensible chain" of ≈+137 self-play, discounted by a 0.6–0.75
+transfer factor to +90–115, giving **~2690, 80% interval 2640–2740**.
+
+The measurement, on the same five anchors as the 2582 run: **2834 ±14, a gain
+of +252.** The naive sum was off by 9 Elo. The careful correction was off by
+144, and outside its own 80% interval.
+
+The three effects above are all real. The error was applying a numeric discount
+for them with nothing calibrating its size — a plausible story standing in for
+a measurement, worth −144 Elo of pessimism. Whatever offsets those effects
+create, they evidently cancel against something in this range (most likely the
+blitz time control used here, which favours the modern engine against anchors
+rated at 40/40).
+
+**Working rule until contradicted:** treat the sum of self-play SPRT gains as an
+unbiased predictor of gauntlet movement, and do not discount it again without
+calibration data. This rests on one paired observation, so the next gauntlet is
+a genuine test of it rather than a formality.
 
 ## 3. The Elo budget to 3000
 
-+310 is needed. The identified levers:
+At a measured 2834, **+166 is needed**, not the +310 this section was written
+against. The identified levers:
 
 | lever | estimate | confidence |
 |---|---|---|
@@ -60,8 +79,16 @@ The defensible chain, all at time control: +75.9 (iteration 3 over handcrafted)
 | Search tuning with adequate statistical power | +30 to +50 | high |
 | Search refinement: LMR terms, pruning, time management | +40 to +70 | medium |
 
-Sum: +250 to +390. It brackets the +310 required, without any entry that
-depends on a novel idea working.
+Sum: +250 to +390, against +166 required. The budget now has roughly a factor
+of two of headroom rather than bracketing the target, which means 3000 no
+longer depends on every lever paying out near the top of its range — and that
+the first two levers alone would do it.
+
+Two cautions against reading that as "3000 is easy". The gauntlet number
+carries a systematic uncertainty of about ±50 that the ±12 does not express, so
+the true starting point may be nearer 2790. And Elo gets harder to buy as it
+accumulates: these estimates were sized against a 2690 engine, and the same
+work is worth less at 2834.
 
 **The strongest single signal is that the network is nowhere near its
 plateau.** It is only training iteration 4, on 28.9M positions, where modern
@@ -200,14 +227,19 @@ Listed so that they can be checked rather than discovered.
   its own artifacts, and that would only become visible after two or three more
   iterations. If it happens, that lever could be worth half the estimate. This
   is the single assumption most likely to break.
-- **The transfer factor is a rule of thumb, not a measurement.** 0.6–0.75 is
-  conventional wisdom. The gauntlet will test it directly, and if the v2.3 result
-  lands far outside 2640–2740 then the method of estimating from self-play
-  chains is itself suspect and should be recalibrated before being used again.
-- **The anchor set no longer brackets the engine.** At ~2690 we sit above four
-  of five anchors, which puts the fit back into extrapolation — the exact defect
-  that made every pre-2582 rating untrustworthy. Anchors above 2750 must be
-  added before the next gauntlet or its number will carry a known flaw.
+- **The transfer factor was a rule of thumb, and it was wrong.** *Settled by the
+  v2.3 gauntlet.* The 0.6–0.75 discount predicted 2690; the measurement was
+  2834, outside the stated interval, while the undiscounted sum was accurate to
+  9 Elo. See §2. The replacement working rule — self-play SPRT sums are
+  unbiased — rests on a single paired observation and is itself now the
+  assumption to check at the next gauntlet.
+- **The anchor set no longer bracketed the engine.** *Addressed.* Senpai 1.0
+  (2985) was added before the v2.3 run, so the fit interpolated rather than
+  extrapolated. At 2834 this is already tightening again: only one anchor is
+  above the engine, and the next gauntlet needs something near 3000–3100 to
+  keep the bracket. Under the previous five-anchor set the v2.3 number would
+  have carried the same known flaw that made every pre-2582 rating
+  untrustworthy.
 - **Architecture gains assume the speed problem is solvable.** If Stage C fails
   its gate, +80 to +120 becomes perhaps +30, and 3000 moves out by an iteration
   or two rather than becoming unreachable.

--- a/docs/ratings.md
+++ b/docs/ratings.md
@@ -37,6 +37,74 @@ exactly what happens below.
 the engine is extrapolating. This is the single largest source of error in the
 older measurements.
 
+## 2026-08-17, NNUE L1=256, 2834 ±12, 1200 games
+
+Six anchors, 20+0.2, one thread, 64 MB hash, `OwnBook` and `Ponder` forced
+off. Two games out of 1200 ended on time (0.17%) and none crashed or played
+an illegal move, so the spread below is a property of the anchors, not of
+corrupted results.
+
+| anchor | published | haVoc score | implies |
+|---|---|---|---|
+| Zurichess Fribourg | 2412 | 88.0% | 2758 |
+| Arasan 12.2 | 2505 | 88.0% | 2851 |
+| Phalanx XXIV | 2521 | 80.2% | 2764 |
+| Fruit 2.1 | 2694 | 76.2% | 2896 |
+| Glaurung 2.2 | 2793 | 59.2% | 2858 |
+| Senpai 1.0 | 2985 | 29.8% | 2836 |
+
+Senpai 1.0 was added for this run. The previous set topped out at Glaurung
+2793; at this strength a fit against it would have been extrapolating past its
+highest anchor, which is the defect that invalidated every superseded row
+below.
+
+The analyser warns that the 139-point spread exceeds its threshold, and the
+warning is correct, but it does not threaten the central value. Every
+defensible subset agrees:
+
+| subset | estimate |
+|---|---|
+| all six | 2834 ±12 |
+| excluding Arasan (the outlier in the 2582 run too) | 2832 ±13 |
+| only anchors scored between 25% and 75%, where the logistic model is least saturated | 2848 ±18 |
+
+The disagreement is between the anchors' published ratings, not about where
+haVoc sits. Zurichess and Arasan yield identical 88.0% scores while their
+published ratings differ by 93 points, so at least one of those two figures
+does not describe the binary built here. Arasan implied high in the 2582 run
+as well, which points at the Arasan build rather than at anything that moved
+this time.
+
+### The prediction was wrong, and the naive method beat the careful one
+
+Before the run two estimates were on record:
+
+| method | prediction | error |
+|---|---|---|
+| naive sum of self-play SPRT gains, 2582 + 261 | 2843 | **+9** |
+| discounting those gains by a 0.6–0.75 "transfer factor" | 2690 | **−144** |
+
+Restricting the new fit to the same five anchors used for the 2582 run, to
+compare like with like, gives 2834 ±14, so the measured gain is **+252**
+against the +261 the self-play SPRTs claimed.
+
+The reasoning behind the discount was that self-play overstates gains, that
+Elo is not additive across a moving baseline, and that fixed-depth results do
+not transfer to time control. Each of those effects is real. The conclusion
+drawn from them was still wrong, because the correction was applied with no
+calibration data — it substituted a plausible story for a measurement and
+happened to be worth −144 Elo of pessimism.
+
+For now, treat the sum of self-play SPRT gains as an *unbiased* predictor of
+gauntlet movement in this rating range, and do not discount it again without
+evidence. One paired data point is thin, so the next gauntlet is a direct test:
+if the naive sum is accurate a second time, this stops being a coincidence.
+
+A caveat that cuts the other way: these games are blitz while the anchor
+ratings come from 40/40, and older engines generally gain relative strength at
+long time control. That systematic offset is not in the ±12 and is the reason
+the README quotes ±50.
+
 ## 2026-08-16, handcrafted evaluation, 2582 ±12, 1000 games
 
 Per-anchor results, which are more informative than the pooled number:


### PR DESCRIPTION
1200 games, 20+0.2, one thread, six anchors (2412–2985). Clean run: 2 time losses in 1200, no crashes or illegal moves.

| anchor | published | score | implies |
|---|---|---|---|
| Zurichess | 2412 | 88.0% | 2758 |
| Arasan 12.2 | 2505 | 88.0% | 2851 |
| Phalanx XXIV | 2521 | 80.2% | 2764 |
| Fruit 2.1 | 2694 | 76.2% | 2896 |
| Glaurung 2.2 | 2793 | 59.2% | 2858 |
| Senpai 1.0 | 2985 | 29.8% | 2836 |

The spread warning fires and is correct, but the value is robust: all six 2834, excluding Arasan 2832, well-resolved anchors only 2848.

**The prediction I put on record was wrong.** I estimated ~2690 (80% interval 2640–2740) and specifically argued the naive sum of self-play SPRTs (2843) was too optimistic. Same-five-anchor measurement: 2834. Naive sum off by 9; my correction off by 144. Documented in `docs/ratings.md` and `docs/plan-to-3000.md` §2 rather than quietly dropped.