### PR TITLE
docs: correct the handoff checksums, which no longer described the engine

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -9,15 +9,31 @@ of positions and counts nodes. The node count is therefore an exact checksum on
 "same code, same parameters, same build configuration". The *time* and *nps*
 will differ between machines; the node count must not.
 
+**Fetch the network first.** Networks are not kept in git, so a fresh clone has
+none, and an engine that cannot find one silently evaluates with the
+handcrafted evaluation instead. That is a perfectly working engine reporting a
+completely different node count, which looks exactly like the build difference
+this check exists to catch.
+
 ```sh
+./scripts/fetch-net.sh                      # ~20 MB, hash-checked against nets/default.txt
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DHAVOC_BUILD_TOOLS=ON
 cmake --build build -j
-printf 'bench\nquit\n' | ./build/havoc      # expect 697583 nodes
-./build/tests/havoc_tests                   # expect 133 passing
+printf 'bench\nquit\n' | ./build/havoc      # expect 776644 nodes, eval NNUE
+./build/tests/havoc_tests                   # expect 219 tests, 0 failing
 ```
 
-A different node count means a build difference, not a porting success. Track it
-down before measuring anything.
+`bench` prints which evaluation it used. If it says `eval HCE` the network was
+not found: check `scripts/fetch-net.sh` actually placed it in `nets/`. For
+reference the handcrafted evaluation benches **1028826 nodes** on the same
+positions, so that number is a missing network rather than a broken port.
+
+Six tablebase tests skip when no Syzygy tables are present, so 213 passing and
+6 skipped is the expected result on a machine without them. Skips are fine;
+failures are not.
+
+A different node count, with the network loaded, means a build difference
+rather than a porting success. Track it down before measuring anything.
 
 ## What does not travel
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -16,9 +16,17 @@ disagree, it wins.
 
 ## 1. Where the engine stands
 
-haVoc is a hand-crafted-evaluation (HCE) alpha-beta engine, currently around
-**2500 Elo** on the CCRL scale. `bench` is **697583 nodes** and there are **160
-passing tests**. Both are exact checksums — see `handoff.md`.
+haVoc is an alpha-beta engine with an NNUE evaluation, measured at **2834 ±12**
+on the CCRL 40/40 scale (1200 games against six anchors, 17 August 2026). With
+the network loaded `bench` is **776644 nodes**; without one it falls back to the
+handcrafted evaluation and benches **1028826**. There are **219 tests**, six of
+which skip without Syzygy tables present. All of those are exact checksums —
+see `handoff.md`.
+
+The handcrafted evaluation is still in the tree and still works
+(`EvalFile none`), but it is no longer what the engine plays with, and the
+tuned search parameters are specific to the network. Sections below that were
+written against the HCE describe a configuration that is no longer the default.
 
 The 15 August 2026 session merged a 15-PR backlog: the first working Windows
 build, soft/hard time limits, three infinite hangs, two segfaults, several


### PR DESCRIPTION
`handoff.md` told a new machine to expect **697583 nodes** and **133 passing tests**. The engine benches **776644** with the network loaded and has **219 tests**. The page then says a different node count means a build problem to track down *before measuring anything* — so following it would send someone hunting a bug that does not exist.

The worse half is not the numbers. **Networks are gitignored, so a fresh clone has none**, and an engine that cannot find one falls back to the handcrafted evaluation and reports a completely different node count *while working perfectly*. The instructions never fetched a network, so that was the likely outcome for anyone following them.

Fixed:
- adds `./scripts/fetch-net.sh` as the first step
- expected result is now `776644 nodes, eval NNUE`
- gives the HCE figure (**1028826**) explicitly, so a missing network identifies itself instead of looking like a corrupted port
- notes `bench` prints which evaluator it used
- records that 6 tablebase tests skip without Syzygy tables, so 213 passed / 6 skipped is a pass

`roadmap.md` §1 had the same problem — "2500 Elo… HCE… 697583 nodes… 160 passing tests" — and now states the measured 2834, both bench figures, the current test count, and a warning that later sections were written against the HCE.

Verified by running bench and the suite locally:
```
Bench: 776644 nodes, eval NNUE
Bench: 1028826 nodes, eval HCE     (EvalFile none)
219 tests / 213 PASSED / 6 SKIPPED
```
These agree with the figures already in `scripts/nnue/README.md`, which was independently correct.

Left alone: the 697583 references in `nnue-integration.md` and `revisit-after-tuning.md` are historical records of specific PRs, not claims about the current engine.

Docs only.