### PR TITLE
ci: stop a slow apt mirror from stalling the whole run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,24 +31,62 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} / ${{ matrix.compiler }}
+    # Without this a hung step runs until GitHub's 6-hour default.
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@v4
 
-      # Install newer compilers on Ubuntu
+      # These installs are the only network-dependent steps in the job and they
+      # have hung for 25+ minutes twice, once on apt.llvm.org and once on plain
+      # apt, blocking every other check on the PR. A hang is far more common
+      # than a genuine failure, so: skip the work when the runner image already
+      # ships the compiler, retry a few times, and cap the step so a stuck
+      # mirror fails in minutes instead of stalling the run.
       - name: Install GCC 13 (Ubuntu)
         if: matrix.os == 'ubuntu-latest' && matrix.compiler == 'gcc'
+        timeout-minutes: 10
         run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-13 g++-13
+          set -u
+          if command -v g++-13 >/dev/null 2>&1; then
+            echo "g++-13 already present: $(g++-13 --version | head -1)"
+            exit 0
+          fi
+          for attempt in 1 2 3; do
+            echo "::group::apt attempt $attempt"
+            if sudo apt-get update && sudo apt-get install -y gcc-13 g++-13; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            sleep 15
+          done
+          echo "gcc-13 install failed after 3 attempts"
+          exit 1
 
       - name: Install Clang 17 (Ubuntu)
         if: matrix.os == 'ubuntu-latest' && matrix.compiler == 'clang'
+        timeout-minutes: 10
         run: |
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh 17
-          sudo apt-get install -y clang-17
+          set -u
+          if command -v clang++-17 >/dev/null 2>&1; then
+            echo "clang++-17 already present: $(clang++-17 --version | head -1)"
+            exit 0
+          fi
+          for attempt in 1 2 3; do
+            echo "::group::llvm.sh attempt $attempt"
+            if wget --timeout=60 --tries=3 -O llvm.sh https://apt.llvm.org/llvm.sh \
+               && chmod +x llvm.sh \
+               && sudo ./llvm.sh 17 \
+               && sudo apt-get install -y clang-17; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            sleep 20
+          done
+          echo "clang-17 install failed after 3 attempts"
+          exit 1
 
       # Configure
       - name: Configure (Unix)


### PR DESCRIPTION
The two Ubuntu compiler installs are the only network-dependent steps in the job, and both have now hung for 25+ minutes — `apt.llvm.org` on #164, plain `apt-get` on #165. Neither *failed*; they just stopped making progress, and with no timeout the whole run sat blocked behind a step that normally takes seconds. Both cleared on re-run with no change, so a hang is far more likely than a real failure.

Three changes, in increasing order of how much they help:

1. **Skip the install if the runner image already ships the compiler.** The images have moved on since these steps were written. On a hit this removes the network from the critical path entirely, rather than making it faster.
2. **Retry 3× with a pause.** Covers a transient mirror or an apt lock held by `unattended-upgrades`.
3. **`timeout-minutes: 10` per step, 45 per job.** This is the part that bounds the damage: a stuck mirror now fails in minutes and names the step, instead of stalling until a human notices and cancels. Without a job timeout the ceiling is GitHub's 6-hour default.

No change to what is built or tested. `actionlint` clean.

Found while shipping #165 — the run had to be cancelled and re-run by hand, for the second time in two PRs.