### PR TITLE
docs: note that the Windows binaries need no redistributable

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ time control. There is no runtime CPU detection, so the AVX2 binary will not
 start on a CPU that lacks AVX2.
 
 Put the `.nnue` file next to the executable and it is found automatically.
+The executables are self-contained: the C runtime is linked statically, so no
+Visual C++ redistributable is required.
 Binaries are built by [CI](.github/workflows/release.yml) from the tagged
 commit and carry a signed provenance attestation:
 


### PR DESCRIPTION
The released executables now link the C runtime statically (#165), so they run on a clean Windows install. Worth stating on the download table: *"VCRUNTIME140.dll was not found"* is the failure a user would otherwise hit, and it gives no hint about what to install.

Verified against the published assets — both import only `KERNEL32.dll`.

Docs only.